### PR TITLE
feat(react-docs-sidenav): uses Product Meta for theme

### DIFF
--- a/packages/docs-sidenav/index.js
+++ b/packages/docs-sidenav/index.js
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from 'react'
+import useProductMeta from '@hashicorp/nextjs-scripts/lib/providers/product-meta'
 import LinkWrap from '@hashicorp/react-link-wrap'
 import MenuIcon from './menu-icon'
 import ChevronIcon from './chevron-icon'
@@ -15,6 +16,7 @@ export default function DocsSidenav({
 }) {
   const [open, setOpen] = useState(false)
   const [filterInput, setFilterInput] = useState('')
+  const { themeClass } = useProductMeta(product)
 
   // we memoize here as the page matching is a pure, expensive calculation that
   // does not need to re-run every render
@@ -31,9 +33,7 @@ export default function DocsSidenav({
 
   return (
     <div
-      className={`g-docs-sidenav${open ? ' open' : ''}${
-        product ? ` theme-${product}` : ''
-      }`}
+      className={`g-docs-sidenav${open ? ' open' : ''} ${themeClass || ''}`}
       data-testid="root"
     >
       <div

--- a/packages/docs-sidenav/props.js
+++ b/packages/docs-sidenav/props.js
@@ -1,16 +1,17 @@
 module.exports = {
   product: {
     type: 'string',
-    description: 'Name of the current product for color theming',
-    testValue: 'default',
+    description: 'Name of the current product for color theming.',
+    testValue: 'nomad',
     options: [
-      'default',
-      'nomad',
-      'consul',
-      'terraform',
-      'packer',
-      'vagrant',
+      'hashicorp', // default
       'boundary',
+      'consul',
+      'nomad',
+      'packer',
+      'terraform',
+      'vault',
+      'vagrant',
       'waypoint',
     ],
   },

--- a/packages/docs-sidenav/style.css
+++ b/packages/docs-sidenav/style.css
@@ -1,34 +1,7 @@
 .g-docs-sidenav {
-  /* Default highlight color (if no product is specified) */
-  --highlight-color: var(--brand);
-
-  &.theme-nomad {
-    --highlight-color: var(--nomad);
-  }
-
-  &.theme-terraform {
-    --highlight-color: var(--terraform);
-  }
-
-  &.theme-consul {
-    --highlight-color: var(--consul);
-  }
-
-  &.theme-packer {
-    --highlight-color: var(--packer);
-  }
-
-  &.theme-vagrant {
-    --highlight-color: var(--vagrant);
-  }
-
-  &.theme-boundary {
-    --highlight-color: var(--boundary);
-  }
-
-  &.theme-waypoint {
-    --highlight-color: #13acae;
-  }
+  --highlight-color: var(
+    --brand
+  ); /* color overridden per product by themeClass */
 
   & > .nav {
     width: 275px;


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1199921479767323/1199921479767345)
🔍 [Preview Link](https://react-components-jmpu8fssz.vercel.app/?component=DocsSidenav)

---

See the [parent PR](https://github.com/hashicorp/react-components/pull/134) for detailed context.

## What this does:

- Refactors `@hashicorp/react-docs-sidenav` to use `useProductMeta` for the theme class

Pretty simple refactor! `product` was already being passed as prop. The only somewhat **breaking change** to note is that `default` is no longer a valid option, but if `default` is passed, the HC colors will render since `default` is not a valid product. So this is technically not breaking, just no longer valid.

## Release Information

Please select one (**required**)

- [ ] **Major** (This PR introduces a breaking (incompatible API) change)
- [X] **Minor** (This PR adds functionality but it backwards-compatible)
- [ ] **Patch** (This PR adds a backwards-compatible bug fix)

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [x] Add release notes to the appropriate section (above).
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
