### PR TITLE
fix(subnav): highlight nav item for nested paths

### DIFF
--- a/packages/subnav/helpers/areBasePathsMatching.ts
+++ b/packages/subnav/helpers/areBasePathsMatching.ts
@@ -1,0 +1,7 @@
+export function areBasePathsMatching(pathA: string, pathB: string) {
+  // use .filter(Boolean) to remove any falsy values, like ""
+  const [pathABase] = pathA.split('/').filter(Boolean)
+  const [pathBBase] = pathB.split('/').filter(Boolean)
+
+  return pathABase === pathBBase
+}

--- a/packages/subnav/index.js
+++ b/packages/subnav/index.js
@@ -7,6 +7,7 @@ import TitleLink from './partials/TitleLink/index.js'
 import MenuItemsDefault from './partials/MenuItemsDefault/index.js'
 import CtaLinks from './partials/CtaLinks/index.js'
 import traverse, { isObject } from './helpers/traverse/index.js'
+import { areBasePathsMatching } from './helpers/areBasePathsMatching'
 
 const productAllowList = {
   consul: 'consul',
@@ -38,7 +39,9 @@ function SubnavInner({
   // Add _isActiveUrl to menuItems so we can highlight them appropriately
   const menuItemsWithActive = traverse(menuItems, (_key, value) => {
     const hasUrl = isObject(value) && value.url
-    if (hasUrl) value._isActiveUrl = value.url === currentPath
+    if (hasUrl) {
+      value._isActiveUrl = areBasePathsMatching(value.url, currentPath)
+    }
     return value
   })
 

--- a/packages/subnav/index.test.js
+++ b/packages/subnav/index.test.js
@@ -81,6 +81,18 @@ describe('<Subnav />', () => {
     })
   })
 
+  it('should highlight the active link for nested routes', async () => {
+    render(<Subnav {...baseProps} currentPath="/docs/nested" />)
+    await waitForGithubStarsUpdate()
+    const activeMenuItem = baseProps.menuItems.filter((menuItem) => {
+      return menuItem.url === '/docs'
+    })[0]
+    const menuItemTextElem = screen.getAllByText(activeMenuItem.text)[0]
+    expect(menuItemTextElem).toBeVisible()
+    const linkElem = menuItemTextElem.parentNode
+    expect(linkElem.classList.contains('is-active')).toBe(true)
+  })
+
   it('should highlight the active link', async () => {
     render(<Subnav {...baseProps} />)
     await waitForGithubStarsUpdate()


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1200312209461188/f)
🔍 [Preview Link](https://react-componen-git-brkfix-subnav-highlight-nested-paths-a9c5a3.vercel.app/)

---

## Description

Notice `Docs` is not highlighted:

![Screen Shot 2021-05-19 at 6 50 26 PM](https://user-images.githubusercontent.com/1289701/118898845-14b5c880-b8d3-11eb-81be-9cf913b0b8c1.png)

This change checks the first path segment to determine whether or not to highlight the nav item, instead of the entire path.

## Release Information

Please select one (**required**)

- [ ] **Major** (This PR introduces a breaking (incompatible API) change)
- [ ] **Minor** (This PR adds functionality but it backwards-compatible)
- [x] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>

Ensure nav items are highlighted if on a nested path.

</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [x] Add release notes to the appropriate section (above).
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
