### PR TITLE
AlertBanner: remove `show` class onClose

### DIFF
--- a/packages/alert-banner/index.jsx
+++ b/packages/alert-banner/index.jsx
@@ -74,6 +74,7 @@ class AlertBanner extends Component {
     const name = `banner_${this.name}`
     cookie.set(name, 1)
 
+    this.setState({ show: false })
     this.trackEvent('close')
   }
 


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}.hashicorp.vercel.app)

---

## Description

Porting https://github.com/hashicorp/web-components/pull/1246/ to the new repo. Currently if a user closes the alert banner, the `.show` class name persists, making it difficult to determine the visible state of the banner ([ex](https://github.com/hashicorp/learn/blob/master/components/nav/partials/browse-section/index.jsx#L112-L125)). With this PR, the `show` class will be in sync with the visual state of the banner.

## Release Information

Please select one (**required**)

- [ ] **Major** (This PR introduces a breaking (incompatible API) change)
- [ ] **Minor** (This PR adds functionality but it backwards-compatible)
- [x] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>
Remove `show` class from AlertBanner when it's hidden by a user.
</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Add release notes to the appropriate section (above).
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
