### PR TITLE
fix(docs-page): process.env.ENABLE_VERSIONED_DOCS is `string`

### DIFF
--- a/.changeset/tender-lies-type.md
+++ b/.changeset/tender-lies-type.md
@@ -1,0 +1,7 @@
+---
+'@hashicorp/react-docs-page': patch
+---
+
+This updates logic to check `process.env.ENABLE_VERSIONED_DOCS === 'true'` since environment variables are _always strings_.
+
+This should prevent some unintended behavior if ENABLE_VERSIONED_DOCS is parsed as a string `"false"`, but unintentionally evaluating to `truthy`

--- a/packages/docs-page/docs.mdx
+++ b/packages/docs-page/docs.mdx
@@ -30,7 +30,7 @@ We have a lot of docs sites, all of which render content in exactly the same way
 >{`<DocsPage
   product={{ name: 'Nomad', slug: 'nomad' }}
   baseRoute='docs'
-  showVersionSelect={false /*process.env.ENABLE_VERSIONED_DOCS*/}
+  showVersionSelect={false /* process.env.ENABLE_VERSIONED_DOCS === "true" */}
   // pass in the results of executing the 'generateStaticProps' function from '@hashicorp/react-docs-page/server'
   staticProps={staticPropsResult}
 >

--- a/packages/docs-page/index.tsx
+++ b/packages/docs-page/index.tsx
@@ -47,7 +47,7 @@ const DocsPageWrapper: FunctionComponent<DocsPageWrapperProps> = ({
   githubFileUrl,
   product: { name, slug },
   showEditPage = true,
-  showVersionSelect = process.env.ENABLE_VERSIONED_DOCS,
+  showVersionSelect = process.env.ENABLE_VERSIONED_DOCS === 'true',
   versions,
 }) => {
   const isMobile = useIsMobile()
@@ -117,7 +117,8 @@ const DocsPageWrapper: FunctionComponent<DocsPageWrapperProps> = ({
           id="inner"
           role="main"
           className={classNames(s.inner, s.tempJumpToSectionParent, {
-            [s.versionedDocsOffset]: process.env.ENABLE_VERSIONED_DOCS,
+            [s.versionedDocsOffset]:
+              process.env.ENABLE_VERSIONED_DOCS === 'true',
           })}
         >
           <Content

--- a/packages/docs-page/props.js
+++ b/packages/docs-page/props.js
@@ -35,7 +35,7 @@ module.exports = {
   showVersionedDocs: {
     type: 'boolean',
     description:
-      'If `true`, a version select option will be displayed. Defaults to `process.env.ENABLE_VERSIONED_DOCS`',
+      'If `true`, a version select option will be displayed. Defaults to `process.env.ENABLE_VERSIONED_DOCS === "true"`',
     default: null,
   },
   additionalComponents: {

--- a/packages/docs-page/server/generate-static-paths.ts
+++ b/packages/docs-page/server/generate-static-paths.ts
@@ -33,7 +33,7 @@ export interface GenerateStaticPathsContext {
 
 const defaultOptions = {
   VERCEL_ENV: process.env.VERCEL_ENV,
-  ENABLE_VERSIONED_DOCS: process.env.ENABLE_VERSIONED_DOCS,
+  ENABLE_VERSIONED_DOCS: process.env.ENABLE_VERSIONED_DOCS === 'true',
 }
 
 export async function generateStaticPaths(

--- a/packages/docs-page/server/generate-static-props.ts
+++ b/packages/docs-page/server/generate-static-props.ts
@@ -77,7 +77,7 @@ export function mapVersionList(
 
 const defaultOptions = {
   VERCEL_ENV: process.env.VERCEL_ENV,
-  ENABLE_VERSIONED_DOCS: process.env.ENABLE_VERSIONED_DOCS,
+  ENABLE_VERSIONED_DOCS: process.env.ENABLE_VERSIONED_DOCS === 'true',
 }
 
 export async function generateStaticProps(


### PR DESCRIPTION
🎟️ [-]()
🔍 [-](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This updates logic to treat `process.env.ENABLE_VERSIONED_DOCS` as `string`
- environment variables are always strings.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
