### PR TITLE
Add css-module jest mock

### DIFF
--- a/__test-helpers/mocks/css-module-mock.js
+++ b/__test-helpers/mocks/css-module-mock.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   moduleNameMapper: {
+    '\\.module.css$': '<rootDir>/__test-helpers/mocks/css-module-mock.js',
     '\\.graphql$': '<rootDir>/__test-helpers/mocks/graphql-fragment-mock.js',
     '\\.svg(?:\\?.*)*$': '<rootDir>/__test-helpers/mocks/svg-mock.js',
   },


### PR DESCRIPTION
This PR mocks `css-module` imports like other imports `jest` would otherwise get hung up on.

@jescalan  -- Is this an appropriate addition?

It is working for me locally but figured I'd check in with a mergeable PR first 

I don't want it buried in my HashiStackMenu work.