### PR TITLE
fix: hide subnav and consent-manager in print

### DIFF
--- a/.changeset/sharp-crabs-appear.md
+++ b/.changeset/sharp-crabs-appear.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-subnav': patch
+---
+
+Hide in print media.

--- a/.changeset/weak-carrots-fry.md
+++ b/.changeset/weak-carrots-fry.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-consent-manager': patch
+---
+
+Hide in print media.

--- a/packages/consent-manager/style.module.css
+++ b/packages/consent-manager/style.module.css
@@ -2,4 +2,8 @@
   @media only percy {
     display: none;
   }
+
+  @media print {
+    display: none;
+  }
 }

--- a/packages/subnav/style.module.css
+++ b/packages/subnav/style.module.css
@@ -29,6 +29,10 @@
       scroll-margin-top: calc(64px + 0.5em);
     }
   }
+
+  @media print {
+    display: none;
+  }
 }
 
 .subnavInner {


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1201221128054915/f)
🔍 [Preview Link](https://react-components-git-zshide-consent-manager-print-hashicorp.vercel.app)

---

This PR updates `@hashicorp/react-consent-manager` and `@hashicorp/react-subnav` to ensure both components are hidden in print media.

- fix(consent-manager): hide in print
- fix(subnav): hide in print
- chore(consent-manager): add changeset
- chore(subnav): add changeset

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
