### PR TITLE
patch(docs-sidenav): fix duplicate active categories

### DIFF
--- a/packages/docs-sidenav/fixtures/nav-data.json
+++ b/packages/docs-sidenav/fixtures/nav-data.json
@@ -36,6 +36,10 @@
                 "title": "AWS",
                 "path": "agent/autoauth/methods/aws"
               },
+              {
+                "title": "AWS active page alias",
+                "href": "/components/docssidenav"
+              },
               { "divider": true },
               {
                 "title": "<code>GCP</code>",
@@ -49,6 +53,20 @@
               {
                 "title": "Internal Direct Link",
                 "href": "/some-non-docs-path"
+              }
+            ]
+          },
+          {
+            "title": "With active nested alias",
+            "routes": [
+              {
+                "title": "Subcategory",
+                "routes": [
+                  {
+                    "title": "Active page alias In Another Category",
+                    "href": "/components/docssidenav"
+                  }
+                ]
               }
             ]
           }

--- a/packages/docs-sidenav/utils/flag-active-nodes.js
+++ b/packages/docs-sidenav/utils/flag-active-nodes.js
@@ -13,7 +13,33 @@ function addIsActiveToNode(navNode, currentPath, pathname) {
       currentPath,
       pathname
     )
-    const isActive = routesWithActive.filter((r) => r.__isActive).length > 0
+    const isActive =
+      routesWithActive.filter((r) => {
+        // Note: we set categories to be "active" only if they have an
+        // internal, "canonical" ({ title, path }) active descendent.
+        //
+        // We do not highlight categories that have "direct link"
+        // ({title, href }) descendants. This covers the following use cases:
+        //
+        // 1. Typical use case - { title, path } internal links
+        //    The category contains the "canonical" { title, path } link,
+        //    ancestor categories will be expanded and highlighted.
+        //    We've validated there are no duplicate { title, path } links
+        //    using the "validate-route-structure" utility.
+        // 2. "Alias" use case - { title, href } internal links
+        //    Categories with active "alias" link descendants will
+        //    not be expanded or highlighted. This is an intentional stopgap
+        //    measure to account for the "alias" use case. For details, see:
+        //    https://app.asana.com/0/1100423001970639/1200311175037672/f
+        //
+        // Note that categories containing external direct links will not
+        // be highlighted. By definition, external direct links will be outside
+        // of the base route where the docs-sidenav is rendered, so we don't
+        // seem to have a need to highlight these as active.
+        const isActiveCanonical = r.__isActive && r.path
+        const isActiveCategory = r.__isActive && r.routes
+        return isActiveCanonical || isActiveCategory
+      }).length > 0
     return { ...navNode, routes: routesWithActive, __isActive: isActive }
   }
   // If it's a node with a path value,


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1200311175037672/f)
🔍 [Preview Link](https://react-components-git-zsfix-docs-sidenav-dupe-h-94c735-hashicorp.vercel.app/components/docssidenav)

---

This PR fixes an issue where multiple active nodes in the sidebar would result in multiple parent categories being expanded.

This issue arises because docs authors sometimes use `{ title, href }` nodes for internal "alias" links rather than external links, which our design and data model did not account for. Docs authors want these links to be treated as "alias" to the canonical `{ title, path }`-style links.

## Pre-fix behaviour, for context

- Both "canonical" and "alias" links are highlighted
- Any ancestor categories of any "canonical" or "alias" link is expanded and highlighted
- Preview:
    <img width="1119" alt="CleanShot 2021-07-06 at 23 15 07@2x" src="https://user-images.githubusercontent.com/4624598/124694846-0ab24e00-deb0-11eb-8763-e22ecad0f736.png">

## Revised behaviour, in this PR

- Both "canonical" and "alias" links are highlighted
- Any ancestor categories of "canonical" links only will be expanded and highlighted. Ancestors of "alias" links (or any other direct links described with `{ title, href }` will not be expanded or highlighted.
- Preview:
    <img width="1081" alt="CleanShot 2021-07-06 at 23 13 30@2x" src="https://user-images.githubusercontent.com/4624598/124694805-f9694180-deaf-11eb-9ee3-2f6b1101b51d.png">
- Preview showing that "alias" links are highlighted, but not their ancestor categories:
    <img width="1111" alt="CleanShot 2021-07-06 at 23 16 19@2x" src="https://user-images.githubusercontent.com/4624598/124694922-32a1b180-deb0-11eb-984e-da6ca628b4af.png">


## Release Information

Please select one (**required**)

- [ ] **Major** (This PR introduces a breaking (incompatible API) change)
- [ ] **Minor** (This PR adds functionality but it backwards-compatible)
- [x] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>

🐛  This release fixes an issue where the parent categories of "alias" links would appear highlighted and expanded. The new behaviour is that these categories will not be highlighted or expanded.

See #269 for additional context on the bug, and on previous and revised behaviour.

</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [x] Add release notes to the appropriate section (above).
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
