### PR TITLE
Add permalink spacing handling to subnav when its sticky

### DIFF
--- a/.changeset/sixty-humans-fix.md
+++ b/.changeset/sixty-humans-fix.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-subnav': patch
+---
+
+Add permalink spacing when subnav is in sticky mode so headlines do not disappear underneath it

--- a/packages/subnav/style.module.css
+++ b/packages/subnav/style.module.css
@@ -11,6 +11,23 @@
 
   &.isSticky {
     border-bottom-color: var(--border-color); /* from theme.module.css */
+
+    /*
+    * About this selector:
+    * `& ~ *` finds all elements after the navigation.
+    * `:target` finds the active permalink on the page.
+    *
+    * About this style:
+    * `scroll-margin-top` adjusts the vertical scroll of a permalink.
+    * `64px` adjusts the scroll to account for the navigation.
+    * `0.5em` further adjusts the scroll to give the permalink breathing room.
+    *
+    * See: https://developer.mozilla.org/en-US/docs/Web/CSS/:target
+    * See: https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-top
+    */
+    & ~ * :target {
+      scroll-margin-top: calc(64px + 0.5em);
+    }
   }
 }
 


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

## Description

When the subnav is in sticky mode, and you have a permalink on the page, the headline ends up scrolling underneath the menu. This little css thingy prevents that from happening. It used to be implemented on each of our documentation sites hanging off the global `.g-subnav` but that no longer works because of css modules, and honestly it should have been part of this component anyway since I can't really imagine a scenario where you would want your permalinks to be hidden by this component, so I think this should do the trick. Tested on vault docs website and it worked wonderfully.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
