### PR TITLE
Update tracking attr

### DIFF
--- a/packages/code-block/index.js
+++ b/packages/code-block/index.js
@@ -18,7 +18,7 @@ function CodeBlock({ code, language, options = {} }) {
   const isHtmlString = typeof code === 'string'
 
   return (
-    <div className="g-code-block">
+    <div className="g-code-block" data-heap-track="code-block">
       {options.showWindowBar && <WindowBar />}
       <div className="block-wrapper">
         <pre


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-wkdupdate-codeblock-copy-attr.hashicorp.vercel.app)

---

## Description

Responding to a [Slack question](https://hashicorp.slack.com/archives/CA3ES0VHA/p1610050156413300) re DOM change that got introduced during the transition from Learn's local `code-block` to the shared component. We use the `data-heap-track` convention rather than `data-track`. 

Edit: per further discussion, I'm also adding an additional tracking attribute to the top-level element as well.

## Release Information

Please select one (**required**)

- [ ] **Major** (This PR introduces a breaking (incompatible API) change)
- [ ] **Minor** (This PR adds functionality but it backwards-compatible)
- [x] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>
Updates the heap tracking attribute for the `CodeBlock` copy-to-clipboard button.
</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Add release notes to the appropriate section (above).
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
