### PR TITLE
chore(docs-page): bump docs-sidenav to stable dep

### DIFF
--- a/packages/docs-page/package-lock.json
+++ b/packages/docs-page/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@hashicorp/react-docs-sidenav": {
-      "version": "6.1.1-alpha.60",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-sidenav/-/react-docs-sidenav-6.1.1-alpha.60.tgz",
-      "integrity": "sha512-mfR6Wl4R4k5KD7lJpl0l4pn4NecmoqV6HxQ+nvMW/d6nIkb6/xWxynmDkEeiyEVpphLKqJFh6boWuFYaar7PbA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-sidenav/-/react-docs-sidenav-7.0.0.tgz",
+      "integrity": "sha512-gzOEG4fwfdfdHvxMuRC73bZUIpUzSPrG826NIM4N0lqUPzsAkDsfEl2+Vg1ZVfgzy2+41E+lIpHW4ZmWc5OZ7A==",
       "requires": {
         "@hashicorp/react-link-wrap": "^2.0.2",
         "fuzzysearch": "1.0.3"

--- a/packages/docs-page/package.json
+++ b/packages/docs-page/package.json
@@ -8,7 +8,7 @@
   ],
   "dependencies": {
     "@hashicorp/react-content": "^6.3.0",
-    "@hashicorp/react-docs-sidenav": "6.1.1-alpha.60",
+    "@hashicorp/react-docs-sidenav": "^7.0.0",
     "@hashicorp/react-head": "^1.2.0",
     "@hashicorp/react-search": "^4.1.0",
     "fs-exists-sync": "0.1.0",


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1199913030172635/f)
🔍 [Preview Link](https://react-components-git-zsbump-docs-page-dep-hashicorp.vercel.app)

---

This PR bumps `@hashicorp/react-docs-page`'s `docs-sidenav` dep from a pre-release to the equivalent stable release.

Ideally this would have somehow happened automatically, but I think I'd messed something up with how I ran pre-releases in #154 that made `lerna` not bump this automatically.

## Release Information

Please select one (**required**)

- [ ] **Major** (This PR introduces a breaking (incompatible API) change)
- [ ] **Minor** (This PR adds functionality but it backwards-compatible)
- [x] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>
This release bumps the `docs-sidenav` dep from a pre-release to the equivalent stable release.
</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [x] Add release notes to the appropriate section (above).
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
