### PR TITLE
fix(content): fix incorrect body type class

### DIFF
--- a/packages/content/style.module.css
+++ b/packages/content/style.module.css
@@ -1,6 +1,6 @@
 .root {
   /* Base typography */
-  composes: g-type-body-long from global;
+  composes: g-type-long-body from global;
 
   /* Include all content base styles */
   composes: a from './styles/a.module.css';


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1199185162145231/f)
🔍 [Preview Link](https://react-components-git-zsfix-content-blunder-hashicorp.vercel.app)

This PR fixes a facepalm-y issue in our `content` component, where `g-type-body-long` is composed, rather than the correct `g-type-long-body`.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
