### PR TITLE
fix(search): adds default to fix error during spread

### DIFF
--- a/packages/search/tools.js
+++ b/packages/search/tools.js
@@ -8,6 +8,8 @@ const fs = require('fs')
 const remark = require('remark')
 const visit = require('unist-util-visit')
 
+const DEFAULT_FRONTMATTER_KEYS = ['page_title', 'description']
+
 const projectRoot = process.cwd()
 
 async function indexDocsContent({
@@ -19,7 +21,7 @@ async function indexDocsContent({
   contentDir = path.join(projectRoot, 'content'),
   filesPattern = '**/*.mdx',
   globOptions = { ignore: path.join(projectRoot, 'content', 'partials/**/*') },
-  frontmatterKeys,
+  frontmatterKeys = DEFAULT_FRONTMATTER_KEYS,
 } = {}) {
   const searchObjects = await getDocsSearchObjects({
     contentDir,
@@ -96,7 +98,7 @@ async function getDocsSearchObjects({
 async function getDocsSearchObject(
   urlPath,
   fileString,
-  frontmatterKeys = ['page_title', 'description']
+  frontmatterKeys = DEFAULT_FRONTMATTER_KEYS
 ) {
   const { content, data } = matter(fileString)
   const searchableDimensions = frontmatterKeys.reduce((acc, key) => {


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

## Description

Context: https://hashicorp.slack.com/archives/CS0V9PG14/p1617323374015800

We are missing a default value for `frontmatterKeys` in `indexDocsContent`, which spreads the value. Adding back a default to ensure we don't get errors.

## Release Information

Please select one (**required**)

- [ ] **Major** (This PR introduces a breaking (incompatible API) change)
- [ ] **Minor** (This PR adds functionality but it backwards-compatible)
- [x] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>

Fixes `TypeError` during spread of `frontmatterKeys` in `indexDocsContent`.

</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [x] Add release notes to the appropriate section (above).
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
