### PR TITLE
fix(terminal): ensure pre has same bg color

### DIFF
--- a/packages/terminal/Terminal.module.css
+++ b/packages/terminal/Terminal.module.css
@@ -50,7 +50,7 @@
     border-radius: 0 0 var(--terminal-radius) var(--terminal-radius);
     padding: 24px 32px;
 
-    & > pre {
+    & pre {
       background: var(--terminal-body-color);
     }
   }

--- a/packages/terminal/Terminal.module.css
+++ b/packages/terminal/Terminal.module.css
@@ -50,6 +50,7 @@
     border-radius: 0 0 var(--terminal-radius) var(--terminal-radius);
     padding: 24px 32px;
 
+    /* Ensures that highlighted code maintains the same background as the terminal element */
     & pre {
       background: var(--terminal-body-color);
     }

--- a/packages/terminal/Terminal.module.css
+++ b/packages/terminal/Terminal.module.css
@@ -49,6 +49,10 @@
     background: var(--terminal-body-color);
     border-radius: 0 0 var(--terminal-radius) var(--terminal-radius);
     padding: 24px 32px;
+
+    & > pre {
+      background: var(--terminal-body-color);
+    }
   }
 }
 


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-brkfix-command-line-termi-0508a5-hashicorp.vercel.app/components/commandlineterminal)

---

## Description

Noticed when updating waypoint that the pre inside of the terminal had a different background color. I updated the styles of the terminal component to set the pre background explicitly. Not sure if there's a better way to do this 🤔. @zchsh curious what you think of this in particular.

Regression:
![Screen Shot 2021-07-22 at 11 56 50 AM](https://user-images.githubusercontent.com/1289701/126679132-7c6d0fd4-c6df-4bc2-b49f-2aed8f8848b4.png)

Also visible here: https://react-components.vercel.app/components/commandlineterminal


## Release Information

Please select one (**required**)

- [ ] **Major** (This PR introduces a breaking (incompatible API) change)
- [ ] **Minor** (This PR adds functionality but it backwards-compatible)
- [x] **Patch** (This PR adds a backwards-compatible bug fix)

<details>
<summary>Release Notes (<strong>required</strong>)</summary>
<!-- This repo requires release notes on each PR in order to publish a package. Remove this comment and replace with release notes that will be reflected in the GitHub release notes. -->
</details>

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Add release notes to the appropriate section (above).
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Cross Browser Testing](https://crossbrowsertesting.com) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
