### PR TITLE
DocsPage: add remark plugins option to server props fn

### DIFF
--- a/packages/docs-page/server.js
+++ b/packages/docs-page/server.js
@@ -24,6 +24,7 @@ export async function generateStaticProps({
   params,
   additionalComponents,
   scope,
+  remarkPlugins,
 }) {
   const docsPath = path.join(process.cwd(), 'content', subpath)
   const pagePath = params.page ? params.page.join('/') : '/'
@@ -36,7 +37,8 @@ export async function generateStaticProps({
     docsPath,
     pagePath,
     generateComponents(productName, additionalComponents),
-    scope
+    scope,
+    remarkPlugins
   )
 
   return {
@@ -68,7 +70,13 @@ async function getStaticMdxPaths(root) {
   })
 }
 
-async function renderPageMdx(root, pagePath, components, scope) {
+async function renderPageMdx(
+  root,
+  pagePath,
+  components,
+  scope,
+  remarkPlugins = []
+) {
   // get the page being requested - figure out if its index page or leaf
   // prefer leaf if both are present
   const leafPath = path.join(root, `${pagePath}.mdx`)
@@ -93,6 +101,7 @@ async function renderPageMdx(root, pagePath, components, scope) {
   const mdxSource = await renderToString(content, {
     mdxOptions: markdownDefaults({
       resolveIncludes: path.join(process.cwd(), 'content/partials'),
+      addRemarkPlugins: remarkPlugins,
     }),
     components,
     scope,


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}.hashicorp.vercel.app)

---

## Description

Per request from the sentinel team, who is working on a custom sentinel playground embed component and wants to apply a remark plugin that will allow it to pull prop content from a code sample filename via remark plugin.

## Release Information

Please select one (**required**)

- [ ] **Major** (This PR introduces a breaking (incompatible API) change)
- [x] **Minor** (This PR adds functionality but it backwards-compatible)
- [ ] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>
Adds the option to pass `remarkPlugins` to the `generateStaticProps` function in the `DocsPage` component server code.
</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Add release notes to the appropriate section (above).
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
