### PR TITLE
Combobox improvements

### DIFF
--- a/.changeset/sour-pears-exercise.md
+++ b/.changeset/sour-pears-exercise.md
@@ -1,0 +1,15 @@
+---
+'@hashicorp/react-combobox': major
+---
+
+Breaking Change: inputProps now handles all input related features to allow more flexibility
+
+### What changed?
+
+Previously `onInputChange` and `onInputBlur` were the only props consumers could use to customize the behavior of the `<input />` internally.
+
+`inputProps` now accepts all InputHTMLElement props for full customization of the input, and importantly allows for adding `name`, `id` or other standard attributes that might be required in certain form implementations.
+
+### How to update your code
+
+Please remove `onInputChange` and `onInputBlur` and use `inputProps` as an object to pass props to the internal `<input />` of the default `Combobox` component.

--- a/.changeset/sour-pears-exercise.md
+++ b/.changeset/sour-pears-exercise.md
@@ -28,6 +28,6 @@ Please remove `onInputChange` and `onInputBlur` and use `inputProps` as an objec
 +         onChange: handleInputChange,
 +         onBlur: validate,
 +         name: 'country',
-        }}
++       }}
         options={COUNTRY_OPTIONS}
 ```

--- a/.changeset/sour-pears-exercise.md
+++ b/.changeset/sour-pears-exercise.md
@@ -6,10 +6,28 @@ Breaking Change: inputProps now handles all input related features to allow more
 
 ### What changed?
 
-Previously `onInputChange` and `onInputBlur` were the only props consumers could use to customize the behavior of the `<input />` internally.
+Previously `onInputChange` and `onInputBlur` were the only props consumers could use to customize the behavior of the interal `<input />` of the `<Combobox />` (the default export of this package).
 
 `inputProps` now accepts all InputHTMLElement props for full customization of the input, and importantly allows for adding `name`, `id` or other standard attributes that might be required in certain form implementations.
+
+### Which components changed?
+
+- `<Combobox />` - the default export of this package - see above or below for me details
+- `<ComboboxInput />` - a named export of this package - now accepts `<input />`-specific props
 
 ### How to update your code
 
 Please remove `onInputChange` and `onInputBlur` and use `inputProps` as an object to pass props to the internal `<input />` of the default `Combobox` component.
+
+```diff
+      <Combobox
+        label="Select your country"
+-       onInputChange={handleInputChange}
+-       onInputBlur={validate}
++       inputProps={{
++         onChange: handleInputChange,
++         onBlur: validate,
++         name: 'country',
+        }}
+        options={COUNTRY_OPTIONS}
+```

--- a/packages/combobox/field/index.tsx
+++ b/packages/combobox/field/index.tsx
@@ -13,9 +13,12 @@ export default function ComboboxField({ name, ...props }: ComboboxFieldProps) {
 
   return (
     <Combobox
-      onInputChange={(e) => {
-        handleTouched() // Set touched if the input value changes at all
-        return helpers.setValue(e.currentTarget.value, true)
+      inputProps={{
+        onChange: (e) => {
+          handleTouched() // Set touched if the input value changes at all
+          return helpers.setValue(e.currentTarget.value, true)
+        },
+        name,
       }}
       onSelect={(value) => {
         handleTouched() // Set touched if the selected value changes at all

--- a/packages/combobox/index.tsx
+++ b/packages/combobox/index.tsx
@@ -19,9 +19,11 @@ export interface ComboboxProps {
   renderOption?: (option: ComboboxOptionValue) => ReactNode
   options: ComboboxOptionValue[]
   openOnFocus?: boolean
-  inputProps: ComboboxInputProps
+  inputProps: Optional<ComboboxInputProps, 'onChange'>
   invalidInputValue?: boolean
 }
+
+type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>
 
 type ComboboxOptionValue = string
 

--- a/packages/combobox/index.tsx
+++ b/packages/combobox/index.tsx
@@ -35,14 +35,14 @@ export default function Combobox({
   renderOption,
   invalidInputValue,
 }: ComboboxProps) {
-  const { onChange: onInputChange, onBlur: onInputBlur } = inputProps
+  const { onChange: onInputChange, onBlur: onInputBlur } = inputProps || {}
 
   const [term, setTerm] = useState('')
   const results = useOptionMatch({ term, options })
   const handleInputValueChange = useCallback(
     (e) => {
       setTerm(e.currentTarget.value)
-      if (onInputChange) return onInputChange(e)
+      if (typeof onInputChange === 'function') return onInputChange(e)
     },
     [onInputChange]
   )

--- a/packages/combobox/index.tsx
+++ b/packages/combobox/index.tsx
@@ -7,6 +7,7 @@ import {
   ComboboxOptionText,
   ComboboxBase,
   ComboboxButton,
+  ComboboxInputProps,
 } from './primitives'
 import { ComboboxOption as ReachComboboxOption } from '@reach/combobox'
 import filterOptions from './utils/filter-options'
@@ -18,8 +19,7 @@ export interface ComboboxProps {
   renderOption?: (option: ComboboxOptionValue) => ReactNode
   options: ComboboxOptionValue[]
   openOnFocus?: boolean
-  onInputChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
-  onInputBlur?: (e: React.FocusEvent<HTMLInputElement>) => void
+  inputProps: ComboboxInputProps
   invalidInputValue?: boolean
 }
 
@@ -31,11 +31,12 @@ export default function Combobox({
   onSelect,
   options,
   openOnFocus = true,
-  onInputChange,
-  onInputBlur,
+  inputProps,
   renderOption,
   invalidInputValue,
 }: ComboboxProps) {
+  const { onChange: onInputChange, onBlur: onInputBlur } = inputProps
+
   const [term, setTerm] = useState('')
   const results = useOptionMatch({ term, options })
   const handleInputValueChange = useCallback(
@@ -54,6 +55,7 @@ export default function Combobox({
     >
       <ComboboxButton label={buttonLabel} />
       <ComboboxInput
+        {...inputProps}
         onChange={handleInputValueChange}
         onBlur={onInputBlur}
         data-has-error={invalidInputValue ?? false}
@@ -96,4 +98,5 @@ export {
   ComboboxOption,
   ComboboxOptionText,
   ComboboxBase,
+  ComboboxButton,
 }

--- a/packages/combobox/index.tsx
+++ b/packages/combobox/index.tsx
@@ -19,11 +19,9 @@ export interface ComboboxProps {
   renderOption?: (option: ComboboxOptionValue) => ReactNode
   options: ComboboxOptionValue[]
   openOnFocus?: boolean
-  inputProps: Optional<ComboboxInputProps, 'onChange'>
+  inputProps: ComboboxInputProps
   invalidInputValue?: boolean
 }
-
-type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>
 
 type ComboboxOptionValue = string
 
@@ -37,7 +35,7 @@ export default function Combobox({
   renderOption,
   invalidInputValue,
 }: ComboboxProps) {
-  const { onChange: onInputChange, onBlur: onInputBlur } = inputProps || {}
+  const { onChange: onInputChange } = inputProps || {}
 
   const [term, setTerm] = useState('')
   const results = useOptionMatch({ term, options })
@@ -59,7 +57,6 @@ export default function Combobox({
       <ComboboxInput
         {...inputProps}
         onChange={handleInputValueChange}
-        onBlur={onInputBlur}
         data-has-error={invalidInputValue ?? false}
       />
       {results?.length > 0 ? (
@@ -87,9 +84,10 @@ export interface OptionMatchParam {
 }
 
 export function useOptionMatch({ term, options }: OptionMatchParam) {
-  const filteredOptions = useMemo(() => filterOptions({ term, options }), [
-    term,
-  ])
+  const filteredOptions = useMemo(
+    () => filterOptions({ term, options }),
+    [term]
+  )
   return filteredOptions.length !== 0 ? filteredOptions : options // Return all options if the filtered list is still empty
 }
 

--- a/packages/combobox/primitives.tsx
+++ b/packages/combobox/primitives.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react'
+import { ReactNode, InputHTMLAttributes } from 'react'
 import {
   Combobox as ReachCombobox,
   ComboboxButton as ReachComboboxButton,
@@ -49,7 +49,9 @@ export function ComboboxPopover({
   )
 }
 
-export interface ComboboxInputProps extends ReachComboboxInputProps {
+type InputProps = InputHTMLAttributes<HTMLInputElement> &
+  ReachComboboxInputProps
+export interface ComboboxInputProps extends InputProps {
   className?: string
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void

--- a/packages/combobox/primitives.tsx
+++ b/packages/combobox/primitives.tsx
@@ -53,7 +53,7 @@ type InputProps = InputHTMLAttributes<HTMLInputElement> &
   ReachComboboxInputProps
 export interface ComboboxInputProps extends InputProps {
   className?: string
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void
 }
 

--- a/packages/combobox/props.js
+++ b/packages/combobox/props.js
@@ -17,7 +17,7 @@ module.exports = {
   inputProps: {
     type: 'object',
     description:
-      "Props passed to the combobox input, props listed below are not an exhaustive list, conforms to React's InputHTMLAttributes",
+      'Props passed to the combobox input, props listed below are not an exhaustive list, conforms to <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts" target="_blank"  rel="noopener noreferrer">React\'s InputHTMLAttributes</a>',
     properties: {
       onChange: {
         type: 'function',

--- a/packages/combobox/props.js
+++ b/packages/combobox/props.js
@@ -16,7 +16,6 @@ module.exports = {
   },
   inputProps: {
     type: 'object',
-
     description:
       "Props passed to the combobox input, props listed below are not an exhaustive list, conforms to React's InputHTMLAttributes",
     properties: {

--- a/packages/combobox/props.js
+++ b/packages/combobox/props.js
@@ -14,13 +14,23 @@ module.exports = {
     description:
       'A handler called when a new option is selected, takes the newly selected option value as its only parameter',
   },
-  onInputChange: {
-    type: 'function',
-    description: 'A change handler for the input',
-  },
-  onInputBlur: {
-    type: 'function',
-    description: 'An `onBlur` handler for the input',
+  inputProps: {
+    type: 'object',
+
+    description:
+      "Props passed to the combobox input, props listed below are not an exhaustive list, conforms to React's InputHTMLAttributes",
+    properties: {
+      onChange: {
+        type: 'function',
+        required: false,
+        description: 'A `onChange` handler for the input',
+      },
+      onBlur: {
+        type: 'function',
+        required: false,
+        description: 'An `onBlur` handler for the input',
+      },
+    },
   },
   openOnFocus: {
     type: 'boolean',

--- a/packages/combobox/style.module.css
+++ b/packages/combobox/style.module.css
@@ -19,6 +19,8 @@
       box-shadow: var(--select-shadow);
       background: var(--white);
       border-radius: 2px;
+      max-height: var(--combobox-list-max-height, 40vh);
+      overflow: scroll;
     }
 
     & [data-reach-combobox-option] {
@@ -88,7 +90,6 @@
 }
 
 .button {
-  --icon-frame: min-content;
   position: absolute;
   background: none;
   border: none;


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description
The proposed changes here allow for flexibility on the default  `<Combobox />` re:  `<input>`-related props and some sensible styling defaults for the list of options . More details about this PR outlined below, per use case.

#### Use case: `name` prop for certain forms
Without the `name` prop, the rendered `<input />` for the Combobox can't be serialized alongside other HTML input elements like you would expect. 

#### Use case: long lists of options could not be styled (to limit height / add scroll) from outside the default `<Combobox />`
We're using this for a long list of countries, and rather than forcing consumers to use `data-reach-*` selectors in their CSS, we provide a `--combobox-list-max-height` but also a sane default of `40vh` with scrolled overflow so we don't ever visually break the viewport with long lists


### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
