### PR TITLE
feat(react-docs-page): surface env var error during development

### DIFF
--- a/.changeset/thirty-panthers-admire.md
+++ b/.changeset/thirty-panthers-admire.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-page': patch
+---
+
+surface warning about missing env vars during development

--- a/packages/docs-page/content-api/index.ts
+++ b/packages/docs-page/content-api/index.ts
@@ -12,9 +12,11 @@ const checkEnvVarsInDev = () => {
   if (process.env.NODE_ENV === 'development') {
     if (!MKTG_CONTENT_API || !MKTG_CONTENT_API_TOKEN) {
       const message = [
-        'You might be missing the following environment variables:',
-        '`MKTG_CONTENT_API`, `MKTG_CONTENT_API_TOKEN`',
-      ].join(' ')
+        'Missing environment variables required to fetch remote content:',
+        MKTG_CONTENT_API ? '\t- `MKTG_CONTENT_API`' : false, 
+        MKTG_CONTENT_API_TOKEN ? '\t- `MKTG_CONTENT_API_TOKEN`' : false,
+        'Reach out to #team-web-platform to get the proper values.'
+      ].filter(Boolean).join('\n')
       throw new Error(message)
     }
   }

--- a/packages/docs-page/content-api/index.ts
+++ b/packages/docs-page/content-api/index.ts
@@ -13,8 +13,8 @@ const checkEnvVarsInDev = () => {
     if (!MKTG_CONTENT_API || !MKTG_CONTENT_API_TOKEN) {
       const message = [
         'Missing environment variables required to fetch remote content:',
-        MKTG_CONTENT_API ? '\t- `MKTG_CONTENT_API`' : false, 
-        MKTG_CONTENT_API_TOKEN ? '\t- `MKTG_CONTENT_API_TOKEN`' : false,
+        !MKTG_CONTENT_API ? '  - `MKTG_CONTENT_API`' : false, 
+        !MKTG_CONTENT_API_TOKEN ? '  - `MKTG_CONTENT_API_TOKEN`' : false,
         'Reach out to #team-web-platform to get the proper values.'
       ].filter(Boolean).join('\n')
       throw new Error(message)

--- a/packages/docs-page/content-api/index.ts
+++ b/packages/docs-page/content-api/index.ts
@@ -7,11 +7,26 @@ const DEFAULT_HEADERS = {
   },
 }
 
+// Courtesy helper for warning about missing env vars during development
+const checkEnvVarsInDev = () => {
+  if (process.env.NODE_ENV === 'development') {
+    if (!MKTG_CONTENT_API || !MKTG_CONTENT_API_TOKEN) {
+      const message = [
+        'You might be missing the following environment variables:',
+        '`MKTG_CONTENT_API`, `MKTG_CONTENT_API_TOKEN`',
+      ].join(' ')
+      throw new Error(message)
+    }
+  }
+}
+
 export async function fetchNavData(
   product: string, //: string, // waypoint
   basePath: string, //: string, // commands | docs | plugins
   version: string //: string // v0.5.x
 ): Promise<any> {
+  checkEnvVarsInDev()
+
   const fullPath = `nav-data/${version}/${basePath}`
   const url = `${MKTG_CONTENT_API}/api/content/${product}/${fullPath}`
   const response = await fetch(url, DEFAULT_HEADERS).then((res) => res.json())
@@ -28,6 +43,8 @@ export async function fetchDocument(
   product: string,
   fullPath: string
 ): Promise<any> {
+  checkEnvVarsInDev()
+
   const url = `${MKTG_CONTENT_API}/api/content/${product}/${fullPath}`
   const response = await fetch(url, DEFAULT_HEADERS).then((res) => res.json())
 
@@ -40,6 +57,8 @@ export async function fetchDocument(
 }
 
 export async function fetchVersionMetadataList(product: string) {
+  checkEnvVarsInDev()
+
   const url = `${MKTG_CONTENT_API}/api/content/${product}/version-metadata?partial=true`
   const response = await fetch(url, DEFAULT_HEADERS).then((res) => res.json())
 


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This causes `react-docs-page` api client code to throw an error in **development** about missing env vars.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
