### PR TITLE
patch(docs-sidenav): fix issue with flex-shrinking icon

### DIFF
--- a/packages/docs-sidenav/style.module.css
+++ b/packages/docs-sidenav/style.module.css
@@ -156,6 +156,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
 
   & svg {
     display: block;


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1199913030172635/f)
🔍 [Preview Link](https://react-components-git-zsfix-additional-docs-sidenav-visual-bugs-hashicorp.vercel.app)

---

This PR patches an issue in `docs-sidenav`, where items with long lines of text would cause icon alignment issues.

## Release Information

Please select one (**required**)

- [ ] **Major** (This PR introduces a breaking (incompatible API) change)
- [ ] **Minor** (This PR adds functionality but it backwards-compatible)
- [x] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>
This release patches an issue in `docs-sidenav`, where items with long lines of text would cause icon alignment issues
</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [x] Add release notes to the appropriate section (above).
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
