### PR TITLE
fix(subnav): add matchOnBasePath prop

### DIFF
--- a/packages/subnav/index.js
+++ b/packages/subnav/index.js
@@ -33,13 +33,16 @@ function SubnavInner({
   constrainWidth,
   currentPath,
   Link,
+  matchOnBasePath = false,
 }) {
   const { themeClass } = useProductMeta(product) // overrides --brand css vars
   // Add _isActiveUrl to menuItems so we can highlight them appropriately
   const menuItemsWithActive = traverse(menuItems, (_key, value) => {
     const hasUrl = isObject(value) && value.url
     if (hasUrl) {
-      value._isActiveUrl = areBasePathsMatching(value.url, currentPath)
+      value._isActiveUrl = matchOnBasePath
+        ? areBasePathsMatching(value.url, currentPath)
+        : value.url === currentPath
     }
     return value
   })

--- a/packages/subnav/index.test.js
+++ b/packages/subnav/index.test.js
@@ -81,8 +81,8 @@ describe('<Subnav />', () => {
     })
   })
 
-  it('should highlight the active link for nested routes', async () => {
-    render(<Subnav {...baseProps} currentPath="/docs/nested" />)
+  it('should highlight the active link for nested routes when matchOnBasePath=true', async () => {
+    render(<Subnav {...baseProps} currentPath="/docs/nested" matchOnBasePath />)
     await waitForGithubStarsUpdate()
     const activeMenuItem = baseProps.menuItems.filter((menuItem) => {
       return menuItem.url === '/docs'

--- a/packages/subnav/props.js
+++ b/packages/subnav/props.js
@@ -98,4 +98,9 @@ module.exports = {
     description:
       "The NextJS Link component to make client-side routing possible. Note that this is passed directly to @hashicorp/react-link-wrap, so we'll fall back to a normal <a/> tag if this prop is not provided.",
   },
+  matchOnBasePath: {
+    type: 'boolean',
+    description:
+      'Whether or not to highlight items if the base path matches the current URL. Defaults to `false`, requiring a full URL  match.',
+  },
 }


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

## Description

Past me thought he was fixing highlighting in #234, but turns out he broke it for many use cases on www. Adding the new behavior behind a prop, `matchOnBasePath`, to ensure we can still retain the previous, full url match strategy.

Bad behavior can be seen here: https://hashicorp-www-next-git-brkchore-migrate-nextjs-8fb983-hashicorp.vercel.app/products/terraform

## Release Information

Please select one (**required**)

- [ ] **Major** (This PR introduces a breaking (incompatible API) change)
- [x] **Minor** (This PR adds functionality but it backwards-compatible)
- [ ] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>
<!-- This repo requires release notes on each PR in order to publish a package. Remove this comment and replace with release notes that will be reflected in the GitHub release notes. -->
</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Add release notes to the appropriate section (above).
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
