### PR TITLE
fix: handle windows paths

### DIFF
--- a/packages/docs-page/server/get-node-from-path.test.ts
+++ b/packages/docs-page/server/get-node-from-path.test.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import { flattenRoutes, getNodeFromPath } from './get-node-from-path'
 
 import navData from './__fixtures__/navData.json'
@@ -27,7 +28,7 @@ Object {
     expect(getNodeFromPath(pathToMatch, navData, CONTENT_DIR))
       .toMatchInlineSnapshot(`
 Object {
-  "filePath": "content/commands/index.mdx",
+  "filePath": ${JSON.stringify(path.join('content', 'commands', 'index.mdx'))},
 }
 `)
   })

--- a/packages/docs-page/server/loaders/file-system.ts
+++ b/packages/docs-page/server/loaders/file-system.ts
@@ -72,7 +72,10 @@ export default class FileSystemLoader implements DataLoader {
     const { mdxSource, frontMatter } = await mdxRenderer(mdxString)
 
     // Construct the githubFileUrl, used for "Edit this page" link
-    const githubFileUrl = `https://github.com/hashicorp/${this.opts.product}/blob/${mainBranch}/website/${navNode.filePath}`
+    const normalizedFilePath = navNode.filePath
+      .split(path.sep)
+      .join(path.posix.sep)
+    const githubFileUrl = `https://github.com/hashicorp/${this.opts.product}/blob/${mainBranch}/website/${normalizedFilePath}`
     // Return all the props
     return {
       currentPath,

--- a/packages/docs-sidenav/utils/validate-file-paths/index.test.js
+++ b/packages/docs-sidenav/utils/validate-file-paths/index.test.js
@@ -43,7 +43,10 @@ describe('<DocsSidenav /> - validate-file-paths', () => {
       },
     ]
     await expect(validateFilePaths(navData, CONTENT_DIR)).rejects.toThrow(
-      'Could not find file to match path "this-file-should-not-exist". Neither "this-file-should-not-exist.mdx" or "this-file-should-not-exist/index.mdx" could be found.'
+      `Could not find file to match path "this-file-should-not-exist". Neither "this-file-should-not-exist.mdx" or "${path.join(
+        'this-file-should-not-exist',
+        'index.mdx'
+      )}" could be found.`
     )
   })
 
@@ -55,7 +58,10 @@ describe('<DocsSidenav /> - validate-file-paths', () => {
       },
     ]
     await expect(validateFilePaths(navData, CONTENT_DIR)).rejects.toThrow(
-      `Ambiguous path "ambiguous". Both "ambiguous.mdx" and "ambiguous/index.mdx" exist. Please delete one of these files.`
+      `Ambiguous path "ambiguous". Both "ambiguous.mdx" and "${path.join(
+        'ambiguous',
+        'index.mdx'
+      )}" exist. Please delete one of these files.`
     )
   })
 })

--- a/packages/docs-sidenav/utils/validate-unlinked-content/index.js
+++ b/packages/docs-sidenav/utils/validate-unlinked-content/index.js
@@ -33,7 +33,7 @@ async function validateUnlinkedContent(navData, contentDir) {
       // Remove extensions, these will not be in routes
       const pathNoExt = relativePath.replace(/\.mdx$/, '')
       // Resolve /index routes, these will not have /index in their path
-      const routePath = pathNoExt.replace(/\/?index$/, '')
+      const routePath = pathNoExt.replace(/[\\/]?index$/, '')
       return routePath
     })
     // Determine if there is a match in nav-data.
@@ -44,7 +44,9 @@ async function validateUnlinkedContent(navData, contentDir) {
       const isIndexPage = pathToMatch === ''
       if (isIndexPage) return false
       // Otherwise, needs a path match in nav-data
-      const matches = navDataFlat.filter(({ path }) => path == pathToMatch)
+      // But first, rewrite all filesystem paths to POSIX paths
+      const normalizedPath = pathToMatch.split(path.sep).join(path.posix.sep)
+      const matches = navDataFlat.filter(({ path }) => path == normalizedPath)
       return matches.length == 0
     })
   return missingPages

--- a/packages/docs-sidenav/utils/validate-unlinked-content/index.test.js
+++ b/packages/docs-sidenav/utils/validate-unlinked-content/index.test.js
@@ -1,3 +1,4 @@
+import path from 'path'
 import validateUnlinkedContent from './'
 
 // We have a fixture folder with unlinked content set up
@@ -16,7 +17,11 @@ describe('<DocsSidenav /> - validate-unlinked-content', () => {
         path: 'hello',
       },
     ]
-    const expectedMissing = ['agent', 'nested', 'nested/another-file']
+    const expectedMissing = [
+      'agent',
+      'nested',
+      path.join('nested', 'another-file'),
+    ]
     const result = await validateUnlinkedContent(navData, CONTENT_DIR)
     expect(result.sort()).toEqual(expectedMissing.sort())
   })


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR updates a few utility functions and tests to account for different path separators on Windows. This ensures that contributors running tests on Windows machines are able to get passing tests.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
