### PR TITLE
Use WCAG-compliant text colors in g-content

### DIFF
--- a/packages/content/style.css
+++ b/packages/content/style.css
@@ -1,37 +1,37 @@
 /* Component variables */
 .g-content {
   /* Default highlight color (if no product is specified) */
-  --highlight-color: var(--brand);
+  --highlight-color: var(--brand-text);
 
   &.consul {
-    --highlight-color: var(--consul);
+    --highlight-color: var(--consul-text);
   }
   &.vault {
-    --highlight-color: var(--brand);
+    --highlight-color: var(--brand-text);
   }
   &.nomad {
-    --highlight-color: var(--nomad);
+    --highlight-color: var(--nomad-text);
   }
   &.terraform {
-    --highlight-color: var(--terraform);
+    --highlight-color: var(--terraform-text);
   }
   &.packer {
-    --highlight-color: var(--packer);
+    --highlight-color: var(--packer-text);
   }
   &.vagrant {
-    --highlight-color: var(--vagrant);
+    --highlight-color: var(--vagrant-text);
   }
   &.boundary {
-    --highlight-color: var(--boundary);
+    --highlight-color: var(--boundary-text);
   }
   &.waypoint {
-    --highlight-color: #13acae;
+    --highlight-color: var(--waypoint-text);
   }
 }
 
 .g-content {
   margin: auto;
-  color: var(--DEPRECATED-gray-3);
+  color: var(--gray-2);
 
   /* On large viewports, all content is spaced from edge of container */
   @media (min-width: 768px) {
@@ -182,7 +182,7 @@
         position: absolute;
         top: 0;
         left: 0;
-        color: var(--DEPRECATED-gray-6);
+        color: var(--gray-5);
         margin-left: calc(-1 * 1.3rem);
         width: 1.3rem;
       }
@@ -285,7 +285,7 @@
     margin: 2em 0;
     padding-left: 2em;
     font-style: italic;
-    border-left: 6px solid var(--DEPRECATED-gray-9);
+    border-left: 6px solid var(--gray-7);
     & em {
       font-style: normal;
     }


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1199236084518165/f)
🔍 [Preview Link](https://react-components-git-{branch-slug}.hashicorp.vercel.app)

---

This PR updates the `@hashicorp/react-content` component to use WCAG-compliant `--highlight-color` values.

## Release Information

Please select one (**required**)

- [ ] **Major** (This PR introduces a breaking (incompatible API) change)
- [x] **Minor** (This PR adds functionality but it backwards-compatible)
- [ ] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>
**Important** - you must use [`@hashicorp/mktg-global-styles@2.1.0`](https://github.com/hashicorp/mktg-global-styles/releases/tag/2.1.0) or later to use this release.

This PR updates the`--highlight-color` CSS custom property scoped under `.g-content` to use WCAG-compliant values.
</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [x] Add release notes to the appropriate section (above).
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
