### PR TITLE
chore: bump hashi stack inline-svg dep

### DIFF
--- a/.changeset/early-ants-worry.md
+++ b/.changeset/early-ants-worry.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-hashi-stack-menu': patch
+---
+
+Bump for deps

--- a/.changeset/early-ants-worry.md
+++ b/.changeset/early-ants-worry.md
@@ -2,4 +2,4 @@
 '@hashicorp/react-hashi-stack-menu': patch
 ---
 
-Bump for deps
+Bump react-inline-svg dependency to `^6.0.3` ensure we're on a more recent version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -27737,7 +27737,7 @@
     },
     "packages/consent-manager": {
       "name": "@hashicorp/react-consent-manager",
-      "version": "7.0.1",
+      "version": "7.0.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/react-button": "^6.0.0",
@@ -27779,7 +27779,7 @@
     },
     "packages/docs-page": {
       "name": "@hashicorp/react-docs-page",
-      "version": "14.4.4",
+      "version": "14.4.5",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-docs-mdx": "^0.1.3",
@@ -27913,7 +27913,7 @@
       "version": "2.0.7",
       "license": "MPL-2.0",
       "dependencies": {
-        "@hashicorp/react-inline-svg": "^6.0.1",
+        "@hashicorp/react-inline-svg": "^6.0.3",
         "slugify": "1.6.0"
       },
       "peerDependencies": {
@@ -28163,7 +28163,7 @@
     },
     "packages/open-api-page": {
       "name": "@hashicorp/react-open-api-page",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.9",
@@ -28306,7 +28306,7 @@
     },
     "packages/select-input": {
       "name": "@hashicorp/react-select-input",
-      "version": "4.0.4",
+      "version": "4.0.5",
       "license": "MPL-2.0",
       "dependencies": {
         "classnames": "^2.3.1",
@@ -28358,7 +28358,7 @@
     },
     "packages/subnav": {
       "name": "@hashicorp/react-subnav",
-      "version": "9.1.2",
+      "version": "9.1.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/mktg-logos": "^1.0.2",
@@ -30734,7 +30734,7 @@
     "@hashicorp/react-hashi-stack-menu": {
       "version": "file:packages/hashi-stack-menu",
       "requires": {
-        "@hashicorp/react-inline-svg": "^6.0.1",
+        "@hashicorp/react-inline-svg": "^6.0.3",
         "slugify": "1.6.0"
       },
       "dependencies": {

--- a/packages/hashi-stack-menu/package.json
+++ b/packages/hashi-stack-menu/package.json
@@ -5,7 +5,7 @@
   "author": "HashiCorp",
   "contributors": ["Jimmy Merritello"],
   "dependencies": {
-    "@hashicorp/react-inline-svg": "^6.0.1",
+    "@hashicorp/react-inline-svg": "^6.0.3",
     "slugify": "1.6.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Bump the hashi stack `react-inline-svg` dependency. The latest published version is depending on `1.x` 😱 

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
