### PR TITLE
fix(select-input): incorrect Downshift key

### DIFF
--- a/.changeset/three-bags-hear.md
+++ b/.changeset/three-bags-hear.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-select-input': patch
+---
+
+This fixes a bug where an object was being passed to Downshift's key

--- a/packages/select-input/index.js
+++ b/packages/select-input/index.js
@@ -8,7 +8,9 @@ import s from './style.module.css'
  * @prop {String} name - input name attribute
  * @prop {String} label - text to display above the input
  * @prop {String} defaultLabel - text to act as placeholder label
- * @prop {String} value - set the value via prop
+ * @prop {Object} value - set the value via prop
+ * @prop {String} value.name - item name
+ * @prop {String} value.label - item label
  * @prop {Array} options - array of option objects within the select
  * @prop {String} options[].name - option name
  * @prop {String} options[].label - option label
@@ -28,7 +30,7 @@ export default function SelectInput({
   // Changes to the value prop will re-render this component by updating the key value.
   return (
     <Downshift
-      key={value}
+      key={value.name}
       initialSelectedItem={value}
       itemToString={(item) => item && item.name}
       onChange={(item) => {

--- a/packages/select-input/index.test.js
+++ b/packages/select-input/index.test.js
@@ -12,3 +12,5 @@ test.todo('displays an alternate placeholder if `defaultLabel` is specified')
 test.todo('displays a custom label if `label` is specified')
 test.todo('uses the `name` if specified for the input')
 test.todo('sets the `value` is one is provided via prop')
+
+test.todo('displays correct value when the value is programmatically updated')


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1201091209139212/f)
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This fixes a bug where an object was being passed to Downshift's `key`
- ![image](https://user-images.githubusercontent.com/26389321/135533004-05fb41b8-bffc-4e9f-af14-814c74f22e4c.png)


### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
