### PR TITLE
Update package.json to include the repository

### DIFF
--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -3,6 +3,11 @@
   "description": "A clickable text box that allows a user to take an action.",
   "version": "6.0.3",
   "author": "HashiCorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/button"
+  },
   "contributors": ["Jeff Escalante"],
   "dependencies": {
     "@hashicorp/platform-product-meta": "^0.1.0",

--- a/packages/call-to-action/package.json
+++ b/packages/call-to-action/package.json
@@ -3,6 +3,11 @@
   "description": "Display a title, content, and links in a call-to-action format",
   "version": "4.1.0",
   "author": "HashiCorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/call-to-action"
+  },
   "contributors": ["Zach Shilton"],
   "dependencies": {
     "@hashicorp/react-button": "^6.0.2"

--- a/packages/code-block/package.json
+++ b/packages/code-block/package.json
@@ -3,6 +3,11 @@
   "description": "A simple code block with clipboard functionality",
   "version": "4.1.5",
   "author": "HashiCorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/code-block"
+  },
   "dependencies": {
     "@hashicorp/react-inline-svg": "^6.0.3",
     "@reach/listbox": "0.15.0",

--- a/packages/consent-manager/package.json
+++ b/packages/consent-manager/package.json
@@ -3,6 +3,11 @@
   "description": "A GDPR-compliant Consent Manager",
   "version": "7.0.2",
   "author": "HashiCorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/consent-manager"
+  },
   "contributors": ["Jennifer Yip", "Jeff Escalante"],
   "dependencies": {
     "@hashicorp/react-button": "^6.0.0",

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -3,6 +3,11 @@
   "description": "Styled prose content",
   "version": "8.0.3",
   "author": "HashiCorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/content"
+  },
   "contributors": ["Mike Wickett", "Zach Shilton"],
   "license": "MPL-2.0",
   "peerDependencies": {

--- a/packages/docs-page/package.json
+++ b/packages/docs-page/package.json
@@ -3,6 +3,11 @@
   "description": "Create a Hashicorp branded docs page in NextJS projects.",
   "version": "14.4.5",
   "author": "HashiCorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/docs-page"
+  },
   "contributors": ["Jeff Escalante", "Kevin Wang"],
   "dependencies": {
     "@hashicorp/platform-docs-mdx": "^0.1.3",

--- a/packages/docs-sidenav/package.json
+++ b/packages/docs-sidenav/package.json
@@ -3,6 +3,11 @@
   "description": "Sidebar used for navigation HashiCorp docs",
   "version": "8.4.0",
   "author": "HashiCorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/docs-sidenav"
+  },
   "contributors": ["Jeff Escalante"],
   "dependencies": {
     "@hashicorp/platform-product-meta": "^0.1.0",

--- a/packages/featured-slider/package.json
+++ b/packages/featured-slider/package.json
@@ -3,6 +3,11 @@
   "description": "featured slider for case studies",
   "version": "5.0.1",
   "author": "HashiCorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/featured-slider"
+  },
   "contributors": ["Zach Shilton"],
   "main": "index.js",
   "license": "MPL-2.0",

--- a/packages/hashi-stack-menu/package.json
+++ b/packages/hashi-stack-menu/package.json
@@ -3,6 +3,11 @@
   "description": "A menu for displaying the entire HashiCorp stack",
   "version": "2.0.7",
   "author": "HashiCorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/hashi-stack-menu"
