### PR TITLE
Roll inlinesvg back for HSM

### DIFF
--- a/packages/hashi-stack-menu/package.json
+++ b/packages/hashi-stack-menu/package.json
@@ -7,7 +7,7 @@
     "Jimmy Merritello"
   ],
   "dependencies": {
-    "@hashicorp/react-inline-svg": "^4.0.2",
+    "@hashicorp/react-inline-svg": "^1.0.2",
     "slugify": "1.3.4"
   },
   "peerDependencies": {

--- a/packages/hashi-stack-menu/stack-item/stack-item.module.css
+++ b/packages/hashi-stack-menu/stack-item/stack-item.module.css
@@ -26,8 +26,9 @@
 
 .productIcon {
   margin-right: 8px;
-  width: 22px;
-  height: auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .badge {


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}.hashicorp.vercel.app)

---

## Description

This PR will create a new release for `<HashiStackMenu />` which does not break `react-inline-svg` dep compat 🤞 

My canary release with these changes check out with tested builds for `nomad` and `consul`  🎉 

## Release Information

Please select one (**required**)

- [ ] **Major** (This PR introduces a breaking (incompatible API) change)
- [ ] **Minor** (This PR adds functionality but it backwards-compatible)
- [x] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>
<!-- This repo requires release notes on each PR in order to publish a package. Remove this comment and replace with release notes that will be reflected in the GitHub release notes. -->
</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Add release notes to the appropriate section (above).
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
