### PR TITLE
feat: DocsPage w/ new VersionSelect

### DIFF
--- a/.changeset/nasty-bears-shop.md
+++ b/.changeset/nasty-bears-shop.md
@@ -1,0 +1,7 @@
+---
+'@hashicorp/react-docs-page': minor
+'@hashicorp/version-select': minor
+---
+
+feat(version-select): added `removeVersionFromPath` util
+feat(react-docs-page): use new VersionSelect; add test coverage; expose extra prop

--- a/packages/docs-page/components/version-alert/index.jsx
+++ b/packages/docs-page/components/version-alert/index.jsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router'
 import {
   getVersionFromPath,
   removeVersionFromPath,
-} from '@hashicorp/versioned-docs/client'
+} from '@hashicorp/version-select/util'
 import s from './style.module.css'
 import useIsMobile from '../../use-is-mobile'
 

--- a/packages/docs-page/components/version-alert/version-alert.test.tsx
+++ b/packages/docs-page/components/version-alert/version-alert.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import VersionAlert from './index'
+
+import { mocked } from 'ts-jest/utils'
+import { useRouter, Router } from 'next/router'
+
+const useRouterMock = mocked(useRouter)
+
+jest.mock('next/router')
+
+describe('<VersionAlert />', () => {
+  const routerMock = ({
+    asPath: '/docs',
+  } as unknown) as Router
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    useRouterMock.mockImplementation(() => routerMock)
+  })
+
+  it('should be hidden when no version is present in the URL', () => {
+    const { container } = render(<VersionAlert product={'waypoint'} />)
+    expect(container.hasChildNodes()).toBe(false)
+  })
+
+  it('should be shown when viewing an older version', () => {
+    useRouterMock.mockImplementation(() => {
+      return ({
+        asPath: '/docs/v0.5.1',
+      } as unknown) as Router
+    })
+
+    const { getByText } = render(<VersionAlert product={'waypoint'} />)
+
+    expect(getByText('waypoint', { exact: false })).toBeInTheDocument()
+    expect(getByText('v0.5.1', { exact: false })).toBeInTheDocument()
+  })
+})

--- a/packages/docs-page/docs.mdx
+++ b/packages/docs-page/docs.mdx
@@ -20,11 +20,17 @@ We have a lot of docs sites, all of which render content in exactly the same way
         componentProps.staticProps.properties.githubFileUrl.testValue,
       currentPath: componentProps.staticProps.properties.currentPath.testValue,
       navData: componentProps.staticProps.properties.navData.testValue,
