### PR TITLE
fix(code-block): use pre, not code, for custom mdx elem

### DIFF
--- a/packages/code-block/mdx/index.js
+++ b/packages/code-block/mdx/index.js
@@ -55,7 +55,7 @@ export function pre({
   const language = className ? className.replace('language-', '') : undefined
   return (
     <CodeBlock
-      className={className}
+      className={classNames(className, { [s.codeMargin]: !hasBarAbove })}
       code={code}
       language={language}
       options={{ showClipboard: !hideClipboard }}


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1199632955771589/list)
🔍 [Preview Link](https://react-components-git-zsfix-code-block-mdx-mapping-hashicorp.vercel.app/)

---

This PR changes `code-block`'s MDX custom components to use the `<pre>` element rather than the `<code>` element. The `<code>` element is now left untouched.

## Release Information

Please select one (**required**)

- [ ] **Major** (This PR introduces a breaking (incompatible API) change)
- [ ] **Minor** (This PR adds functionality but it backwards-compatible)
- [x] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>

🩹 Patch release. This release changes `@hashicorp/react-code-block/mdx` custom components to use the `<pre>` element rather than the `<code>` element to insert the component into MDX. The `<code>` element is now left untouched, and can continue to be used for inline code (although we would prefer to use backticks instead).

Note that `@hashicorp/react-code-block/mdx` no longer exports a `code` element. For clarity, consumers should remove any references to the previous custom `code` element exported by `code-block/mdx`. However, we're marking this as non-breaking as passing `undefined` for any custom component has no effect on the rendered MDX.

</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [x] Add release notes to the appropriate section (above).
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
