### PR TITLE
Roll back inline svg to its previous state

### DIFF
--- a/packages/inline-svg/index.js
+++ b/packages/inline-svg/index.js
@@ -1,23 +1,3 @@
 export default function InlineSvg({ src, ...props }) {
-  // match the attributes and content from the serialized svg
-  const [, attrs, __html] = src?.match(svgMatch) || []
-
-  // combine the attributes and props into new spreadable props
-  const svgProps = attrs
-    ? {
-        ...[...attrs.matchAll(attrMatch)].reduce(
-          (svgProps, [, name, value]) => ({
-            ...svgProps,
-            [name]: value,
-          }),
-          {}
-        ),
-        ...props,
-      }
-    : props
-
-  return <svg {...svgProps} dangerouslySetInnerHTML={{ __html }} />
+  return <div dangerouslySetInnerHTML={{ __html: src }} {...props}></div>
 }
-
-const svgMatch = /^[\W\w]*<svg([^>]+)>([\W\w]*)(<\/svg>[\W\w]*?)?$/
-const attrMatch = /(\S+)=["']?((?:.(?!["']?\s+(?:\S+)=|\s*\/?[>"']))+.)["']?/g

--- a/packages/inline-svg/index.test.js
+++ b/packages/inline-svg/index.test.js
@@ -13,7 +13,7 @@ describe('<InlineSvg />', () => {
     const { container } = render(<InlineSvg {...props} />)
     const rootElem = container.firstChild
 
-    expect(rootElem.localName).toBe('svg')
+    expect(rootElem.localName).toBe('div')
     expect(rootElem.getAttribute('id')).toMatch(props.id)
     expect(rootElem.getAttribute('class')).toMatch(props.className)
     expect(rootElem.hasAttribute('src')).toBe(false)
@@ -31,7 +31,7 @@ describe('<InlineSvg />', () => {
     const rootElem = container.firstChild
 
     expect(rootElem).toHaveClass('test-class')
-    expect(rootElem.localName).toBe('svg')
+    expect(rootElem.localName).toBe('div')
     expect(rootElem.getAttribute('id')).toMatch(props.id)
     expect(rootElem.getAttribute('class')).toMatch(props.className)
     expect(rootElem.hasAttribute('src')).toBe(false)
@@ -39,12 +39,12 @@ describe('<InlineSvg />', () => {
   })
 
   it('should render an empty svg if the contents are invalid', () => {
-    const props = { src: '<p>Hello World' }
+    const props = { src: '<pU(DFASD' }
 
     const { container } = render(<InlineSvg {...props} />)
     const rootElem = container.firstChild
 
-    expect(rootElem.localName).toBe('svg')
+    expect(rootElem.localName).toBe('div')
     expect(rootElem.childNodes.length).toBe(0)
   })
 })


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-jefix-inline-svg.hashicorp.vercel.app/?component=InlineSvg)

---

## Description

The inline svg component was sneakily changed in the port to this repo in a way that is both more complex than we need, and breaking. This PR rolls it back to its previous state.

## Release Information

Please select one (**required**)

- [x] **Major** (This PR introduces a breaking (incompatible API) change)
- [ ] **Minor** (This PR adds functionality but it backwards-compatible)
- [ ] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>
SVGs will be wrapped by a `div` with this change
</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Add release notes to the appropriate section (above).
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
