### PR TITLE
fix(code-block): remove font-style highlight CSS

### DIFF
--- a/packages/code-block/theme-dark.module.css
+++ b/packages/code-block/theme-dark.module.css
@@ -78,21 +78,7 @@
     color: #fff;
   }
 
-  &:global(.important),
-  &:global(.statement),
-  &:global(.bold) {
-    font-weight: bold;
-  }
-
   &:global(.punctuation) {
     color: #bebec5;
-  }
-
-  &:global(.entity) {
-    cursor: help;
-  }
-
-  &:global(.italic) {
-    font-style: italic;
   }
 }

--- a/packages/code-block/theme-light.module.css
+++ b/packages/code-block/theme-light.module.css
@@ -80,22 +80,6 @@
     color: #f25a92;
   }
 
-  &:global(.important) {
-    font-weight: normal;
-  }
-
-  &:global(.bold) {
-    font-weight: bold;
-  }
-
-  &:global(.italic) {
-    font-style: italic;
-  }
-
-  &:global(.entity) {
-    cursor: help;
-  }
-
   &:global(.namespace) {
     opacity: 0.7;
   }


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

This PR fixes a minor issue in `code-block`  related to font-styles that don't work as expected due to incompatibility with our current `monospace` font.

Merging this as a hot fix as this is a regression, and since the fix is straightforward.

#### Before

Bold font-weight causes letter width difference, which looks extremely awkward.

![before](https://user-images.githubusercontent.com/4624598/122630336-cd1c8b00-d090-11eb-9a56-7d3cac4389ce.png)

#### After

All font-style-affecting syntax token CSS is removed. Syntax tokens affect coloration only.

<img width="760" alt="after" src="https://user-images.githubusercontent.com/4624598/122630334-ca219a80-d090-11eb-8e57-6365b3bf7841.png">


## Release Information

Please select one (**required**)

- [ ] **Major** (This PR introduces a breaking (incompatible API) change)
- [ ] **Minor** (This PR adds functionality but it backwards-compatible)
- [x] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>

This release fixes a minor issue in `code-block`  related to font-styles that don't work as expected due to incompatibility with our current `monospace` font.

</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [x] Add release notes to the appropriate section (above).
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
