### PR TITLE
feat(product-download): support custom title, plus design tweaks

### DIFF
--- a/packages/product-download-page/index.test.js
+++ b/packages/product-download-page/index.test.js
@@ -164,6 +164,23 @@ describe('<ProductDownloadsPage />', () => {
       expect(screen.getByText('Containers')).toBeInTheDocument()
     })
   })
+
+  describe('Page Settings', () => {
+    it('should render a generated page title if no pageTitle prop is provided', () => {
+      setup()
+      const expectedTitle = screen.getByText('Download Waypoint')
+      expect(expectedTitle).toBeInTheDocument()
+      expect(expectedTitle.tagName).toBe('H1')
+    })
+
+    it('should allow the pageTitle prop to override the generated page title', () => {
+      const pageTitle = 'My Special Custom Title'
+      setup({ pageTitle })
+      const expectedTitle = screen.getByText(pageTitle)
+      expect(expectedTitle).toBeInTheDocument()
+      expect(expectedTitle.tagName).toBe('H1')
+    })
+  })
 })
 
 // Fixture Data

--- a/packages/product-download-page/index.test.js
+++ b/packages/product-download-page/index.test.js
@@ -19,7 +19,7 @@ describe('<ProductDownloadsPage />', () => {
       setup()
 
       expect(screen.getByText('Package Manager')).toBeInTheDocument()
-      expect(screen.getByText('Binary Download')).toBeInTheDocument()
+      expect(screen.getByText('macOS Binary Download')).toBeInTheDocument()
     })
 
     it('should switch to a different OS when clicking a tab', () => {

--- a/packages/product-download-page/index.tsx
+++ b/packages/product-download-page/index.tsx
@@ -27,7 +27,7 @@ export default function ProductDownloadsPage({
   className,
   packageManagerOverrides = [],
   enterpriseMode = false,
-  pageTitle, // optional, will default to title constructed from useProductMeta name
+  pageTitle,
   // these props are piped in from `generateStaticProps`
   product,
   latestVersion,

--- a/packages/product-download-page/index.tsx
+++ b/packages/product-download-page/index.tsx
@@ -27,6 +27,7 @@ export default function ProductDownloadsPage({
   className,
   packageManagerOverrides = [],
   enterpriseMode = false,
+  pageTitle, // optional, will default to title constructed from useProductMeta name
   // these props are piped in from `generateStaticProps`
   product,
   latestVersion,
@@ -114,8 +115,9 @@ export default function ProductDownloadsPage({
       <HashiHead title={`Downloads | ${name} by HashiCorp`} />
       <div className={`${styles.root} ${themeClass || ''} ${className || ''}`}>
         <h1 className={styles.pageTitle}>
-          Download {name}
-          {enterpriseMode ? ' Enterprise' : ''}
+          {pageTitle ||
+            `Download ${name}
+          ${enterpriseMode ? ' Enterprise' : ''}`}
         </h1>
         <DownloadCards
           defaultTabIdx={osIndex}

--- a/packages/product-download-page/index.tsx
+++ b/packages/product-download-page/index.tsx
@@ -173,6 +173,7 @@ interface ProductDownloadsPageProps {
   changelog?: string
   className?: string
   packageManagerOverrides?: PackageManagerConfig[]
+  pageTitle?: string
   enterpriseMode: boolean
   product: HashiCorpProduct
   latestVersion: string

--- a/packages/product-download-page/partials/download-cards/index.tsx
+++ b/packages/product-download-page/partials/download-cards/index.tsx
@@ -91,7 +91,9 @@ function Cards({
           </div>
         )}
         <div className={hasPackageManager ? styles.card : styles.soloCard}>
-          <span className={styles.cardTitle}>Binary Download</span>
+          <span className={styles.cardTitle}>
+            {prettyOs(os)} Binary Download
+          </span>
           <div>
             <div className={styles.logoWrapper}>
               {logo}

--- a/packages/product-download-page/partials/release-information/style.module.css
+++ b/packages/product-download-page/partials/release-information/style.module.css
@@ -1,7 +1,6 @@
 .root {
   background-color: var(--gray-6);
-  padding: 42px 0;
-  margin: 42px 0;
+  padding: 48px 0 128px 0;
   color: var(--gray-2);
 
   & p {

--- a/packages/product-download-page/props.js
+++ b/packages/product-download-page/props.js
@@ -1,6 +1,11 @@
 const baseProps = require('../../props.js')
 
 module.exports = {
+  pageTitle: {
+    type: 'string',
+    description:
+      "Override the default constructed page title. Useful if the download page is for a non-product release asset, such as Vagrant's vmware utility.",
+  },
   releases: {
     type: 'object',
     description: 'API response from releases endpoint',

--- a/packages/product-download-page/style.module.css
+++ b/packages/product-download-page/style.module.css
@@ -1,7 +1,5 @@
 .root {
-  composes: .g-grid-container from global;
-  margin-top: 72px;
-  margin-bottom: 72px;
+  padding-top: 72px;
 
   & a {
     text-decoration: underline;
@@ -26,11 +24,12 @@
 
 .gettingStarted {
   max-width: 680px;
-  margin: 40px auto 64px;
+  margin: 0 auto;
+  padding: 40px 0 64px 0;
   text-align: center;
 
   @media (--medium-up) {
-    margin: 88px auto 128px;
+    padding: 88px 0 128px 0;
   }
 }
 


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1200743193658743/f)
🔍 [Preview Link](https://react-components-git-zstweak-product-downloads-page-hashicorp.vercel.app)

---

This PR makes non-breaking tweaks to our `@hashicorp/product-downloads-page` component. The primary goal of this PR is to better meet the need for non-product download pages, namely the Vagrant vmware Utility download page (which currently feels dependent on these tweaks).

### Release Notes 

This minor release adds an optional `pageTitle` prop, and makes minor UX and design tweaks. See #281 for details.

### Changes

- Adds `pageTitle` prop. This allows an override of the default page title, which is very locked in to being product-only as it relies on `useProductMeta`.
- Prefixes `Binary Download` product card labels with the pretty OS name, to help clarify when tab content switches
- Fixes some minor spacing issues

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.