### PR TITLE
Change release check to check for main branch

### DIFF
--- a/scripts/release-check-branch.sh
+++ b/scripts/release-check-branch.sh
@@ -6,11 +6,12 @@ RED=$'\e[31m'
 GREEN=$'\e[32m'
 NC=$'\e[0m'
 
+PUBLISH_BRANCH="main"
 echo "${NL}${GRAY}Checking branch..."
 currentbranch=$(git rev-parse --abbrev-ref HEAD)
-if [ $currentbranch != "master" ]; then
-    echo "${RED}ERROR!${NC} Publish should only be run from master.${NL}You're on a branch ${RED}${currentbranch}${NC}${NL}"
+if [ $currentbranch != $PUBLISH_BRANCH ]; then
+    echo "${RED}ERROR!${NC} Publish should only be run from ${PUBLISH_BRANCH}.${NL}You're on a branch ${RED}${currentbranch}${NC}${NL}"
     exit 1
 else
-    echo "${GREEN}✓${NC} Publishing off master${NL}"
+    echo "${GREEN}✓${NC} Publishing off ${PUBLISH_BRANCH}${NL}"
 fi


### PR DESCRIPTION
This PR modifies the `release:check-branch` script to allow non-canary releases from `main` only. Previously the script checked for `master`, which makes it currently impossible to publish from `main`.

## Release Information

Please select one (**required**)

> NOTE: Not expected to result in the release of any package.

- [ ] **Major** (This PR introduces a breaking (incompatible API) change)
- [ ] **Minor** (This PR adds functionality but it backwards-compatible)
- [x] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>
Not expected to result in the release of any package.
</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [x] Add release notes to the appropriate section (above).
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
