### PR TITLE
Adds optional lang prop to `<HashiHead />`

### DIFF
--- a/packages/head/index.tsx
+++ b/packages/head/index.tsx
@@ -3,6 +3,7 @@ import Head from 'next/head'
 export default function HashiHead(props: HashiHeadProps): React.ReactElement {
   return (
     <Head>
+      {whenString(props.lang, <html lang={props.lang} />)}
       {whenString(props.title, <title>{props.title}</title>)}
       <meta httpEquiv="x-ua-compatible" content="ie=edge" />
       <meta property="og:locale" content="en_US" key="og:locale" />
@@ -75,6 +76,7 @@ const whenString = (value, returnValue) =>
 // -----
 
 interface HashiHeadProps {
+  lang?: string
   canonicalUrl?: string
   children?: React.ReactNode
   description?: string

--- a/packages/head/props.js
+++ b/packages/head/props.js
@@ -1,4 +1,8 @@
 module.exports = {
+  lang: {
+    type: 'string',
+    description: 'Set the lang attribute on the HTML element.',
+  },
   title: {
     type: 'string',
     description:


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1200641486648086/1200899791949972)
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This update allows us to set an optional lang attribute on the `<html />` element via the `<HashiHead />` component.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
