### PR TITLE
hashi-stack-menu: remove /about link

### DIFF
--- a/packages/hashi-stack-menu/data/index.js
+++ b/packages/hashi-stack-menu/data/index.js
@@ -117,5 +117,4 @@ export default [
     title: 'Browse Products',
     sections: DEFAULT_MENU_SECTIONS,
   },
-  { title: 'About HashiCorp', linkUrl: 'https://www.hashicorp.com/about' },
 ]


### PR DESCRIPTION
per request from armon to remove /about link