### PR TITLE
feat(split-rich-cta-list): useProductMeta theming & color updates

### DIFF
--- a/packages/split-rich-cta-list/docs.mdx
+++ b/packages/split-rich-cta-list/docs.mdx
@@ -3,7 +3,7 @@ componentName: 'SplitRichCTAList'
 ---
 
 <LiveComponent>{`<SplitRichCTAList
-  brand="terraform"
+  product="terraform"
   heading="Get Started with Terraform Modules on AWS"
   items={[
     {
@@ -25,7 +25,6 @@ componentName: 'SplitRichCTAList'
   ]}
 />`}</LiveComponent>
 
-
 #### SplitRichCTAList Props
 
 There are many props that can be used to customize this component, all of which are listed below:
@@ -40,7 +39,7 @@ The `SplitRichCTAList` is not opinionated about the container it is placed in (`
 
 ```
 <section className="g-grid-container">
-  <SplitRichCTAList brand="terraform" heading="Get Started with Terraform Modules on AWS" items={[]} />
+  <SplitRichCTAList product="terraform" heading="Get Started with Terraform Modules on AWS" items={[]} />
 </section>
 ```
 
@@ -52,14 +51,16 @@ Sane usage of this component would have you `require` in the SVG where this is b
 
 ```jsx
 <SplitRichCTAList
-  brand="terraform"
+  product="terraform"
   heading="Get Started with Terraform Modules on AWS"
   items={[
     {
       icon: require('./img/my-svg.svg'),
       title: 'Amazon Virtual Private Cloud (VPC) for Terraform on AWS',
-      description: 'Provision Amazon VPC resources, managed by Terraform, on the AWS Cloud.',
-      linkUrl: 'https://registry.terraform.io/modules/aws-quickstart/vpc/aws/latest',
+      description:
+        'Provision Amazon VPC resources, managed by Terraform, on the AWS Cloud.',
+      linkUrl:
+        'https://registry.terraform.io/modules/aws-quickstart/vpc/aws/latest',
     },
   ]}
 />

--- a/packages/split-rich-cta-list/index.jsx
+++ b/packages/split-rich-cta-list/index.jsx
@@ -1,13 +1,20 @@
 import Link from 'next/link'
 import classNames from 'classnames'
+import useProductMeta from '@hashicorp/nextjs-scripts/lib/providers/product-meta'
 import InlineSvg from '@hashicorp/react-inline-svg'
 import LinkWrap from '@hashicorp/react-link-wrap'
 import RightArrow from './img/arrow-right.svg?include'
 import styles from './styles.module.css'
 
-export default function SplitRichCTAList({ className, brand, heading, items }) {
+export default function SplitRichCTAList({
+  className,
+  product,
+  heading,
+  items,
+}) {
+  const { themeClass } = useProductMeta(product)
   return (
-    <div className={classNames(styles.splitRichCTAList, className)}>
+    <div className={classNames(styles.splitRichCTAList, className, themeClass)}>
       <h3>{heading}</h3>
       <ul>
         {items.map((item) => (
@@ -15,7 +22,7 @@ export default function SplitRichCTAList({ className, brand, heading, items }) {
             <LinkWrap Link={Link} href={item.linkUrl} className={styles.item}>
               <InlineSvg className={styles.icon} src={item.icon} />
               <div className={styles.text}>
-                <h5 className={styles[brand]}>{item.title}</h5>
+                <h5>{item.title}</h5>
                 <p className={styles.bodySmall}>{item.description}</p>
               </div>
               <InlineSvg className={styles.arrow} src={RightArrow} />

--- a/packages/split-rich-cta-list/package.json
+++ b/packages/split-rich-cta-list/package.json
@@ -14,7 +14,8 @@
   },
   "license": "MPL-2.0",
   "peerDependencies": {
-    "react": "^16.9.0"
+    "react": "^16.9.0",
+    "@hashicorp/nextjs-scripts": ">=16.x"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/split-rich-cta-list/props.js
+++ b/packages/split-rich-cta-list/props.js
@@ -1,20 +1,8 @@
+const baseProps = require('../../props.js')
+
 module.exports = {
-  brand: {
-    description:
-      'Styles the SplitRichCTAList with a color based on a HashiCorp product',
-    type: 'string',
-    control: { type: 'select' },
-    options: [
-      'hashicorp',
-      'nomad',
-      'consul',
-      'terraform',
-      'vault',
-      'packer',
-      'vagrant',
-      'waypoint',
-      'boundary',
-    ],
+  product: {
+    ...baseProps.product,
     testValue: 'hashicorp',
   },
   heading: {

--- a/packages/split-rich-cta-list/styles.module.css
+++ b/packages/split-rich-cta-list/styles.module.css
@@ -31,7 +31,6 @@
       width: 100%;
     }
 
-
     & > li {
       padding-left: 16px;
       @media (width < 910px) {
@@ -44,6 +43,7 @@
         transition: 0.25s ease;
         transition-property: background-color;
         width: 100%;
+        color: var(--black);
 
         &:hover {
           background-color: var(--gray-6);
@@ -60,31 +60,6 @@
           & h5 {
             margin-bottom: 8px;
             margin-top: 0;
-            color: var(--brand);
-            &.terraform {
-              color: var(--terraform);
-            }
-            &.consul {
-              color: var(--consul);
-            }
-            &.nomad {
-              color: var(--nomad);
-            }
-            &.vault {
-              color: var(--vault);
-            }
-            &.vagrant {
-              color: var(--vagrant);
-            }
-            &.packer {
-              color: var(--packer);
-            }
-            &.waypoint {
-              color: var(--waypoint);
-            }
-            &.boundary {
-              color: var(--boundary);
-            }
           }
 
           & p.bodySmall {


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

## Description

Somehow we missed this one as well. Another theming migration with `useProductMeta`.  

The theme was just changing the heading color, but **design wants all headings to be black**, even with product variations. So I'm wondering if we just remove this prop altogether since it really isn't doing anything color-wise... although it could be helpful later on if we want to add brand-specific styles to some of the UI. Or if the icons want to use the themed '--brand' color. Would love some input here.

### Migration

```diff
<SplitRichCTAList
- brand="terraform"
+ product="terraform"
  heading="Get Started with Terraform Modules on AWS"
  items={[
    {
      icon: require('./img/my-svg.svg'),
      title: 'Amazon Virtual Private Cloud (VPC) for Terraform on AWS',
      description:
        'Provision Amazon VPC resources, managed by Terraform, on the AWS Cloud.',
      linkUrl:
        'https://registry.terraform.io/modules/aws-quickstart/vpc/aws/latest',
    },
  ]}
/>
```

## Release Information

Please select one (**required**)

- [x] **Major** (This PR introduces a breaking (incompatible API) change)
- [ ] **Minor** (This PR adds functionality but it backwards-compatible)
- [ ] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>
<!-- This repo requires release notes on each PR in order to publish a package. Remove this comment and replace with release notes that will be reflected in the GitHub release notes. -->
</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [ ] Add release notes to the appropriate section (above).
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
