### PR TITLE
Temp remove publish script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -110,67 +110,72 @@ jobs:
               .join('\n')
             if (!releaseNotes.length || releaseNotes.startsWith('<!--')) return core.setFailed('Cannot find release notes associated with this pull request!')
             core.setOutput("releaseNotes", releaseNotes)
-  release_package:
-    name: Publish package
-    runs-on: ubuntu-latest
-    needs: [scan_changed_packages, verify_description]
-    if: ${{ needs.scan_changed_packages.outputs.packageName != 'N/A' && github.event.action == 'closed' && github.event.pull_request.merged == true }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - run: git checkout master
-      - name: Setup Node.js
-        uses: actions/setup-node@v1
-        with:
-          always-auth: true
-          node-version: "12.x"
-          registry-url: "https://registry.npmjs.org"
-      - run: npm ci --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
-      - run: npm run vercel-build
-      - name: Configure git credentials
-        run: |
-          git config --global user.email "mktg-dev-github-bot@hashicorp.com"
-          git config --global user.name "HashiBot Web"
-      - name: Tag major version
-        if: ${{ needs.verify_description.outputs.version == 'Major'}}
-        run: |
-          echo 'VERSION<<EOF' >> $GITHUB_ENV
-          ./node_modules/.bin/lerna version major --yes | jq -Rsr 'split(" => ") | .[1] | gsub("[\\n\\t]"; "")' >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-      - name: Tag minor version
-        if: ${{ needs.verify_description.outputs.version == 'Minor'}}
-        run: |
-          echo 'VERSION<<EOF' >> $GITHUB_ENV
-          ./node_modules/.bin/lerna version minor --yes | jq -Rsr 'split(" => ") | .[1] | gsub("[\\n\\t]"; "")' >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-      - name: Tag patch version
-        if: ${{ needs.verify_description.outputs.version == 'Patch'}}
-        run: |
-          echo 'VERSION<<EOF' >> $GITHUB_ENV
-          ./node_modules/.bin/lerna version patch --yes | jq -Rsr 'split(" => ") | .[1] | gsub("[\\n\\t]"; "")' >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-      - name: Print version
-        run: echo $VERSION
-      - name: Create GitHub release
-        uses: actions/github-script@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.repos.createRelease({
-              owner: context.payload.repository.owner.login,
-              repo: context.payload.repository.name,
-              tag_name: `${process.env.PACKAGE_NAME}@${process.env.VERSION}`,
-              body: process.env.RELEASE_NOTES,
-              draft: false,
-              prerelease: false,
-            });
-        env:
-          PACKAGE_NAME: ${{ needs.scan_changed_packages.outputs.packageName }}
-          RELEASE_NOTES: ${{ needs.verify_description.outputs.releaseNotes }}
-      - name: Publish package
-        run: ./node_modules/.bin/lerna publish from-package --yes
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
+  # release_package:
+  #   name: Publish package
+  #   runs-on: ubuntu-latest
+  #   needs: [scan_changed_packages, verify_description]
+  #   if: ${{ needs.scan_changed_packages.outputs.packageName != 'N/A' && github.event.action == 'closed' && github.event.pull_request.merged == true }}
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - run: git checkout master
+  #     - name: Setup Node.js
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: "12.x"
+  #         registry-url: "https://registry.npmjs.org"
+  #     - run: npm ci --ignore-scripts
+  #       env:
+  #         NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
+  #     - run: npm run vercel-build
+  #     - name: Configure git credentials
+  #       run: |
+  #         git config --global user.email "mktg-dev-github-bot@hashicorp.com"
+  #         git config --global user.name "HashiBot Web"
+  #     - name: Tag major version
+  #       if: ${{ needs.verify_description.outputs.version == 'Major'}}
+  #       run: |
+  #         echo 'VERSION<<EOF' >> $GITHUB_ENV
+  #         ./node_modules/.bin/lerna version major --yes | jq -Rsr 'split(" => ") | .[1] | gsub("[\\n\\t]"; "")' >> $GITHUB_ENV
+  #         echo 'EOF' >> $GITHUB_ENV
+  #       env:
+  #         NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
+  #     - name: Tag minor version
+  #       if: ${{ needs.verify_description.outputs.version == 'Minor'}}
+  #       run: |
+  #         echo 'VERSION<<EOF' >> $GITHUB_ENV
+  #         ./node_modules/.bin/lerna version minor --yes | jq -Rsr 'split(" => ") | .[1] | gsub("[\\n\\t]"; "")' >> $GITHUB_ENV
+  #         echo 'EOF' >> $GITHUB_ENV
+  #       env:
+  #         NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
+  #     - name: Tag patch version
+  #       if: ${{ needs.verify_description.outputs.version == 'Patch'}}
+  #       run: |
+  #         echo 'VERSION<<EOF' >> $GITHUB_ENV
+  #         ./node_modules/.bin/lerna version patch --yes | jq -Rsr 'split(" => ") | .[1] | gsub("[\\n\\t]"; "")' >> $GITHUB_ENV
+  #         echo 'EOF' >> $GITHUB_ENV
+  #       env:
+  #         NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
+  #     - name: Print version
+  #       run: echo $VERSION
+  #     - name: Create GitHub release
+  #       uses: actions/github-script@v2
+  #       with:
+  #         github-token: ${{ secrets.GITHUB_TOKEN }}
+  #         script: |
+  #           github.repos.createRelease({
+  #             owner: context.payload.repository.owner.login,
+  #             repo: context.payload.repository.name,
+  #             tag_name: `${process.env.PACKAGE_NAME}@${process.env.VERSION}`,
+  #             body: process.env.RELEASE_NOTES,
+  #             draft: false,
+  #             prerelease: false,
+  #           });
+  #       env:
+  #         PACKAGE_NAME: ${{ needs.scan_changed_packages.outputs.packageName }}
+  #         RELEASE_NOTES: ${{ needs.verify_description.outputs.releaseNotes }}
+  #     - name: Publish package
+  #       run: ./node_modules/.bin/lerna publish from-package --yes
+  #       env:
+  #         NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}


### PR DESCRIPTION
Avoid inconsistent repo states by removing publish script while triaging

Related: #75 