### PR TITLE
[Combobox] Move Formik to peerDeps

### DIFF
--- a/.changeset/afraid-melons-collect.md
+++ b/.changeset/afraid-melons-collect.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-combobox': patch
+---
+
+Move formik to peerDependencies

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hashicorp/react-combobox",
   "description": "Combobox component with base functionality and styles built for composability",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "HashiCorp",
   "contributors": ["Jimmy Merritello", "Kendall Strautman"],
   "license": "MPL-2.0",

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -11,7 +11,7 @@
     "classnames": "^2.3.1",
     "fuzzysearch": "1.0.3"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "formik": "^2.2.9"
   },
   "publishConfig": {


### PR DESCRIPTION

📝 To-Do
- [x] Run prerelease
- [x] Verify prerelease

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

`formik` must be a peer dependency so we do not install another copy of it. `<ComboboxField />` leverages the shared `FormikContext` via `useField`, so of course this needs to be using the same `formik`.

Hit this error when attempting to use `<ComboboxField />` over on another project. As an optional dependency, `npm` went ahead and installed a different `formik` local to this package (seen in the error).

![image](https://user-images.githubusercontent.com/7191639/133796249-b8624457-da1b-4d3f-b847-29cc0ace3f97.png)


### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
