### PR TITLE
feat(docs-page): make args to docs-page server methods consistent

### DIFF
--- a/packages/docs-page/README.md
+++ b/packages/docs-page/README.md
@@ -30,17 +30,20 @@ function DocsLayout(props) {
 }
 
 export async function getStaticPaths() {
-  const paths = await generateStaticPaths(NAV_DATA, CONTENT_DIR)
+  const paths = await generateStaticPaths({
+    navDataFile: NAV_DATA,
+    localContentDir: CONTENT_DIR,
+  })
   return { paths, fallback: false }
 }
 
 export async function getStaticProps({ params }) {
-  const props = await generateStaticProps(
-    NAV_DATA,
-    CONTENT_DIR,
+  const props = await generateStaticProps({
+    navDataFile: NAV_DATA,
+    localContentDir: CONTENT_DIR,
     params,
-    PRODUCT
-  )
+    product: PRODUCT,
+  })
   return { props }
 }
 

--- a/packages/docs-page/server.js
+++ b/packages/docs-page/server.js
@@ -14,7 +14,7 @@ async function generateStaticPaths({
   navDataFile,
   localContentDir,
   paramId = DEFAULT_PARAM_ID,
-} = {}) {
+}) {
   // Fetch and parse navigation data
   const navData = await resolveNavData(navDataFile, localContentDir)
   const paths = getPathsFromNavData(navData, paramId)
@@ -50,7 +50,7 @@ async function generateStaticProps({
   remarkPlugins = [],
   scope, // optional, I think?
   paramId = DEFAULT_PARAM_ID,
-} = {}) {
+}) {
   //  Read in the nav data, and resolve local filePaths
   const navData = await resolveNavData(navDataFile, localContentDir)
   // Build the currentPath from page parameters


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

## Description

Usage of `generateStaticProps` is a little awkward are passing arguments both as objects as well as based on order. I think aligning on an object argument contract here makes it more consistent and easier for consumers.

Current usage:
```ts
    props: await generateStaticProps(
      NAV_DATA_FILE,
      CONTENT_DIR,
      params,
      { name: productName, slug: productSlug },
      {
        subpath,
        mainBranch: 'master',
        additionalComponents,
        basePath: 'docs',
        currentVersion: version,
      }
    ),
```

Updated usage:
```ts
    props: await generateStaticProps({
	  navDataFile: NAV_DATA_FILE,
	  localContentDir: CONTENT_DIR
	  product: { name: productName, slug: productSlug },
	  params,
	  subpath,
	  mainBranch: 'master',
	  additionalComponents,
	  basePath: 'docs',
	  currentVersion: version,
   }),
```

## Release Information

Please select one (**required**)

- [ ] **Major** (This PR introduces a breaking (incompatible API) change)
- [ ] **Minor** (This PR adds functionality but it backwards-compatible)
- [ ] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>

Refactors `react-docs-page` `generateStaticProps` arguments to accept an object for all arguments.

</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [ ] Add release notes to the appropriate section (above).
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
