### PR TITLE
DocsPage: fix validation error when using heading nodes

### DIFF
--- a/.changeset/unlucky-poets-wink.md
+++ b/.changeset/unlucky-poets-wink.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-sidenav': patch
+---
+
+fix a small bug with validation for heading nodes

--- a/packages/docs-sidenav/utils/validate-route-structure/index.js
+++ b/packages/docs-sidenav/utils/validate-route-structure/index.js
@@ -58,9 +58,9 @@ function validateBranchRoutes(navNodes, depth = 0) {
     }
     // Ensure the only other node type is
     // a divider node, if not, throw an error
-    if (!navNode.divider) {
+    if (!(navNode.divider || navNode.heading)) {
       throw new Error(
-        `Unrecognized nav-data node. Please ensure all nav-data nodes are either NavLeaf, NavBranch, NavDirectLink, or NavDivider types. Invalid node: ${JSON.stringify(
+        `Unrecognized nav-data node. Please ensure all nav-data nodes are either NavLeaf, NavBranch, NavDirectLink, NavHeading, or NavDivider types. Invalid node: ${JSON.stringify(
           navNode
         )}.`
       )

--- a/packages/docs-sidenav/utils/validate-route-structure/index.test.js
+++ b/packages/docs-sidenav/utils/validate-route-structure/index.test.js
@@ -8,10 +8,11 @@ describe('<DocsSidenav /> - validate-file-paths', () => {
         path: '',
       },
     ]
-    const emptyPathError = `Empty path value on NavLeaf. Path values must be non-empty strings. Node: ${JSON.stringify(
-      navData[0]
-    )}.`
-    expect(() => validateRouteStructure(navData)).toThrow(emptyPathError)
+    expect(() =>
+      validateRouteStructure(navData)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Empty path value on NavLeaf. Path values must be non-empty strings. Node: {\\"title\\":\\"Whoops I Left The Path Empty\\",\\"path\\":\\"\\"}."`
+    )
   })
 
   it("throws an error if a NavLeaf's path is nested at the wrong depth", () => {
@@ -34,13 +35,17 @@ describe('<DocsSidenav /> - validate-file-paths', () => {
         ],
       },
     ]
-    const depthError = `Invalid path depth. At depth 1, found path "directory/some-nested-dir/some-file". Please move this path to the correct depth of 2.`
-    expect(() => validateRouteStructure(navData)).toThrow(depthError)
+    expect(() =>
+      validateRouteStructure(navData)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Invalid path depth. At depth 1, found path \\"directory/some-nested-dir/some-file\\". Please move this path to the correct depth of 2."`
+    )
   })
 
   it('throws an error if an empty array is passed', () => {
-    const emptyRoutesError = `Found empty array of navNodes at depth 0. There must be more than one route.`
-    expect(() => validateRouteStructure([])).toThrow(emptyRoutesError)
+    expect(() => validateRouteStructure([])).toThrowErrorMatchingInlineSnapshot(
+      `"Found empty array of navNodes at depth 0. There must be more than one route."`
+    )
   })
 
   it('throws an error if a NavBranch has has an empty array of routes', () => {
@@ -50,8 +55,11 @@ describe('<DocsSidenav /> - validate-file-paths', () => {
         routes: [],
       },
     ]
-    const emptyRoutesError = `Found empty array of navNodes at depth 1. There must be more than one route.`
-    expect(() => validateRouteStructure(navData)).toThrow(emptyRoutesError)
+    expect(() =>
+      validateRouteStructure(navData)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Found empty array of navNodes at depth 1. There must be more than one route."`
+    )
   })
 
   it('throws an error if sibling routes have different parent routes', () => {
@@ -74,8 +82,11 @@ describe('<DocsSidenav /> - validate-file-paths', () => {
         ],
       },
     ]
-    const siblingError = `Found mismatched paths at depth 1: ["directory","another-directory"].`
-    expect(() => validateRouteStructure(navData)).toThrow(siblingError)
+    expect(() =>
+      validateRouteStructure(navData)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Found mismatched paths at depth 1: [\\"directory\\",\\"another-directory\\"]."`
+    )
   })
 
   it('throws an error if there are duplicate routes', () => {
@@ -98,8 +109,11 @@ describe('<DocsSidenav /> - validate-file-paths', () => {
         ],
       },
     ]
-    const duplicateError = `Duplicate routes found for "directory". Please resolve duplicates.`
-    expect(() => validateRouteStructure(navData)).toThrow(duplicateError)
+    expect(() =>
+      validateRouteStructure(navData)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Duplicate routes found for \\"directory\\". Please resolve duplicates."`
+    )
   })
 
   it('throws an error if a NavLeaf has a missing title', () => {
@@ -128,8 +142,11 @@ describe('<DocsSidenav /> - validate-file-paths', () => {
         ],
       },
     ]
-    const noTitleError = `Missing nav-data title on NavBranch. Please add a title to the node with the inferred path "some-directory".`
-    expect(() => validateRouteStructure(navData)).toThrow(noTitleError)
+    expect(() =>
+      validateRouteStructure(navData)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Missing nav-data title on NavBranch. Please add a title to the node with the inferred path \\"some-directory\\"."`
+    )
   })
 
   it('throws an error if a NavDirectLink has a missing title', () => {
@@ -138,8 +155,11 @@ describe('<DocsSidenav /> - validate-file-paths', () => {
         href: '/some-direct-link',
       },
     ]
-    const noTitleError = `Missing nav-data title on NavDirectLink. Please add a title to the node with href "/some-direct-link".`
-    expect(() => validateRouteStructure(navData)).toThrow(noTitleError)
+    expect(() =>
+      validateRouteStructure(navData)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Missing nav-data title on NavDirectLink. Please add a title to the node with href \\"/some-direct-link\\"."`
+    )
   })
 
   it('throws an error if a NavDirectLink has an empty href', () => {
@@ -149,10 +169,11 @@ describe('<DocsSidenav /> - validate-file-paths', () => {
         href: '',
       },
     ]
-    const emptyHrefError = `Empty href value on NavDirectLink. href values must be non-empty strings. Node: ${JSON.stringify(
-      navData[0]
-    )}.`
-    expect(() => validateRouteStructure(navData)).toThrow(emptyHrefError)
+    expect(() =>
+      validateRouteStructure(navData)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Empty href value on NavDirectLink. href values must be non-empty strings. Node: {\\"title\\":\\"Empty Href Link\\",\\"href\\":\\"\\"}."`
+    )
   })
 
   it('throws an error for unrecognized nodes', () => {
@@ -161,10 +182,11 @@ describe('<DocsSidenav /> - validate-file-paths', () => {
         foo: 'bar',
       },
     ]
-    const emptyHrefError = `Unrecognized nav-data node. Please ensure all nav-data nodes are either NavLeaf, NavBranch, NavDirectLink, or NavDivider types. Invalid node: ${JSON.stringify(
-      navData[0]
-    )}.`
-    expect(() => validateRouteStructure(navData)).toThrow(emptyHrefError)
+    expect(() =>
+      validateRouteStructure(navData)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Unrecognized nav-data node. Please ensure all nav-data nodes are either NavLeaf, NavBranch, NavDirectLink, NavHeading, or NavDivider types. Invalid node: {\\"foo\\":\\"bar\\"}."`
+    )
   })
 
   it('does not throw an error for a valid nav-data tree with a direct-links-only branch', () => {


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

## Description

Small bugfix to follow up #336 !

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
