### PR TITLE
DocsSideNav: add PropsTable to docs

### DIFF
--- a/packages/docs-sidenav/docs.mdx
+++ b/packages/docs-sidenav/docs.mdx
@@ -13,3 +13,7 @@ This is a cool component for documentation
 />`}</LiveComponent>
 
 <UsageDetails packageJson={packageJson} />
+
+### Props
+
+<PropsTable props={componentProps} />


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}.hashicorp.vercel.app)

---

## Description

Just noticed this while poking around the sidenav that it's missing a `PropsTable`. Not anymore!

## Release Information

Please select one (**required**)

- [ ] **Major** (This PR introduces a breaking (incompatible API) change)
- [ ] **Minor** (This PR adds functionality but it backwards-compatible)
- [x] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>
Adds props documentation to style guide.
</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [x] Add release notes to the appropriate section (above).
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
