### PR TITLE
test(version-select): coverage for URL sync

### DIFF
--- a/.changeset/weak-chairs-judge.md
+++ b/.changeset/weak-chairs-judge.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-version-select': patch
+---
+
+Adds additional test coverage. Depends on https://github.com/hashicorp/react-components/pull/369

--- a/.changeset/weak-chairs-judge.md
+++ b/.changeset/weak-chairs-judge.md
@@ -1,5 +1,0 @@
----
-'@hashicorp/react-version-select': patch
----
-
-Adds additional test coverage. Depends on https://github.com/hashicorp/react-components/pull/369

--- a/packages/version-select/index.test.tsx
+++ b/packages/version-select/index.test.tsx
@@ -58,7 +58,7 @@ describe('<VersionSelect />', () => {
     const { getByRole } = render(<VersionSelect {...defaultProps} />)
 
     const button = getByRole('button')
-    expect(button).toHaveTextContent('latest')
+    expect(button).toHaveTextContent('v0.5.x (latest)')
   })
 
   it('should display version from the URL', () => {
@@ -74,6 +74,33 @@ describe('<VersionSelect />', () => {
 
     const button = getByRole('button')
     expect(button).toHaveTextContent('v0.4.x')
+  })
+
+  it('should display the correct version after browser-back', () => {
+    useRouterMock.mockImplementation(() => {
+      return ({
+        route: '/commands/[[...page]]',
+        pathname: '/commands/[[...page]]',
+        asPath: '/commands',
+        push: mockPush,
+      } as unknown) as Router
+    })
+
+    const { getByRole, getAllByRole } = render(
+      <VersionSelect {...defaultProps} />
+    )
+    const index = 1
+
+    const combobox = getByRole('combobox')
+    userEvent.click(combobox)
+
+    const options = getAllByRole('option')
+    userEvent.click(options[index])
+
+    history.back()
+
+    const button = getByRole('button')
+    expect(button).toHaveTextContent('v0.5.x (latest)')
   })
 
   it('should navigate to a selected version', () => {
@@ -203,6 +230,36 @@ describe('<VersionSelect />', () => {
     userEvent.click(options[index])
 
     expect(mockPush).toHaveBeenNthCalledWith(1, '/docs/some/nested/article')
+  })
+
+  it('should navigate from a version to another version while retaining the sub path', () => {
+    useRouterMock.mockImplementation(() => {
+      return ({
+        route: '/docs/[[...page]]',
+        pathname: '/docs/[[...page]]',
+        query: {
+          page: ['v0.4.x', 'some', 'nested', 'article'],
+        },
+        asPath: '/docs/v0.4.x/some/nested/article',
+        push: mockPush,
+      } as unknown) as Router
+    })
+
+    const { getByRole, getAllByRole } = render(
+      <VersionSelect {...defaultProps} />
+    )
+    const index = 2
+
+    const combobox = getByRole('combobox')
+    userEvent.click(combobox)
+
+    const options = getAllByRole('option')
+    userEvent.click(options[index])
+
+    expect(mockPush).toHaveBeenNthCalledWith(
+      1,
+      '/docs/v0.3.x/some/nested/article'
+    )
   })
 
   it('should noop if selecting latest, while on latest', () => {

--- a/packages/version-select/index.test.tsx
+++ b/packages/version-select/index.test.tsx
@@ -54,7 +54,7 @@ describe('<VersionSelect />', () => {
     expect(options).toHaveLength(VERSIONS.length)
   })
 
-  it('should display the correct version after router events', () => {
+  it('should display the correct version from the URL', () => {
     // initial, latest
     useRouterMock.mockImplementation(() => {
       return ({

--- a/packages/version-select/index.test.tsx
+++ b/packages/version-select/index.test.tsx
@@ -54,53 +54,39 @@ describe('<VersionSelect />', () => {
     expect(options).toHaveLength(VERSIONS.length)
   })
 
-  it('should display the latest version', () => {
-    const { getByRole } = render(<VersionSelect {...defaultProps} />)
-
-    const button = getByRole('button')
-    expect(button).toHaveTextContent('v0.5.x (latest)')
-  })
-
-  it('should display version from the URL', () => {
+  it('should display the correct version after router events', () => {
+    // initial, latest
     useRouterMock.mockImplementation(() => {
       return ({
-        route: '/docs/[[...page]]',
-        pathname: '/docs/[[...page]]',
-        asPath: '/docs/v0.4.x/some/nested/article',
-        push: mockPush,
-      } as unknown) as Router
-    })
-    const { getByRole } = render(<VersionSelect {...defaultProps} />)
-
-    const button = getByRole('button')
-    expect(button).toHaveTextContent('v0.4.x')
-  })
-
-  it('should display the correct version after browser-back', () => {
-    useRouterMock.mockImplementation(() => {
-      return ({
-        route: '/commands/[[...page]]',
-        pathname: '/commands/[[...page]]',
         asPath: '/commands',
         push: mockPush,
       } as unknown) as Router
     })
 
-    const { getByRole, getAllByRole } = render(
-      <VersionSelect {...defaultProps} />
-    )
-    const index = 1
+    const { getByRole, rerender } = render(<VersionSelect {...defaultProps} />)
+    expect(getByRole('button')).toHaveTextContent('v0.5.x (latest)')
 
-    const combobox = getByRole('combobox')
-    userEvent.click(combobox)
+    // simulate navigation to v0.4.x
+    useRouterMock.mockImplementation(() => {
+      return ({
+        asPath: '/commands/v0.4.x',
+        push: mockPush,
+      } as unknown) as Router
+    })
 
-    const options = getAllByRole('option')
-    userEvent.click(options[index])
+    rerender(<VersionSelect {...defaultProps} />)
+    expect(getByRole('button')).toHaveTextContent('v0.4.x')
 
-    history.back()
+    // simulate browser-back to latest
+    useRouterMock.mockImplementation(() => {
+      return ({
+        asPath: '/commands/',
+        push: mockPush,
+      } as unknown) as Router
+    })
 
-    const button = getByRole('button')
-    expect(button).toHaveTextContent('v0.5.x (latest)')
+    rerender(<VersionSelect {...defaultProps} />)
+    expect(getByRole('button')).toHaveTextContent('v0.5.x (latest)')
   })
 
   it('should navigate to a selected version', () => {


### PR DESCRIPTION
🎟️ [-]()
🔍 [-](-)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Fixed by https://github.com/hashicorp/react-components/pull/369 (select-input 4.0.4)

This adds more test coverage

Smoke test: https://waypoint-none31bq2-hashicorp.vercel.app/commands which is using `select-input 4.0.4` under the hood

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
