### PR TITLE
Fixes and updates for DocsPage

### DIFF
--- a/packages/docs-page/README.md
+++ b/packages/docs-page/README.md
@@ -4,7 +4,7 @@ The **DocsPage** component lets you create a Hashicorp branded docs page in Next
 
 ## Example Usage
 
-This component must be used on an [optional catch-all route](https://nextjs.org/docs/routing/dynamic-routes#optional-catch-all-routes) page, like `pages/docs/[[slug]].mdx` - example source shown below:
+This component is intended to be used on an [optional catch-all route](https://nextjs.org/docs/routing/dynamic-routes#optional-catch-all-routes) page, like `pages/docs/[[slug]].mdx` - example source shown below:
 
 ```js
 import order from 'data/docs-navigation.js'
@@ -38,7 +38,7 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ params }) {
-  return generateStaticProps(subpath, productName, params)
+  return generateStaticProps({ subpath, productName, params })
 }
 
 export default DocsLayout

--- a/packages/docs-page/index.js
+++ b/packages/docs-page/index.js
@@ -63,7 +63,7 @@ export default function DocsPage({
       {showEditPage && (
         <div id="edit-this-page" className="g-container">
           <a
-            href={`https://github.com/hashicorp/${slug}/blob/${mainBranch}/website/content/docs/${filePath}`}
+            href={`https://github.com/hashicorp/${slug}/blob/${mainBranch}/website/content/${filePath}`}
           >
             <img src={require('./img/github-logo.svg')} alt="github logo" />
             <span>Edit this page</span>

--- a/packages/docs-page/server.js
+++ b/packages/docs-page/server.js
@@ -17,7 +17,13 @@ export async function generateStaticPaths(subpath) {
   return { paths, fallback: false }
 }
 
-export async function generateStaticProps(subpath, productName, params) {
+export async function generateStaticProps({
+  subpath,
+  productName,
+  params,
+  additionalComponents,
+  scope,
+}) {
   const docsPath = path.join(process.cwd(), 'content', subpath)
   const pagePath = params.page ? params.page.join('/') : '/'
 
@@ -28,7 +34,8 @@ export async function generateStaticProps(subpath, productName, params) {
   const { mdxSource, frontMatter, filePath } = await renderPageMdx(
     docsPath,
     pagePath,
-    generateComponents(productName)
+    generateComponents(productName, additionalComponents),
+    scope
   )
 
   return {
@@ -39,7 +46,7 @@ export async function generateStaticProps(subpath, productName, params) {
       }),
       mdxSource,
       frontMatter,
-      filePath,
+      filePath: `${subpath}/${filePath}`,
       pagePath: `/${subpath}/${pagePath}`,
     },
   }
@@ -60,7 +67,7 @@ async function getStaticMdxPaths(root) {
   })
 }
 
-async function renderPageMdx(root, pagePath, components) {
+async function renderPageMdx(root, pagePath, components, scope) {
   // get the page being requested - figure out if its index page or leaf
   // prefer leaf if both are present
   const leafPath = path.join(root, `${pagePath}.mdx`)
@@ -87,6 +94,7 @@ async function renderPageMdx(root, pagePath, components) {
       resolveIncludes: path.join(process.cwd(), 'content/partials'),
     }),
     components,
+    scope,
   })
 
   return {


### PR DESCRIPTION
## Description

My initial work here was clearly a little sloppy, but thats why we have testing amiright?

- The "edit this page" link functionality, previously was bugged and would always link to `/content/docs` and only to one nesting level, generating consistently broken links outside a narrow use case. This is now fixed.
- The `generateStaticProps` function now takes `additionalComponents` as an arg and actually server renders them, which was not happening previously. It also takes a `scope` arg if data needs to be passed in, which is normal for mdx remote, and all the args were converted to an object rather than individual args as its now up to 5. This is a breaking change.

## Release Information

Please select one (**required**)

- [x] **Major** (This PR introduces a breaking (incompatible API) change)
- [ ] **Minor** (This PR adds functionality but it backwards-compatible)
- [ ] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>
- The "edit this page" link functionality, previously was bugged and would always link to `/content/docs` and only to one nesting level, generating consistently broken links outside a narrow use case. This is now fixed.
- The `generateStaticProps` function now takes `additionalComponents` as an arg and actually server renders them, which was not happening previously. It also takes a `scope` arg if data needs to be passed in, which is normal for mdx remote, and all the args were converted to an object rather than individual args as its now up to 5. This is a breaking change.
</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Add release notes to the appropriate section (above).
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
