### PR TITLE
feat(Tabs): adds onChange prop to Tabs and fixes arrow bug

### DIFF
--- a/packages/tabs/docs.mdx
+++ b/packages/tabs/docs.mdx
@@ -24,7 +24,7 @@ General purpose tabs component. Used heavily across all websites, but especially
 
 ### Examples
 
-A bunch of tabs:
+#### A bunch of tabs
 
 <LiveComponent>{`<Tabs>
   <Tab heading="First Tab" />
@@ -36,7 +36,7 @@ A bunch of tabs:
   <Tab heading="Seventh tab with an even longer name than the second tab" />
 </Tabs>`}</LiveComponent>
 
-With tooltips!
+#### With tooltips!
 
 <LiveComponent>{`<Tabs>
   <Tab heading="First Tab" />
@@ -47,7 +47,18 @@ With tooltips!
   <Tab heading="Sixth Tab" tooltip="'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut a ex et nulla aliquam placerat. Phasellus euismod posuere porttitor. Praesent quis mollis nibh, eget imperdiet velit. Nunc pulvinar ultrices metus quis dapibus.'"/>
 </Tabs>`}</LiveComponent>
 
-With Tab Groups:
+#### With an onChange handler
+
+<LiveComponent>{`<Tabs onChange={console.log}>
+  <Tab heading="First Tab" />
+  <Tab heading="Second tab with long name" tooltip="What a useful tip!" />
+  <Tab heading="Third long name tab" />
+  <Tab heading="Fourth tab lots of tabs" tooltip="How neat is that?" />
+  <Tab heading="Fifth Tab" />
+  <Tab heading="Sixth Tab" tooltip="'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut a ex et nulla aliquam placerat. Phasellus euismod posuere porttitor. Praesent quis mollis nibh, eget imperdiet velit. Nunc pulvinar ultrices metus quis dapibus.'"/>
+</Tabs>`}</LiveComponent>
+
+#### With Tab Groups
 
 First, second and third tabs should be actively synced based on their matching `group` property. _Note_ the `TabProvider` must wrap the page where this component is used for 'groups' to function properly.
 

--- a/packages/tabs/index.js
+++ b/packages/tabs/index.js
@@ -3,7 +3,13 @@ import classNames from 'classnames'
 import TabTriggers from './partials/TabTriggers/index.js'
 import TabProvider, { useTabGroups } from './provider'
 
-function Tabs({ defaultTabIdx, centered, fullWidthBorder, children }) {
+function Tabs({
+  defaultTabIdx,
+  centered,
+  fullWidthBorder,
+  children,
+  onChange,
+}) {
   if (!children) {
     process.env.NODE_ENV !== 'production' &&
       console.warn(
@@ -27,6 +33,7 @@ function Tabs({ defaultTabIdx, centered, fullWidthBorder, children }) {
 
   function setActiveTab(targetIdx, groupId) {
     setActiveTabIdx(targetIdx)
+    if (onChange) onChange(targetIdx, groupId)
     if (groupCtx) groupCtx.setActiveTabGroup(groupId)
   }
 

--- a/packages/tabs/index.test.js
+++ b/packages/tabs/index.test.js
@@ -18,9 +18,9 @@ const baseProps = [
   },
 ]
 
-function BaseTabs({ tabs, defaultTabIdx = 0 }) {
+function BaseTabs({ tabs, defaultTabIdx = 0, onChange }) {
   return (
-    <Tabs defaultTabIdx={defaultTabIdx}>
+    <Tabs defaultTabIdx={defaultTabIdx} onChange={onChange}>
       {tabs.map(({ heading, tooltip, group, content }) => {
         return (
           <Tab key={heading} heading={heading} tooltip={tooltip} group={group}>
@@ -136,6 +136,18 @@ describe('<Tabs />', () => {
     }
     const { getByText } = render(<SingleTab tab={baseProps[0]} />)
     expect(getByText('Tab 1 Content')).toBeInTheDocument()
+  })
+
+  it('should accept and call an onChange prop when a new tab is clicked', () => {
+    const onChange = jest.fn()
+    const { getByText } = render(
+      <BaseTabs tabs={baseProps} onChange={onChange} />
+    )
+
+    const { heading } = baseProps[0]
+    const targetTab = getByText(heading)
+    fireEvent.click(targetTab)
+    expect(onChange).toHaveBeenCalled()
   })
 })
 

--- a/packages/tabs/partials/TabTriggers/style.css
+++ b/packages/tabs/partials/TabTriggers/style.css
@@ -72,6 +72,7 @@
           max-width: none;
           padding-left: 48px;
           padding-right: 60px;
+          width: auto;
         }
       }
     }

--- a/packages/tabs/props.js
+++ b/packages/tabs/props.js
@@ -16,6 +16,11 @@ module.exports = {
       'If true, the border line underneath the tabs expands to the full width of the container, rather than being slightly padded from the edges',
     control: { type: 'checkbox' },
   },
+  onChange: {
+    type: 'function',
+    description:
+      'Optional callback which is executed when a new tab is selected. Passed `(newTabIndex, groupId)`.',
+  },
   children: {
     type: 'React.ReactNode',
     description: 'Data to be displayed as tabs',


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1200778644540399/f)
🎟️ [Asana Task \#2](https://app.asana.com/0/1100423001970639/1200778644540401/f)
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Adds a new `onChange` prop to `Tabs`. Also fixed up the arrow bug that @alexcarpenter noticed, it was a quick change so threw it in here!

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
      1
