### PR TITLE
Fix issue with --highlight-color being needed, eg for tab border

### DIFF
--- a/packages/content/style.css
+++ b/packages/content/style.css
@@ -157,20 +157,20 @@
   We don't want to clobber these with our default link styles */
   & a:not([class]),
   & a.__permalink-h {
-    color: var(--highlight-color);
+    color: var(--highlight-color-text);
     position: relative;
     transition: color 0.3s;
     text-decoration: none;
 
     &:hover {
-      color: var(--highlight-color);
+      color: var(--highlight-color-text);
       &:not(.__permalink-h) {
         text-decoration: underline;
       }
     }
 
     & > code {
-      color: var(--highlight-color);
+      color: var(--highlight-color-text);
     }
   }
 


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1199236084518165/f)
🔍 [Preview Link](https://react-components-git-zsrefine-content-highlight-color.hashicorp.vercel.app/)

---

This PR is a follow-up to a recent update that I made a bit too quickly. It seems `--highlight-color` is actually useful to keep as its current value, and we should **add** a `--highlight-color-text` value (and use that for links by default).

This way, components that don't require a specific contrast ratio (since they aren't using `--highlight-color` for text) can continue to use the main brand color swatch.

## Release Information

Please select one (**required**)

- [ ] **Major** (This PR introduces a breaking (incompatible API) change)
- [ ] **Minor** (This PR adds functionality but it backwards-compatible)
- [x] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>
This release is a follow-up to a recent update. It changes `--highlight-color` back to the core brand color, and **adds** a `--highlight-color-text` CSS custom property (and uses that property for links by default).

This way, components that don't require a specific contrast ratio (since they aren't using `--highlight-color` for text) can continue to use the main brand color swatch.
</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [x] Add release notes to the appropriate section (above).
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
