### PR TITLE
feat(docs-page): Adds headProps to DocsPage

### DIFF
--- a/packages/docs-page/index.js
+++ b/packages/docs-page/index.js
@@ -18,6 +18,7 @@ export function DocsPageWrapper({
   pageTitle,
   baseRoute,
   githubFileUrl,
+  headProps,
   product: { name, slug },
   showEditPage = true,
 }) {
@@ -38,6 +39,7 @@ export function DocsPageWrapper({
         description={description}
         siteName={`${name} by HashiCorp`}
         title={`${pageTitle} | ${name} by HashiCorp`}
+        {...headProps}
       />
       {/* render the sidebar nav */}
       {/* TODO: we can probably remove several of these wrappers */}
@@ -86,6 +88,7 @@ export default function DocsPage({
   showEditPage = true,
   additionalComponents,
   staticProps: { mdxSource, frontMatter, currentPath, navData, githubFileUrl },
+  headProps,
 }) {
   // This component is written to work with next-mdx-remote -- here it hydrates the content
   const content = hydrate(mdxSource, {
@@ -103,6 +106,7 @@ export default function DocsPage({
       product={product}
       showEditPage={showEditPage}
       baseRoute={baseRoute}
+      headProps={headProps}
     >
       {content}
     </DocsPageWrapper>

--- a/packages/docs-page/index.test.js
+++ b/packages/docs-page/index.test.js
@@ -39,6 +39,26 @@ describe('<DocsPage />', () => {
     expect(site_name).toBe(`Terraform by HashiCorp`)
   })
 
+  it('Supports overriding props passed to <HashiHead>', () => {
+    render(
+      <DocsPage
+        {...defaultProps}
+        headProps={{
+          siteName: 'HashiCorp Cloud Platform',
+          title: 'Test Page | HashiCorp Cloud Platform',
+        }}
+      />
+    )
+    // title renders correctly
+    expect(document.title).toBe(`Test Page | HashiCorp Cloud Platform`)
+    // siteName renders correctly
+    const site_name = Array.prototype.slice
+      .call(document.getElementsByTagName('meta'))
+      .filter((tag) => tag.getAttribute('property') === 'og:site_name')[0]
+      .getAttribute('content')
+    expect(site_name).toBe(`HashiCorp Cloud Platform`)
+  })
+
   it('passes props correctly to <DocsSidenav>', () => {
     render(<DocsPage {...defaultProps} />)
     // Confirm `product` is passed via document title

--- a/packages/docs-page/props.js
+++ b/packages/docs-page/props.js
@@ -118,4 +118,9 @@ module.exports = {
     },
     testValue: {},
   },
+  headProps: {
+    type: 'object',
+    description:
+      'Pass props directly to the rendered [@hashicorp/react-head](/?component=Head) component.',
+  },
 }


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link]()

---

## Description

Support passing `headProps` to `DocsPage` to override props we are passing to the underlying `HashiHead`.

Info here: https://app.asana.com/0/0/1199913030172645/1200143576905244/f

## Release Information

Please select one (**required**)

- [ ] **Major** (This PR introduces a breaking (incompatible API) change)
- [x] **Minor** (This PR adds functionality but it backwards-compatible)
- [ ] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>
<!-- This repo requires release notes on each PR in order to publish a package. Remove this comment and replace with release notes that will be reflected in the GitHub release notes. -->

Support new `headProps` prop to `DocsPage`, which passes them down to the underlying `HashiHead`.

</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [x] Add release notes to the appropriate section (above).
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
