### PR TITLE
Remove marked from case-study-slider

### DIFF
--- a/packages/case-study-slider/index.js
+++ b/packages/case-study-slider/index.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import Logo from './Logo'
 import StatusBar from './StatusBar'
-import marked from 'marked'
 import Button from '@hashicorp/react-button'
 import Image from '@hashicorp/react-image'
 import fragment from './fragment.graphql'
@@ -16,7 +15,7 @@ class CaseStudySlider extends Component {
       timing: timing,
       numFrames: this.data.caseStudies.length,
       measure: true,
-      containerWidth: 0
+      containerWidth: 0,
     }
 
     this.frames = []
@@ -48,7 +47,7 @@ class CaseStudySlider extends Component {
         this.setState(
           {
             numFrames: this.data.caseStudies.length,
-            measure: true
+            measure: true,
           },
           () => {
             if (this.data.caseStudies.length === 1) {
@@ -67,7 +66,7 @@ class CaseStudySlider extends Component {
       this.setState(
         {
           timing: parseInt(this.props.timing),
-          active: 0
+          active: 0,
         },
         this.resetTimer
       )
@@ -109,7 +108,7 @@ class CaseStudySlider extends Component {
       this.setState({
         frameSize: width,
         containerWidth: width * this.state.numFrames,
-        measure: false
+        measure: false,
       })
     }
   }
@@ -131,7 +130,7 @@ class CaseStudySlider extends Component {
         ? {}
         : {
             width: `${containerWidth}px`,
-            transform: `translateX(-${(containerWidth / numFrames) * active}px`
+            transform: `translateX(-${(containerWidth / numFrames) * active}px`,
           }
 
     // Create inline styling to apply to each frame
@@ -168,7 +167,7 @@ class CaseStudySlider extends Component {
           <div className="slider-container" style={containerStyle}>
             {/* React pushes a null ref the first time, so we're filtering those out. */}
             {/* see https://reactjs.org/docs/refs-and-the-dom.html#caveats-with-callback-refs */}
-            {caseStudies.map(caseStudy => {
+            {caseStudies.map((caseStudy) => {
               const caseStudyLink =
                 caseStudy.caseStudyLink ||
                 `/resources/${caseStudy.caseStudyResource.slug}`
@@ -176,7 +175,7 @@ class CaseStudySlider extends Component {
                 <div
                   className={`slider-frame${single ? ' single' : ''}`}
                   style={frameStyle}
-                  ref={el => el && this.frames.push(el)}
+                  ref={(el) => el && this.frames.push(el)}
                   key={caseStudy.headline}
                 >
                   <div className="case-study">
@@ -198,13 +197,13 @@ class CaseStudySlider extends Component {
                       <h3
                         className="g-type-display-4"
                         dangerouslySetInnerHTML={{
-                          __html: marked.inlineLexer(caseStudy.headline, [])
+                          __html: caseStudy.headline,
                         }}
                       />
                       <p
                         className="g-type-body"
                         dangerouslySetInnerHTML={{
-                          __html: marked.inlineLexer(caseStudy.description, [])
+                          __html: caseStudy.description,
                         }}
                       />
                       <Button

--- a/packages/case-study-slider/package-lock.json
+++ b/packages/case-study-slider/package-lock.json
@@ -38,11 +38,6 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
-    "marked": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
-    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",

--- a/packages/case-study-slider/package.json
+++ b/packages/case-study-slider/package.json
@@ -8,8 +8,7 @@
   ],
   "dependencies": {
     "@hashicorp/react-button": "^2.2.4",
-    "@hashicorp/react-image": "^2.0.3",
-    "marked": "^0.7.0"
+    "@hashicorp/react-image": "^2.0.3"
   },
   "peerDependencies": {
     "react": "^16.9.0"


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1188331750716498/1199185162145233/f)
🔍 [Preview Link](https://react-components-git-zsremove-marked-from-case-study-slider.hashicorp.vercel.app)

This PR removes `marked` from `case-study-slider`.

This makes it so that `case-study-slider` **no longer supports** markdown for `headline` or `description` props. Instead, it now supports plain text strings or strings of HTML only.

Note that [none of the current Dato entries for the associated model use markdown for `headline` or `description`](https://hashicorp.admin.datocms.com/cda-explorer/?query=query%20MyQuery%20%7B%0A%20%20_allSbcCaseStudiesMeta%20%7B%0A%20%20%20%20count%0A%20%20%7D%0A%20%20allSbcCaseStudies%28first%3A50%29%20%7B%0A%20%20%20%20id%0A%09%09headline%0A%20%20%20%20description%0A%20%20%7D%0A%7D%0A). So despite this significant and technically breaking change, it seems that we won't have to do any work to update to the new release.

I've cut a pre-release and tested this change on `hashicorp-www-next` - https://github.com/hashicorp/hashicorp-www-next/pull/1803. All seems well 👍 


## Release Information

Please select one (**required**)

- [x] **Major** (This PR introduces a breaking (incompatible API) change)
- [ ] **Minor** (This PR adds functionality but it backwards-compatible)
- [ ] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>
Removes support for markdown in `headline` and `description`.
</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [x] Add release notes to the appropriate section (above).
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
