### PR TITLE
Add onBlur to combobox

### DIFF
--- a/packages/combobox/index.tsx
+++ b/packages/combobox/index.tsx
@@ -19,6 +19,7 @@ export interface ComboboxProps {
   options: ComboboxOptionValue[]
   openOnFocus?: boolean
   onInputChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onInputBlur?: (e: React.FocusEvent<HTMLInputElement>) => void
   invalidInputValue?: boolean
 }
 
@@ -31,6 +32,7 @@ export default function Combobox({
   options,
   openOnFocus = true,
   onInputChange,
+  onInputBlur,
   renderOption,
   invalidInputValue,
 }: ComboboxProps) {
@@ -53,6 +55,7 @@ export default function Combobox({
       <ComboboxButton label={buttonLabel} />
       <ComboboxInput
         onChange={handleInputValueChange}
+        onBlur={onInputBlur}
         data-has-error={invalidInputValue ?? false}
       />
       {results?.length > 0 ? (

--- a/packages/combobox/primitives.tsx
+++ b/packages/combobox/primitives.tsx
@@ -52,6 +52,7 @@ export function ComboboxPopover({
 export interface ComboboxInputProps extends ReachComboboxInputProps {
   className?: string
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void
 }
 
 export function ComboboxInput({

--- a/packages/combobox/props.js
+++ b/packages/combobox/props.js
@@ -18,6 +18,10 @@ module.exports = {
     type: 'function',
     description: 'A change handler for the input',
   },
+  onInputBlur: {
+    type: 'function',
+    description: 'An `onBlur` handler for the input',
+  },
   openOnFocus: {
     type: 'boolean',
     description: 'Controls whether the dropdown opens on focus of the input',


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-jmcombobox-onblur-hashicorp.vercel.app/components/combobox)

---



## Description

This PR adds an `onInputBlur` prop to the default component, and `onBlur` to the `<ComboboxInput />` - I was surprised this was not already in the underlying interface, and am still considering what the proper solution is. I'd like to make sure we give the proper amount of control to consumers at the `<input>` level and expose the right props in the default component without being exhaustive.



### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
      1
