### PR TITLE
fix downloads page ent matcher

### DIFF
--- a/packages/product-download-page/index.tsx
+++ b/packages/product-download-page/index.tsx
@@ -46,7 +46,7 @@ export default function ProductDownloadsPage({
   const sortedReleases = latestReleases
     // remove enterprise releases unless enterpriseMode is active
     .filter((releaseVersion) => {
-      const isEnterpriseVersion = !!releaseVersion.match(/\+ent(?:-.*?)*$/)
+      const isEnterpriseVersion = !!releaseVersion.match(/\+ent(?:.*?)*$/)
       if (enterpriseMode) return isEnterpriseVersion
       return !isEnterpriseVersion
     })


### PR DESCRIPTION
Vault had an unusual pattern of naming enterprise releases that was causing the "enterprise version" matcher not to filter them correctly from the downloads page. This loosens the requirements to make sure that match works!