### PR TITLE
Adds support for red, blue, vagrant, packer in Content

### DIFF
--- a/packages/content/props.json5
+++ b/packages/content/props.json5
@@ -15,6 +15,8 @@
       'nomad',
       'packer',
       'vagrant',
+      'red',
+      'blue',
     ],
   },
 }

--- a/packages/content/style.css
+++ b/packages/content/style.css
@@ -15,6 +15,18 @@
   &.terraform {
     --highlight-color: var(--terraform);
   }
+  &.packer {
+    --highlight-color: var(--packer);
+  }
+  &.vagrant {
+    --highlight-color: var(--vagrant);
+  }
+  &.red {
+    --highlight-color: var(--red);
+  }
+  &.blue {
+    --highlight-color: var(--blue);
+  }
 }
 
 .g-content {
@@ -83,7 +95,7 @@
   }
 
   /*
-   *  
+   *
    *  Code
    *
    */


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1174857014925179/1195493119191677)

🔍 [Boundary Preview](https://react-components-git-brcontent-themes.hashicorp.vercel.app/?component=Content&id=LTEyMjU5MjYwNTA&values=IjxDb250ZW50XG4gIHByb2R1Y3Q9J3JlZCdcbiAgY29udGVudD17PHA%2BaGVsbG8gd29ybGQgPGEgaHJlZj0nIyc%2BdGhpcyBpcyBhIGxpbms8L2E%2BPC9wPn1cbi8%2BIg%3D%3D)
🔍 [Waypoint Preview](https://react-components-git-brcontent-themes.hashicorp.vercel.app/?component=Content&id=LTEyMjU5MjYwNTA&values=IjxDb250ZW50XG4gIHByb2R1Y3Q9J2JsdWUnXG4gIGNvbnRlbnQ9ezxwPmhlbGxvIHdvcmxkIDxhIGhyZWY9JyMnPnRoaXMgaXMgYSBsaW5rPC9hPjwvcD59XG4vPiI%3D)
🔍 [Vagrant Preview](https://react-components-git-brcontent-themes.hashicorp.vercel.app/?component=Content&id=LTEyMjU5MjYwNTA&values=IjxDb250ZW50XG4gIHByb2R1Y3Q9J3ZhZ3JhbnQnXG4gIGNvbnRlbnQ9ezxwPmhlbGxvIHdvcmxkIDxhIGhyZWY9JyMnPnRoaXMgaXMgYSBsaW5rPC9hPjwvcD59XG4vPiI%3D)
🔍 [Packer Preview](https://react-components-git-brcontent-themes.hashicorp.vercel.app/?component=Content&id=LTEyMjU5MjYwNTA&values=IjxDb250ZW50XG4gIHByb2R1Y3Q9J3BhY2tlcidcbiAgY29udGVudD17PHA%2BaGVsbG8gd29ybGQgPGEgaHJlZj0nIyc%2BdGhpcyBpcyBhIGxpbms8L2E%2BPC9wPn1cbi8%2BIg%3D%3D)

---

## Description

Adds support for red, blue, vagrant, and packer product themes in Content

It looks like vagrant & packer were missed in previous implementations here (but the JSON5 docs imply that they should be included).

Currently on the [packer site](https://www.packer.io/docs/commands/console#usage-examples-repl-session-hcl2), it's actually using `brand` as the highlight color, and not packer (which seems like a miss).

<img width="2223" alt="Screen Shot 2020-09-30 at 12 09 27 AM" src="https://user-images.githubusercontent.com/2105067/94653990-467d0f00-02b1-11eb-9567-7906632a08ee.png">

Obviously doesn't impact vagrant; as our brand color is vagrant, but for robustness I included the variable there anyways (if we ever change the color 😉 )

## Release Information

Please select one (**required**)

- [ ] **Major** (This PR introduces a breaking (incompatible API) change)
- [x] **Minor** (This PR adds functionality but it backwards-compatible)
- [ ] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>
Adds support for red, blue, vagrant, and packer product themes in Content
</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Add release notes to the appropriate section (above).
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