+  },
   "contributors": ["Jimmy Merritello"],
   "dependencies": {
     "@hashicorp/react-inline-svg": "^6.0.1",

--- a/packages/head/package.json
+++ b/packages/head/package.json
@@ -3,6 +3,11 @@
   "description": "Create a Hashicorp branded <head> in NextJS projects.",
   "version": "3.1.2",
   "author": "HashiCorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/head"
+  },
   "contributors": ["Jonathan Neal"],
   "license": "MPL-2.0",
   "peerDependencies": {

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -3,6 +3,11 @@
   "description": "super optimized image element, pulls from dato and formats for 7 screen sizes in two formats. Skips optimization for SVGs.",
   "version": "4.0.3",
   "author": "Hashicorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/image"
+  },
   "contributors": ["Jeff Escalante"],
   "dependencies": {
     "object-assign": "^4.1.1",

--- a/packages/link-wrap/package.json
+++ b/packages/link-wrap/package.json
@@ -3,6 +3,11 @@
   "description": "Wraps a standard 'a' element to enable NextJS Link usage",
   "version": "3.0.3",
   "author": "Hashicorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/link-wrap"
+  },
   "contributors": ["Jeff Escalante"],
   "license": "MPL-2.0",
   "peerDependencies": {

--- a/packages/markdown-page/package.json
+++ b/packages/markdown-page/package.json
@@ -3,6 +3,11 @@
   "description": "Create a single page based on a mdx file in NextJS projects.",
   "version": "1.4.4",
   "author": "HashiCorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/markdown-page"
+  },
   "contributors": ["Jeff Escalante"],
   "dependencies": {
     "@hashicorp/platform-markdown-utils": "^0.1.4",

--- a/packages/product-features-list/package.json
+++ b/packages/product-features-list/package.json
@@ -3,6 +3,11 @@
   "description": "list for product features",
   "version": "5.0.1",
   "author": "HashiCorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/product-features-list"
+  },
   "contributors": ["Nicole Forrester"],
   "dependencies": {
     "@hashicorp/react-button": "^6.0.3",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -3,6 +3,11 @@
   "description": "Algolia-powered search component",
   "version": "6.1.1",
   "author": "HashiCorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/search"
+  },
   "contributors": ["Kevin Pruett", "Jimmy Merritello"],
   "dependencies": {
     "@hashicorp/react-inline-svg": "^6.0.1",

--- a/packages/section-header/package.json
+++ b/packages/section-header/package.json
@@ -3,6 +3,11 @@
   "description": "very simple headline & subheading for a section of a page",
   "version": "5.0.4",
   "author": "HashiCorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/section-header"
+  },
   "contributors": ["Jeff Escalante"],
   "dependencies": {
     "@hashicorp/js-utils": "^1.0.10"

--- a/packages/subnav/package.json
+++ b/packages/subnav/package.json
@@ -3,6 +3,11 @@
   "description": "Displays a navigation bar, with links and a call-to-action.",
   "version": "9.1.3",
   "author": "HashiCorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/subnav"
+  },
   "contributors": ["Zach Shilton"],
   "dependencies": {
     "@hashicorp/mktg-logos": "^1.0.2",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -3,6 +3,11 @@
   "description": "Display content in a tabbed interface",
   "version": "7.1.0",
   "author": "HashiCorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/tabs"
+  },
   "contributors": ["Zach Shilton"],
   "dependencies": {
     "@hashicorp/react-inline-svg": "^6.0.1",

--- a/packages/text-split-with-code/package.json
+++ b/packages/text-split-with-code/package.json
@@ -3,6 +3,11 @@
   "description": "Display a title, description, and links alongside a code block",
   "version": "3.4.0",
   "author": "HashiCorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/text-split-with-code"
+  },
   "contributors": ["Brandon Romano"],
   "dependencies": {
     "@hashicorp/react-code-block": "^4.1.5",

--- a/packages/text-split-with-image/package.json
+++ b/packages/text-split-with-image/package.json
@@ -3,6 +3,11 @@
   "version": "4.3.0",
   "description": "Display an image alongside a title, description, and links.",
   "author": "HashiCorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/text-split-with-image"
+  },
   "contributors": ["Brandon Romano"],
   "publishConfig": {
     "access": "public"

--- a/packages/text-split/package.json
+++ b/packages/text-split/package.json
@@ -3,6 +3,11 @@
   "description": "Display a title, description, and links alongside arbitrary content",
   "version": "4.0.0",
   "author": "HashiCorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/text-split"
+  },
   "contributors": ["Zach Shilton"],
   "dependencies": {
     "@hashicorp/platform-product-meta": "^0.1.0",

--- a/packages/toggle/package.json
+++ b/packages/toggle/package.json
@@ -3,6 +3,11 @@
   "description": "a simple toggle",
   "version": "4.0.1",
   "author": "HashiCorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/toggle"
+  },
   "contributors": ["Jennifer Yip", "Jeff Escalante"],
   "license": "MPL-2.0",
   "peerDependencies": {

--- a/packages/use-cases/package.json
+++ b/packages/use-cases/package.json
@@ -3,6 +3,11 @@
   "description": "A set of three horizontally-aligned callout boxes containing an icon, a short title, and descriptive text, and a link.",
   "version": "5.0.0",
   "author": "HashiCorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/use-cases"
+  },
   "contributors": ["RJ Spiker"],
   "dependencies": {
     "@hashicorp/react-image": "^4.0.3",

--- a/packages/vertical-text-block-list/package.json
+++ b/packages/vertical-text-block-list/package.json
@@ -3,6 +3,11 @@
   "description": "Vertical block list of links",
   "version": "7.0.0",
   "author": "HashiCorp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/react-components.git",
+    "directory": "packages/vertical-text-block-list"
+  },
   "contributors": ["Mike Wickett", "Jeff Escalante"],
   "dependencies": {
     "@hashicorp/platform-product-meta": "^0.1.0",


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@rancyr](https://github.com/v-rr), [@Jaydon Peng](https://github.com/v-jiepeng), [@Zhongpeng Zhou](https://github.com/v-zhzhou) and [@Jingying Gu](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* @hashicorp/react-vertical-text-block-list
* @hashicorp/react-use-cases
* @hashicorp/react-toggle
* @hashicorp/react-text-split-with-image
* @hashicorp/react-text-split-with-code
* @hashicorp/react-text-split
* @hashicorp/react-tabs
* @hashicorp/react-subnav
* @hashicorp/react-section-header
* @hashicorp/react-search
* @hashicorp/react-product-features-list
* @hashicorp/react-markdown-page
* @hashicorp/react-link-wrap
* @hashicorp/react-image
* @hashicorp/react-head
* @hashicorp/react-hashi-stack-menu
* @hashicorp/react-featured-slider
* @hashicorp/react-docs-sidenav
* @hashicorp/react-docs-page
* @hashicorp/react-content
* @hashicorp/react-consent-manager
* @hashicorp/react-code-block
* @hashicorp/react-call-to-action
* @hashicorp/react-button