### PR TITLE
fix(version-select): Navigation bug + minor improvements

### DIFF
--- a/.changeset/silent-ads-work.md
+++ b/.changeset/silent-ads-work.md
@@ -1,0 +1,9 @@
+---
+'@hashicorp/react-version-select': patch
+---
+
+Fixed a bug with `version-select` where navigating to a latest version, while on the latest version caused the site to be pushed to "/latest", which is unintended.
+
+Also added minor improvements to not call Next.js router `push` when selecting a version that is the same as the current version.
+
+Added test coverage.

--- a/packages/version-select/index.test.tsx
+++ b/packages/version-select/index.test.tsx
@@ -13,9 +13,9 @@ const useRouterMock = mocked(useRouter)
 const mockPush = jest.fn()
 
 const VERSIONS = [
-  { name: 'latest', label: 'latest' },
-  { name: 'v0.5.1', label: 'v0.5.1' },
-  { name: 'v0.4.0', label: 'v0.4.0' },
+  { name: 'latest', label: 'v0.5.x (latest)' },
+  { name: 'v0.4.x', label: 'v0.4.x' },
+  { name: 'v0.3.x', label: 'v0.3.x' },
 ]
 
 const defaultProps = {
@@ -66,14 +66,14 @@ describe('<VersionSelect />', () => {
       return ({
         route: '/docs/[[...page]]',
         pathname: '/docs/[[...page]]',
-        asPath: '/docs/v0.5.1/some/nested/article',
+        asPath: '/docs/v0.4.x/some/nested/article',
         push: mockPush,
       } as unknown) as Router
     })
     const { getByRole } = render(<VersionSelect {...defaultProps} />)
 
     const button = getByRole('button')
-    expect(button).toHaveTextContent('v0.5.1')
+    expect(button).toHaveTextContent('v0.4.x')
   })
 
   it('should navigate to a selected version', () => {
@@ -97,7 +97,7 @@ describe('<VersionSelect />', () => {
     const options = getAllByRole('option')
     userEvent.click(options[index])
 
-    expect(mockPush).toHaveBeenNthCalledWith(1, '/commands/v0.5.1')
+    expect(mockPush).toHaveBeenNthCalledWith(1, '/commands/v0.4.x')
   })
 
   it('should navigate to the latest version', () => {
@@ -105,7 +105,7 @@ describe('<VersionSelect />', () => {
       return ({
         route: '/commands/[[...page]]',
         pathname: '/commands/[[...page]]',
-        asPath: '/commands/v0.5.1',
+        asPath: '/commands/v0.4.x',
         push: mockPush,
       } as unknown) as Router
     })
@@ -150,7 +150,7 @@ describe('<VersionSelect />', () => {
 
     expect(mockPush).toHaveBeenNthCalledWith(
       1,
-      '/docs/v0.4.0/some/nested/article'
+      '/docs/v0.3.x/some/nested/article'
     )
   })
 
@@ -160,9 +160,9 @@ describe('<VersionSelect />', () => {
         route: '/docs/[[...page]]',
         pathname: '/docs/[[...page]]',
         query: {
-          page: ['v0.4.0', 'some', 'nested', 'article'],
+          page: ['v0.4.x', 'some', 'nested', 'article'],
         },
-        asPath: '/docs/v0.4.0/some/nested/article',
+        asPath: '/docs/v0.4.x/some/nested/article',
         push: mockPush,
       } as unknown) as Router
     })
@@ -179,5 +179,61 @@ describe('<VersionSelect />', () => {
     userEvent.click(options[index])
 
     expect(mockPush).toHaveBeenNthCalledWith(1, '/docs/some/nested/article')
+  })
+
+  it('should noop if selecting latest, while on latest', () => {
+    useRouterMock.mockImplementation(() => {
+      return ({
+        route: '/docs/[[...page]]',
+        pathname: '/docs/[[...page]]',
+        query: {
+          page: ['some', 'nested', 'article'],
+        },
+        asPath: '/docs/some/nested/article',
+        push: mockPush,
+      } as unknown) as Router
+    })
+
+    const { getByRole, getAllByRole } = render(
+      <VersionSelect {...defaultProps} />
+    )
+    const index = 0
+
+    const combobox = getByRole('combobox')
+    userEvent.click(combobox)
+
+    const options = getAllByRole('option')
+    userEvent.click(options[index])
+
+    expect(mockPush).not.toHaveBeenCalled()
+  })
+
+  it('should noop if selecting a version, while on the same version', () => {
+    const currentVersion = 'v0.4.x'
+
+    useRouterMock.mockImplementation(() => {
+      return ({
+        route: '/docs/[[...page]]',
+        pathname: '/docs/[[...page]]',
+        query: {
+          page: ['some', 'nested', 'article'],
+        },
+        asPath: `/docs/${currentVersion}/some/nested/article`,
+        push: mockPush,
+      } as unknown) as Router
+    })
+
+    const { getByRole, getAllByRole } = render(
+      <VersionSelect {...defaultProps} />
+    )
+    const index = VERSIONS.findIndex((v) => v.name === currentVersion)
+
+    const combobox = getByRole('combobox')
+    userEvent.click(combobox)
+
+    const options = getAllByRole('option')
+    userEvent.click(options[index])
+
+    expect(mockPush).not.toHaveBeenCalled()
   })
 })

--- a/packages/version-select/index.tsx
+++ b/packages/version-select/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useRouter } from 'next/router'
 import SelectInput from '@hashicorp/react-select-input'
 
-import { getVersionFromPath } from './util'
+import { getVersionFromPath, removeVersionFromPath } from './util'
 
 interface Props {
   versions: { label: string; name: string }[]
@@ -18,14 +18,21 @@ const VersionSelect: React.ComponentType<Props> = ({ versions }) => {
   const version = getVersionFromPath(asPath)
 
   const onVersionSelect = (newVersion: string) => {
-    const remove = version ? 1 : 0
-
-    if (newVersion === 'latest' && version) {
-      pathParts.splice(2, remove)
-    } else {
-      pathParts.splice(2, remove, newVersion)
+    // If selecting version same as current version, noop
+    if (newVersion === version) return
+    // If selecting latest...
+    if (newVersion === 'latest') {
+      if (!version) {
+        // If route is latest, noop
+        return
+      } else {
+        // Else, remove version from path; Navigate to latest
+        return push(removeVersionFromPath(asPath))
+      }
     }
 
+    // If selecting version different than current version
+    pathParts.splice(2, 0, newVersion)
     push(pathParts.join('/'))
   }
 


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1201068752304258/f)
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

From the `changeset`

> Fixed a bug with `version-select` where navigating to a latest version, while on the latest version caused the site to be pushed to "/latest", which is unintended.
> 
> Also added minor improvements to not call Next.js router `push` when selecting a version that is the same as the current version.
> 
> Added test coverage.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
