### PR TITLE
fix(Alert): make state and textColor optional

### DIFF
--- a/.changeset/rude-keys-chew.md
+++ b/.changeset/rude-keys-chew.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-alert': patch
+---
+
+Adjust prop interface, make `state` and `textColor` optional.

--- a/packages/alert/index.tsx
+++ b/packages/alert/index.tsx
@@ -69,7 +69,7 @@ interface AlertProps {
   url: string
   tag: string
   text: string
-  state: 'success' | 'warning' | 'error'
-  textColor: 'dark' | 'light'
+  state?: 'success' | 'warning' | 'error'
+  textColor?: 'dark' | 'light'
   className?: string
 }


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Based on the implementation, both `state` and `textColor` are optional props. Adjusting this based on this as well as usage encountered in sites.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