+      versions: [
+        { name: 'latest', label: 'v0.5.2 (latest)' },
+        { name: 'v0.4.0', label: 'v0.4.0' },
+        { name: 'v0.1.0', label: 'v0.1.0' },
+      ],
     },
   }}
 >{`<DocsPage
   product={{ name: 'Nomad', slug: 'nomad' }}
   baseRoute='docs'
+  showVersionSelect={false /*process.env.ENABLE_VERSIONED_DOCS*/}
   // pass in the results of executing the 'generateStaticProps' function from '@hashicorp/react-docs-page/server'
   staticProps={staticPropsResult}
 >

--- a/packages/docs-page/index.tsx
+++ b/packages/docs-page/index.tsx
@@ -8,10 +8,9 @@ import { NavData } from '@hashicorp/react-docs-sidenav/types'
 import HashiHead from '@hashicorp/react-head'
 import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote'
 import { SearchProvider } from '@hashicorp/react-search'
-import {
-  VersionSelect,
-  getVersionFromPath,
-} from '@hashicorp/versioned-docs/client'
+
+import VersionSelect from '@hashicorp/version-select'
+import { getVersionFromPath } from '@hashicorp/version-select/util'
 import { MDXProviderComponentsProp } from '@mdx-js/react'
 
 import SearchBar from './components/search-bar'
@@ -32,6 +31,7 @@ interface DocsPageWrapperProps {
   githubFileUrl: string
   product: { name: string; slug: string }
   showEditPage: boolean
+  showVersionSelect: boolean
   versions: { name: string; label: string }[]
 }
 
@@ -46,6 +46,7 @@ const DocsPageWrapper: FunctionComponent<DocsPageWrapperProps> = ({
   githubFileUrl,
   product: { name, slug },
   showEditPage = true,
+  showVersionSelect = process.env.ENABLE_VERSIONED_DOCS,
   versions,
 }) => {
   const isMobile = useIsMobile()
@@ -69,13 +70,13 @@ const DocsPageWrapper: FunctionComponent<DocsPageWrapperProps> = ({
     </SearchProvider>
   )
 
-  const versionSelect = process.env.ENABLE_VERSIONED_DOCS ? (
+  const versionSelect = showVersionSelect ? (
     <div className={s.versionSelect}>
       <VersionSelect versions={versions} />
     </div>
   ) : null
 
-  const versionAlert = process.env.ENABLE_VERSIONED_DOCS ? (
+  const versionAlert = showVersionSelect ? (
     <VersionAlert product={name} />
   ) : null
 
@@ -88,7 +89,7 @@ const DocsPageWrapper: FunctionComponent<DocsPageWrapperProps> = ({
         siteName={`${name} by HashiCorp`}
         title={`${pageTitle} | ${name} by HashiCorp`}
       />
-      {process.env.ENABLE_VERSIONED_DOCS && versionInPath ? (
+      {showVersionSelect && versionInPath ? (
         <Head>
           <meta name="robots" content="noindex" key="robots" />
         </Head>
@@ -147,6 +148,7 @@ export interface DocsPageProps {
   product: { name: string; slug: string }
   baseRoute: string
   showEditPage: boolean
+  showVersionSelect: boolean
   additionalComponents: MDXProviderComponentsProp
   staticProps: {
     mdxSource: MDXRemoteSerializeResult
@@ -166,6 +168,7 @@ export default function DocsPage({
   product,
   baseRoute,
   showEditPage = true,
+  showVersionSelect = false,
   additionalComponents,
   staticProps: {
     mdxSource,
@@ -198,6 +201,7 @@ export default function DocsPage({
       pageTitle={frontMatter.page_title}
       product={product}
       showEditPage={showEditPage}
+      showVersionSelect={showVersionSelect}
       baseRoute={baseRoute}
       versions={versions}
     >

--- a/packages/docs-page/package.json
+++ b/packages/docs-page/package.json
@@ -13,7 +13,7 @@
     "@hashicorp/react-head": "^3.1.2",
     "@hashicorp/react-placeholder": "^0.1.0",
     "@hashicorp/react-search": "^6.0.0",
-    "@hashicorp/versioned-docs": "^0.0.20",
+    "@hashicorp/version-select": "^0.1.0",
     "classnames": "^2.3.1",
     "fs-exists-sync": "^0.1.0",
     "gray-matter": "^4.0.3",

--- a/packages/docs-page/props.js
+++ b/packages/docs-page/props.js
@@ -31,6 +31,12 @@ module.exports = {
       'If `true`, an `Edit this page` link will appear on the bottom right of each page.',
     default: true,
   },
+  showVersionedDocs: {
+    type: 'boolean',
+    description:
+      'If `true`, a version select option will be displayed. Defaults to `process.env.ENABLE_VERSIONED_DOCS`',
+    default: null,
+  },
   additionalComponents: {
     type: 'object',
     description:

--- a/packages/docs-page/props.js
+++ b/packages/docs-page/props.js
@@ -1,4 +1,5 @@
 const docsSidenavProps = require('../docs-sidenav/props')
+const versionSelectProps = require('../version-select/props')
 const sharedProps = require('../../props')
 
 module.exports = {
@@ -174,6 +175,7 @@ module.exports = {
       },
       currentPath: docsSidenavProps.currentPath,
       navData: docsSidenavProps.navData,
+      versions: versionSelectProps.versions,
     },
     testValue: {},
   },

--- a/packages/version-select/index.test.tsx
+++ b/packages/version-select/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import userEvent from '@testing-library/user-event'
-import { render, RenderResult } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import VersionSelect from './index'
 

--- a/packages/version-select/util.test.ts
+++ b/packages/version-select/util.test.ts
@@ -2,11 +2,29 @@ import { getVersionFromPath, removeVersionFromPath } from './util'
 
 describe('getVersionFromPath', () => {
   it('should return the version if it is present', () => {
-    const path =
-      'https://waypointproject.io/docs/v10.2.4-canary.6/waypoint-hcl/variables/deploy'
+    {
+      const path =
+        'https://waypointproject.io/docs/v10.2.4-canary.6/waypoint-hcl/variables/deploy'
 
-    const version = getVersionFromPath(path)
-    expect(version).toEqual('v10.2.4-canary.6')
+      const version = getVersionFromPath(path)
+      expect(version).toEqual('v10.2.4-canary.6')
+    }
+
+    {
+      const path =
+        'https://waypointproject.io/docs/v9000.9000.x/waypoint-hcl/variables/deploy'
+
+      const version = getVersionFromPath(path)
+      expect(version).toEqual('v9000.9000.x')
+    }
+
+    {
+      const path =
+        'https://waypointproject.io/docs/v0.5.x/waypoint-hcl/variables/deploy'
+
+      const version = getVersionFromPath(path)
+      expect(version).toEqual('v0.5.x')
+    }
   })
 
   it('should return `undefined` if no version is present', () => {
@@ -16,33 +34,50 @@ describe('getVersionFromPath', () => {
   })
 
   it('should return `undefined` if version is not formatted properly', () => {
-    let path =
-      'https://waypointproject.io/docs/10.2.4-canary.6/waypoint-hcl/variables/deploy'
-    let version = getVersionFromPath(path)
-    expect(version).toBeUndefined()
+    {
+      const path =
+        'https://waypointproject.io/docs/10.2.4-canary.6/waypoint-hcl/variables/deploy'
+      const version = getVersionFromPath(path)
+      expect(version).toBeUndefined()
+    }
 
-    path = 'https://waypointproject.io/docs/v10.2/waypoint-hcl/variables/deploy'
-    version = getVersionFromPath(path)
-    expect(version).toBeUndefined()
+    {
+      const path =
+        'https://waypointproject.io/docs/v10.2/waypoint-hcl/variables/deploy'
+      const version = getVersionFromPath(path)
+      expect(version).toBeUndefined()
+    }
   })
 })
 
 describe('removeVersionFromPath', () => {
   it('should return a cleaned path', () => {
-    const path =
-      'https://waypointproject.io/docs/v10.2.4-canary.6/waypoint-hcl/variables/deploy'
+    {
+      const path =
+        'https://waypointproject.io/docs/v10.2.4-canary.6/waypoint-hcl/variables/deploy'
 
-    const cleanedPath = removeVersionFromPath(path)
-    expect(cleanedPath).toEqual(
-      'https://waypointproject.io/docs/waypoint-hcl/variables/deploy'
-    )
-  })
+      const cleanedPath = removeVersionFromPath(path)
+      expect(cleanedPath).toEqual(
+        'https://waypointproject.io/docs/waypoint-hcl/variables/deploy'
+      )
+    }
 
-  it('should return a cleaned path 2', () => {
-    const path = '/v9.0.1/'
+    {
+      const path = '/v9.0.1/'
 
-    const cleanedPath = removeVersionFromPath(path)
-    expect(cleanedPath).toEqual('/')
+      const cleanedPath = removeVersionFromPath(path)
+      expect(cleanedPath).toEqual('/')
+    }
+
+    {
+      const path =
+        'https://waypointproject.io/docs/v0.5.x/waypoint-hcl/variables/deploy'
+
+      const cleanedPath = removeVersionFromPath(path)
+      expect(cleanedPath).toEqual(
+        'https://waypointproject.io/docs/waypoint-hcl/variables/deploy'
+      )
+    }
   })
 
   it('should return the original path if no version is present', () => {

--- a/packages/version-select/util.test.ts
+++ b/packages/version-select/util.test.ts
@@ -1,4 +1,4 @@
-import { getVersionFromPath } from './util'
+import { getVersionFromPath, removeVersionFromPath } from './util'
 
 describe('getVersionFromPath', () => {
   it('should return the version if it is present', () => {
@@ -24,5 +24,33 @@ describe('getVersionFromPath', () => {
     path = 'https://waypointproject.io/docs/v10.2/waypoint-hcl/variables/deploy'
     version = getVersionFromPath(path)
     expect(version).toBeUndefined()
+  })
+})
+
+describe('removeVersionFromPath', () => {
+  it('should return a cleaned path', () => {
+    const path =
+      'https://waypointproject.io/docs/v10.2.4-canary.6/waypoint-hcl/variables/deploy'
+
+    const cleanedPath = removeVersionFromPath(path)
+    expect(cleanedPath).toEqual(
+      'https://waypointproject.io/docs/waypoint-hcl/variables/deploy'
+    )
+  })
+
+  it('should return a cleaned path 2', () => {
+    const path = '/v9.0.1/'
+
+    const cleanedPath = removeVersionFromPath(path)
+    expect(cleanedPath).toEqual('/')
+  })
+
+  it('should return the original path if no version is present', () => {
+    const path = 'https://waypointproject.io/docs/waypoint-hcl/variables/deploy'
+
+    const cleanedPath = removeVersionFromPath(path)
+    expect(cleanedPath).toEqual(
+      'https://waypointproject.io/docs/waypoint-hcl/variables/deploy'
+    )
   })
 })

--- a/packages/version-select/util.ts
+++ b/packages/version-select/util.ts
@@ -10,3 +10,19 @@ export function getVersionFromPath(path: string): string | undefined {
 
   return version
 }
+
+/**
+ * Removes a semver string from a path, and returns the new path.
+ * Returns the original string if no semver is present.
+ */
+export function removeVersionFromPath(path: string): string {
+  const pathSegments = path.split('/')
+
+  const i = pathSegments.findIndex((el) => SEMVER_REGEX.test(el))
+
+  if (i > -1) {
+    return [...pathSegments.slice(0, i), ...pathSegments.slice(i + 1)].join('/')
+  } else {
+    return path
+  }
+}

--- a/packages/version-select/util.ts
+++ b/packages/version-select/util.ts
@@ -1,4 +1,4 @@
-const SEMVER_REGEX = /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/i
+const REGEX = /^v([0-9]+)\.([0-9]+)\.(x|[0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/i
 
 /**
  * Extract the version from a path string, or an array of path segments
@@ -6,19 +6,19 @@ const SEMVER_REGEX = /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A
 export function getVersionFromPath(path: string): string | undefined {
   const pathSegments = path.split('/')
 
-  const version = pathSegments.find((el) => SEMVER_REGEX.test(el))
+  const version = pathSegments.find((el) => REGEX.test(el))
 
   return version
 }
 
 /**
- * Removes a semver string from a path, and returns the new path.
- * Returns the original string if no semver is present.
+ * Removes a version string from a path, and returns the new path.
+ * Returns the original string if no version is present.
  */
 export function removeVersionFromPath(path: string): string {
   const pathSegments = path.split('/')
 
-  const i = pathSegments.findIndex((el) => SEMVER_REGEX.test(el))
+  const i = pathSegments.findIndex((el) => REGEX.test(el))
 
   if (i > -1) {
     return [...pathSegments.slice(0, i), ...pathSegments.slice(i + 1)].join('/')


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1200973126209666/f)
🔍 [Preview Link](https://react-components-c8n9ub4bu-hashicorp.vercel.app/components/docspage)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This adds the newer VersionSelect component to `DocsPage`, and removes dependency on `@hashicorp/versioned-docs`

This adds a `showVersionSelect` prop on `DocsPage` — you can now toggle this via _the live editor_

This exports a `removeVersionFromPath` util from version-select

This backfills some test coverage 🧪 

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
