### PR TITLE
Remove `hyphens: none` in `Content` component

### DIFF
--- a/packages/content/style.css
+++ b/packages/content/style.css
@@ -44,7 +44,6 @@
 
   /* On large viewports, all content is spaced from edge of container */
   @media (min-width: 768px) {
-    hyphens: none;
     padding-left: 2rem;
     padding-right: 2rem;
   }


### PR DESCRIPTION
This has been causing issues in chrome with improper line breaks, I think it needs to be removed to get this bug fixed - we can further investigate moving forward if it causes other issues, but the line break issue is not acceptable.