### PR TITLE
Support HTML rather than markdown in vertical-text-block-list

### DIFF
--- a/packages/vertical-text-block-list/index.js
+++ b/packages/vertical-text-block-list/index.js
@@ -1,4 +1,3 @@
-import marked from 'marked'
 import LinkWrap from '@hashicorp/react-link-wrap'
 import Image from '@hashicorp/react-image'
 
@@ -24,7 +23,7 @@ export default function VerticalTextBlockList({ data, centerText, Link }) {
               <div
                 className="body-text g-type-body-large"
                 dangerouslySetInnerHTML={{
-                  __html: marked.inlineLexer(item.body, []),
+                  __html: item.body,
                 }}
                 data-testid={`body-text-${item.header}`}
               />

--- a/packages/vertical-text-block-list/index.test.js
+++ b/packages/vertical-text-block-list/index.test.js
@@ -31,7 +31,9 @@ describe('<VerticalTextBlockList />', () => {
 
   it('should render body text as markdown', () => {
     render(
-      <VerticalTextBlockList data={[{ header: 'test', body: '**foo**' }]} />
+      <VerticalTextBlockList
+        data={[{ header: 'test', body: '<strong>foo</strong>' }]}
+      />
     )
     expect(
       screen.getByTestId(`body-text-test`).querySelector('strong')

--- a/packages/vertical-text-block-list/package-lock.json
+++ b/packages/vertical-text-block-list/package-lock.json
@@ -31,11 +31,6 @@
       "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
       "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q=="
     },
-    "marked": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
-    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",

--- a/packages/vertical-text-block-list/package.json
+++ b/packages/vertical-text-block-list/package.json
@@ -9,8 +9,7 @@
   ],
   "dependencies": {
     "@hashicorp/react-image": "^2.0.3",
-    "@hashicorp/react-link-wrap": "^0.0.3",
-    "marked": "^0.7.0"
+    "@hashicorp/react-link-wrap": "^0.0.3"
   },
   "license": "MPL-2.0",
   "peerDependencies": {

--- a/packages/vertical-text-block-list/props.js
+++ b/packages/vertical-text-block-list/props.js
@@ -20,7 +20,7 @@ module.exports = {
           body: {
             type: 'string',
             description:
-              'text that appears to the right of the headline, can contain markdown',
+              'text that appears to the right of the headline, can contain HTML',
           },
           linkUrl: {
             type: 'string',


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1188331750716498/1199185162145233/f)
🔍 [Preview Link](https://react-components-git-zsremove-marked-from-vertical-text-block-list.hashicorp.vercel.app)

---

This PR updates the `vertical-text-block-list` component to remove support for `markdown` in the `item.body` prop, and instead support HTML. This is part of a broader effort to move text processing to build time.

Note that [current uses of `vertical-text-block-list`](https://sourcegraph.hashi-mktg.com/search?q=-file:.json%24+%40hashicorp/react-vertical-text-block-list&patternType=regexp#1) manually pass markdown to the component. We plan on shifting either to manually passed HTML, or to moving props into `getStaticProps`, and processing them with [`markdownToInlineHtml`](https://github.com/hashicorp/nextjs-scripts/blob/main/markdown/markdown-to-inline-html/index.js).

## Release Information

Please select one (**required**)

- [x] **Major** (This PR introduces a breaking (incompatible API) change)
- [ ] **Minor** (This PR adds functionality but it backwards-compatible)
- [ ] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>
Removes support for markdown in `item.body`, replaces with support for HTML.
</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [x] Add release notes to the appropriate section (above).
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
