### PR TITLE
Fix: make `<ProductFeaturesList>` headings h3

### DIFF
--- a/.changeset/honest-clocks-kick.md
+++ b/.changeset/honest-clocks-kick.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-product-features-list': patch
+---
+
+A11y fix to ensure sequential order of headings h2 -> h3 instead of h2 -> h4

--- a/packages/product-features-list/index.js
+++ b/packages/product-features-list/index.js
@@ -13,7 +13,7 @@ export default function ProductFeaturesList({ heading, features, className }) {
               <img src={icon} alt={title} />
             </div>
             <div>
-              <h4 className={s.featureHeading}>{title}</h4>
+              <h3 className={s.featureHeading}>{title}</h3>
               <p className={s.featureContent}>{content}</p>
               {link && (
                 <Button


### PR DESCRIPTION
🔍 [Preview Link](https://react-components-git-acproduct-features-list-heading-hashicorp.vercel.app/components/productfeatureslist)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

A11y fix to ensure sequential order of headings h2 -> h3 instead of h2 -> h4

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
