### PR TITLE
make certain docs-page types optional

### DIFF
--- a/.changeset/kind-dingos-provide.md
+++ b/.changeset/kind-dingos-provide.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-page': patch
+---
+
+Adjust prop interface to make showVersionSelect, additionalComponents, and showEditPage optional

--- a/packages/docs-page/index.tsx
+++ b/packages/docs-page/index.tsx
@@ -147,9 +147,9 @@ const DocsPageWrapper: FunctionComponent<DocsPageWrapperProps> = ({
 export interface DocsPageProps {
   product: { name: string; slug: string }
   baseRoute: string
-  showEditPage: boolean
-  showVersionSelect: boolean
-  additionalComponents: MDXProviderComponentsProp
+  showEditPage?: boolean
+  showVersionSelect?: boolean
+  additionalComponents?: MDXProviderComponentsProp
   staticProps: {
     mdxSource: MDXRemoteSerializeResult
     frontMatter: {


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

`showEditPage`, `showVersionSelect`, and `additionalComponents` are not necessary to be specified for every usage, making them optional!

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
