### PR TITLE
Show Consent Manager globally

### DIFF
--- a/packages/consent-manager/docs.mdx
+++ b/packages/consent-manager/docs.mdx
@@ -5,6 +5,7 @@ componentName: ConsentManager
 A GDPR-compliant consent manager, integrated with segment.
 
 <LiveComponent>{`<ConsentManager
+  version={1}
   segmentWriteKey='iyi06c432UL7SB1r3fQReec4bNwFyzkW'
   utilServerRoot='https://hashicorp-web-util-staging.herokuapp.com'
   privacyPolicyLink='https://www.hashicorp.com/privacy'
@@ -28,7 +29,7 @@ A GDPR-compliant consent manager, integrated with segment.
       url: 'http://www.an-optional-url-for-a-script-to-add-to-the-page.com',
     },
     {
-      name: 'Name of the service',
+      name: 'Name of the service 2',
       category: 'Example Category',
       description: 'A script with additional elements to be injected',
       body: '',

--- a/packages/consent-manager/index.js
+++ b/packages/consent-manager/index.js
@@ -1,6 +1,5 @@
 import { Component } from 'react'
 import EventEmitter from 'events'
-import inEU from '@segment/in-eu'
 import ConsentBanner from './partials/banner'
 import ConsentPreferences from './partials/dialog'
 import { loadPreferences, savePreferences } from './partials/cookies'
@@ -47,7 +46,11 @@ export default class ConsentManager extends Component {
   }
 
   shouldRequireConsent() {
-    // 1. Check cookies
+    // 1. If prop override is set, always show the consent bar.
+    if (this.props.forceShow) {
+      return true
+    }
+    // 2. Check cookies and apply existing consent preferences if they've already been set.
     if (
       this.state.preferences &&
       this.state.preferences.version === this.props.version
@@ -60,14 +63,8 @@ export default class ConsentManager extends Component {
       )
       return false
     }
-    // 2. Check inEU. If in-eu, show consent. If not, show nothing. Load all.
-    if (inEU() || this.props.forceShow) {
-      return true
-    } else {
-      // Load all analytics
-      this.saveAndLoadAnalytics({ loadAll: true })
-      return false
-    }
+    // 3. Always show the consent bar if we don't have a response stored.
+    return true
   }
 
   componentDidMount() {

--- a/packages/consent-manager/index.js
+++ b/packages/consent-manager/index.js
@@ -26,7 +26,7 @@ export default class ConsentManager extends Component {
 
   saveAndLoadAnalytics(preferences) {
     if (typeof preferences === 'undefined') {
-      preferences = { All: false, 'Segment.io': false }
+      preferences = { loadAll: false, segment: false }
     }
     savePreferences(preferences, this.props.version)
 
@@ -52,7 +52,7 @@ export default class ConsentManager extends Component {
     }
     // 2. Check cookies and apply existing consent preferences if they've already been set.
     if (
-      this.state.preferences &&
+      Object.keys(this.state.preferences).length !== 0 &&
       this.state.preferences.version === this.props.version
     ) {
       // Load segment and custom integrations
@@ -62,9 +62,10 @@ export default class ConsentManager extends Component {
         this.props.additionalServices
       )
       return false
+    } else {
+      // 3. Always show the consent bar if we don't have a response stored.
+      return true
     }
-    // 3. Always show the consent bar if we don't have a response stored.
-    return true
   }
 
   componentDidMount() {

--- a/packages/consent-manager/index.test.js
+++ b/packages/consent-manager/index.test.js
@@ -57,28 +57,6 @@ test('shows the banner if the forceShow prop is true', () => {
   expect(screen.getByTestId('consent-banner')).toBeInTheDocument()
 })
 
-test('shows the banner if in EU', async () => {
-  await runWithMockedImport(
-    '@segment/in-eu',
-    () => true,
-    (MockedConsentManager) => {
-      render(<MockedConsentManager {...defaultProps} forceShow={false} />)
-      expect(screen.queryByTestId('consent-banner')).toBeInTheDocument()
-    }
-  )
-})
-
-test('does not show the banner if not in EU', async () => {
-  await runWithMockedImport(
-    '@segment/in-eu',
-    () => false,
-    (MockedConsentManager) => {
-      render(<MockedConsentManager {...defaultProps} forceShow={false} />)
-      expect(screen.queryByTestId('consent-banner')).not.toBeInTheDocument()
-    }
-  )
-})
-
 test('sets existing preferences and does not show the banner if preferences are already set', async () => {
   await runWithMockedImport(
     './partials/cookies',
@@ -109,23 +87,6 @@ test('shows the banner if preferences are set but version has increased', async 
       expect(screen.queryByTestId('consent-banner')).toBeInTheDocument()
     }
   )
-})
-
-test('automatically opts in to all if not in EU', async () => {
-  let prefs
-  await runWithMockedImport(
-    './partials/cookies',
-    {
-      loadPreferences: () => {},
-      savePreferences: (preferences) => {
-        prefs = preferences
-      },
-    },
-    (MockedConsentManager) => {
-      render(<MockedConsentManager {...defaultProps} forceShow={false} />)
-    }
-  )
-  expect(prefs.loadAll).toBe(true)
 })
 
 test('if the manage preferences button is clicked, opens the dialog and makes body un-scrollable', async () => {

--- a/packages/consent-manager/index.test.js
+++ b/packages/consent-manager/index.test.js
@@ -49,7 +49,6 @@ const defaultProps = {
     },
   ],
   container: '#consent-manager',
-  forceShow: true,
 }
 
 test('shows the banner if the forceShow prop is true', () => {
@@ -62,7 +61,7 @@ test('sets existing preferences and does not show the banner if preferences are 
     './partials/cookies',
     {
       loadPreferences: () => {
-        return { All: false, 'Segment.io': false }
+        return { loadAll: false, segment: false, version: 0 }
       },
       savePreferences: () => {},
     },
@@ -78,12 +77,14 @@ test('shows the banner if preferences are set but version has increased', async 
     './partials/cookies',
     {
       loadPreferences: () => {
-        return { All: false, 'Segment.io': false, version: 1 }
+        return { loadAll: false, segment: false, version: 1 }
       },
       savePreferences: () => {},
     },
     (MockedConsentManager) => {
-      render(<MockedConsentManager {...defaultProps} version={2} />)
+      render(
+        <MockedConsentManager {...defaultProps} forceShow={false} version={2} />
+      )
       expect(screen.queryByTestId('consent-banner')).toBeInTheDocument()
     }
   )

--- a/packages/consent-manager/package-lock.json
+++ b/packages/consent-manager/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashicorp/react-consent-manager",
-  "version": "5.3.2",
+  "version": "6.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/consent-manager/package-lock.json
+++ b/packages/consent-manager/package-lock.json
@@ -4,23 +4,62 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@segment/in-eu": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@segment/in-eu/-/in-eu-0.2.1.tgz",
-      "integrity": "sha512-7JKBw/l3S9J0ldo/n6XPfd3sT89f300KOCvmZsd8sryVZOWlE4L2LMKT538I34bjRdaOd1aJ52TsOAZUOLqxiQ==",
+    "@hashicorp/platform-product-meta": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/platform-product-meta/-/platform-product-meta-0.1.0.tgz",
+      "integrity": "sha512-UXAiYENDP8I0mD9+LNMyaCksUPthPRkxAIzg12SbERgx5kAjEaBCzYRHKXibL1dZpVQiRfs0i/0ieSw0mP2y+Q==",
       "requires": {
-        "jstz": "^2.0.0"
+        "@hashicorp/platform-util": "^0.1.0"
       }
+    },
+    "@hashicorp/platform-util": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/platform-util/-/platform-util-0.1.0.tgz",
+      "integrity": "sha512-XGWmQnMThygQKUsB5fPfhWT2KIbAq3Zax1K7TiEarX7IrngpEk7oTpVUR0uEraZgpfsaOfhHGSilvBRZjCZ+Ew==",
+      "requires": {
+        "nprogress": "0.2.0"
+      }
+    },
+    "@hashicorp/react-button": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-button/-/react-button-5.2.1.tgz",
+      "integrity": "sha512-X3v175qyCi1U7r6X6i283Bskqq90Zce0KxUeKGPh2jpt+ZmYJ2ftjknzpCv4/S2/bqmEs96+Qe2a8hH1JWhxcA==",
+      "requires": {
+        "@hashicorp/platform-product-meta": "^0.1.0",
+        "@hashicorp/react-inline-svg": "^1.0.0",
+        "classnames": "^2.2.6",
+        "slugify": "1.3.6"
+      }
+    },
+    "@hashicorp/react-inline-svg": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-inline-svg/-/react-inline-svg-1.0.2.tgz",
+      "integrity": "sha512-AAFnBslSTgnEr++dTbMn3sybAqvn7myIj88ijGigF6u11eSRiV64zqEcyYLQKWTV6dF4AvYoxiYC6GSOgiM0Yw=="
+    },
+    "@hashicorp/react-toggle": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-toggle/-/react-toggle-3.0.2.tgz",
+      "integrity": "sha512-AT6iP+YhaiLufwdqwZZOpwG3e3s7XGzxpehpIDckZP8xliQudbIpXKRX55Aatv7aCujvhBl/e+huM99Y/dMJoA=="
+    },
+    "classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "js-cookie": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
       "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
     },
-    "jstz": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/jstz/-/jstz-2.1.1.tgz",
-      "integrity": "sha512-8hfl5RD6P7rEeIbzStBz3h4f+BQHfq/ABtoU6gXKQv5OcZhnmrIpG7e1pYaZ8hS9e0mp+bxUj08fnDUbKctYyA=="
+    "nprogress": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
+      "integrity": "sha1-y480xTIT2JVyP8urkH6UIq28r7E="
+    },
+    "slugify": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.6.tgz",
+      "integrity": "sha512-wA9XS475ZmGNlEnYYLPReSfuz/c3VQsEMoU43mi6OnKMCdbnFXd4/Yg7J0lBv8jkPolacMpOrWEaoYxuE1+hoQ=="
     }
   }
 }

--- a/packages/consent-manager/package.json
+++ b/packages/consent-manager/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "@hashicorp/react-button": "^5.2.1",
     "@hashicorp/react-toggle": "^3.0.2",
-    "@segment/in-eu": "^0.2.1",
     "js-cookie": "^2.2.0"
   },
   "license": "MPL-2.0",

--- a/packages/consent-manager/package.json
+++ b/packages/consent-manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hashicorp/react-consent-manager",
   "description": "A GDPR-compliant Consent Manager",
-  "version": "5.3.2",
+  "version": "6.0.0",
   "author": "HashiCorp",
   "contributors": [
     "Jennifer Yip",

--- a/packages/consent-manager/props.js
+++ b/packages/consent-manager/props.js
@@ -21,6 +21,11 @@ module.exports = {
     description:
       "root path of the instance of HashiCorp's `web-utility-server` to use. This is used to fetch integrations based on segment write key",
   },
+  forceShow: {
+    type: 'boolean',
+    description:
+      'Useful for development, setting this to true will always show the consent bar even if a cookie with existing preferences is stored',
+  },
   segmentServices: {
     type: 'array',
     description:

--- a/packages/consent-manager/props.js
+++ b/packages/consent-manager/props.js
@@ -3,23 +3,28 @@ module.exports = {
     type: 'string',
     description:
       'bump this number when services have changed to "reset" the consent manager and prompt for consent again',
+    required: true,
   },
   privacyPolicyLink: {
     type: 'string',
     description: "a link to the company's privacy policy page",
+    required: true,
   },
   cookiePolicyLink: {
     type: 'string',
     description: "a link to the company's cookie policy page",
+    required: true,
   },
   segmentWriteKey: {
     type: 'string',
     description: 'segment.io write key',
+    required: true,
   },
   utilServerRoot: {
     type: 'string',
     description:
       "root path of the instance of HashiCorp's `web-utility-server` to use. This is used to fetch integrations based on segment write key",
+    required: true,
   },
   forceShow: {
     type: 'boolean',
@@ -130,7 +135,7 @@ module.exports = {
               },
               value: {
                 type: 'string',
-                description: 'value of the data attrivute',
+                description: 'value of the data attribute',
               },
             },
           },


### PR DESCRIPTION
📝 [RFC](https://docs.google.com/document/d/12UIDBgpR6lilkFrxQFr7i1zTxCm04szAZkGKSSlgRkI/edit#)

---

## Description

This removes the `@segment/in-eu` package and check from our Consent Manager. This change means it will now be shown to all visitors, regardless of their geography. 

Also updates tests, and fixes some small bugs (I think..):

* The `forceShow` prop wasn't working quite right because of the wrong conditional order in `shouldRequireConsent`
* The `preference` object key names were off (e.g. `All` instead of `loadAll`) - prime example of where a TS refactor would help us out here, but that's outside my scope at the moment unfortunately)

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
      1
