### PR TITLE
feat(search): add `heapId` prop for tracking

### DIFF
--- a/packages/search/index.js
+++ b/packages/search/index.js
@@ -18,6 +18,7 @@ function Search({
     event.preventDefault()
   },
   showSearchLegend = true,
+  heapId = 'SearchBox',
 }) {
   if (!renderHitContent) {
     throw new Error(
@@ -74,6 +75,7 @@ function Search({
             setCancelled,
             setQuery,
             onSubmit,
+            heapId,
           }}
           activeHit={hitIndex}
         />

--- a/packages/search/props.js
+++ b/packages/search/props.js
@@ -30,4 +30,10 @@ module.exports = {
     description: 'Enable the search keyboard legend',
     default: false,
   },
+  heapId: {
+    type: 'string',
+    description:
+      'Value for `data-heap-track` attribute applied to the search input',
+    default: 'SearchBox',
+  },
 }

--- a/packages/search/search-box.js
+++ b/packages/search/search-box.js
@@ -17,6 +17,7 @@ function SearchBox({
   setQuery,
   onSubmit,
   activeHit,
+  heapId,
 }) {
   const searchBoxRef = useRef(null)
 
@@ -84,6 +85,7 @@ function SearchBox({
           aria-autocomplete="list"
           aria-controls={SEARCH_RESULTS_ID}
           aria-activedescendant={activeHit > 0 ? `hit-${activeHit}` : ''}
+          data-heap-track={heapId}
         />
         <button
           type="submit"


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/0/1199645122344711/f)
🔍 [Preview Link](https://react-components-git-wkd-search-heap-attribute-hashicorp.vercel.app?component=Search)

---

## Description

Adds a `heapId` prop that gets passed to a `data-heap-track` attribute on the search input (default value: `SearchBox`). Necessary to facilitate the Education team's desire for Heap tracking on search.

## Release Information

Please select one (**required**)

- [ ] **Major** (This PR introduces a breaking (incompatible API) change)
- [x] **Minor** (This PR adds functionality but it backwards-compatible)
- [ ] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>
Adds a `heapId` prop that gets passed to a `data-heap-track` attribute on the search input (default value: `SearchBox`).
</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [x] Add release notes to the appropriate section (above).
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
