### PR TITLE
fix(search): revert unist-util-visit dep

### DIFF
--- a/.changeset/funny-tigers-shop.md
+++ b/.changeset/funny-tigers-shop.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-search': patch
+---
+
+Revert version of `unist-util-visit` so that the script can be run in a cjs node environment

--- a/package-lock.json
+++ b/package-lock.json
@@ -27499,14 +27499,14 @@
     },
     "packages/docs-page": {
       "name": "@hashicorp/react-docs-page",
-      "version": "14.2.5",
+      "version": "14.3.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-docs-mdx": "^0.1.3",
         "@hashicorp/platform-markdown-utils": "^0.1.3",
         "@hashicorp/react-alert": "^6.0.0",
         "@hashicorp/react-content": "^8.0.2",
-        "@hashicorp/react-docs-sidenav": "^8.2.5",
+        "@hashicorp/react-docs-sidenav": "^8.3.0",
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-placeholder": "^0.1.0",
         "@hashicorp/react-search": "^6.0.0",
@@ -27554,7 +27554,7 @@
     },
     "packages/docs-sidenav": {
       "name": "@hashicorp/react-docs-sidenav",
-      "version": "8.2.5",
+      "version": "8.3.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
@@ -27928,7 +27928,7 @@
         "react-instantsearch-dom": "^6.12.1",
         "remark": "^13.0.0",
         "search-insights": "^1.7.1",
-        "unist-util-visit": "^3.0.0"
+        "unist-util-visit": "^2.0.3"
       },
       "devDependencies": {
         "random-words": "^1.1.1"
@@ -30324,7 +30324,7 @@
         "@hashicorp/platform-markdown-utils": "^0.1.3",
         "@hashicorp/react-alert": "^6.0.0",
         "@hashicorp/react-content": "^8.0.2",
-        "@hashicorp/react-docs-sidenav": "^8.2.5",
+        "@hashicorp/react-docs-sidenav": "^8.3.0",
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-placeholder": "^0.1.0",
         "@hashicorp/react-search": "^6.0.0",
@@ -30605,7 +30605,7 @@
         "react-instantsearch-dom": "^6.12.1",
         "remark": "^13.0.0",
         "search-insights": "^1.7.1",
-        "unist-util-visit": "^3.0.0"
+        "unist-util-visit": "^2.0.3"
       },
       "dependencies": {
         "@reach/visually-hidden": {

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -16,7 +16,7 @@
     "react-instantsearch-dom": "^6.12.1",
     "remark": "^13.0.0",
     "search-insights": "^1.7.1",
-    "unist-util-visit": "^3.0.0"
+    "unist-util-visit": "^2.0.3"
   },
   "license": "MPL-2.0",
   "peerDependencies": {


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

`unist-util-visit` was recently upgraded to serve ESM. This is great, except we currently run this script in a CJS node environment. I'm gonna revert for now until we have tooling in place to run node scripts which leverage ESM.

Example failure: https://app.circleci.com/pipelines/github/hashicorp/vagrant/2025/workflows/0467ada7-c83c-4090-8c25-16ede596f0d3/jobs/2033

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
