### PR TITLE
DocsPage: add return type to `generateStaticProps`

### DIFF
--- a/packages/docs-page/index.tsx
+++ b/packages/docs-page/index.tsx
@@ -6,7 +6,7 @@ import Content from '@hashicorp/react-content'
 import DocsSidenav from '@hashicorp/react-docs-sidenav'
 import { NavData } from '@hashicorp/react-docs-sidenav/types'
 import HashiHead from '@hashicorp/react-head'
-import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote'
+import { MDXRemote } from 'next-mdx-remote'
 import { SearchProvider } from '@hashicorp/react-search'
 
 import VersionSelect from '@hashicorp/react-version-select'
@@ -20,6 +20,7 @@ import temporary_injectJumpToSection from './temporary_jump-to-section'
 import LoadingSkeleton from './components/loading-skeleton'
 import useIsMobile from './use-is-mobile'
 import s from './style.module.css'
+import { GenerateStaticPropsResult } from './server/generate-static-props'
 
 interface DocsPageWrapperProps {
   canonicalUrl: string
@@ -150,18 +151,7 @@ export interface DocsPageProps {
   showEditPage?: boolean
   showVersionSelect?: boolean
   additionalComponents?: MDXProviderComponentsProp
-  staticProps: {
-    mdxSource: MDXRemoteSerializeResult
-    frontMatter: {
-      canonical_url: string
-      description: string
-      page_title: string
-    }
-    currentPath: string
-    navData: NavData
-    githubFileUrl: string
-    versions: { name: string; label: string }[]
-  }
+  staticProps: GenerateStaticPropsResult
 }
 
 export default function DocsPage({

--- a/packages/docs-page/server/generate-static-props.ts
+++ b/packages/docs-page/server/generate-static-props.ts
@@ -16,6 +16,9 @@ import { stripVersionFromPathParams, normalizeVersion } from '../util'
 import { resolveNavData } from './resolve-nav-data'
 import { getNodeFromPath } from './get-node-from-path'
 
+import { MDXRemoteSerializeResult } from 'next-mdx-remote'
+import { NavData } from '@hashicorp/react-docs-sidenav/types'
+
 const moizeOpts: Options = { isPromise: true, maxSize: Infinity }
 const cachedFetchNavData = moize(fetchNavData, moizeOpts)
 const cachedFetchVersionMetadataList = moize(
@@ -54,6 +57,16 @@ interface VersionSelectItem {
   name: string
   label: string
 }
+
+export interface GenerateStaticPropsResult {
+  mdxSource: MDXRemoteSerializeResult
+  frontMatter: { [key: string]: any }
+  currentPath: string
+  navData: NavData
+  githubFileUrl: string
+  versions: { name: string; label: string }[]
+}
+
 /**
  * formats a list of version-metadata to
  * be passed to `<VersionSelect versions=[...] />`
@@ -85,7 +98,7 @@ export async function generateStaticProps(
     navDataFile,
     localContentDir,
     params,
-    product: { name: productName, slug: productSlug },
+    product: { slug: productSlug },
     mainBranch = 'main',
     remarkPlugins = [],
     scope,
@@ -93,7 +106,7 @@ export async function generateStaticProps(
     basePath,
   }: GenerateStaticPropsContext,
   { VERCEL_ENV, ENABLE_VERSIONED_DOCS } = defaultOptions
-) {
+): Promise<GenerateStaticPropsResult> {
   const mdxRenderer = (mdx) =>
     renderPageMdx(mdx, {
       remarkPlugins,


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

## Description

I was tinkering with some things in here and noticed that I was getting a "no return type" error on the `generateStaticProps` function - fixed this and took an opportunity to have it drop a useful type export as well.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
