### PR TITLE
chore(react-docs-page): throw when data loader gSP errors

### DIFF
--- a/.changeset/rare-cats-visit.md
+++ b/.changeset/rare-cats-visit.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-page': minor
+---
+
+Throw when getStaticProps errors

--- a/packages/docs-page/content-api/__snapshots__/content-api.test.ts.snap
+++ b/packages/docs-page/content-api/__snapshots__/content-api.test.ts.snap
@@ -100,14 +100,7 @@ need to reload your shell.
 }
 `;
 
-exports[`contentApi fetchDocument should throw if a document is not found 1`] = `
-"Failed to fetch: http://localhost:3001/api/content/waypoint/doc/latest/commands/k8s-bootstrap | {
-  \\"meta\\": {
-    \\"status_code\\": 404,
-    \\"status_text\\": \\"Not Found\\"
-  }
-}"
-`;
+exports[`contentApi fetchDocument should throw if a document is not found 1`] = `"Failed to fetch: http://localhost:3001/api/content/waypoint/doc/latest/commands/k8s-bootstrap"`;
 
 exports[`contentApi fetchNavData should return the requested navdata 1`] = `
 Object {
@@ -382,14 +375,7 @@ Object {
 }
 `;
 
-exports[`contentApi fetchNavData should throw if a navData is not found 1`] = `
-"Failed to fetch: http://localhost:3001/api/content/waypoint/nav-data/v0.9000.x/commands | {
-  \\"meta\\": {
-    \\"status_code\\": 404,
-    \\"status_text\\": \\"Not Found\\"
-  }
-}"
-`;
+exports[`contentApi fetchNavData should throw if a navData is not found 1`] = `"Failed to fetch: http://localhost:3001/api/content/waypoint/nav-data/v0.9000.x/commands"`;
 
 exports[`contentApi fetchVersionMetadataList should return an empty list for invalid product name 1`] = `Array []`;
 

--- a/packages/docs-page/content-api/index.ts
+++ b/packages/docs-page/content-api/index.ts
@@ -1,24 +1,25 @@
 const MKTG_CONTENT_API = process.env.MKTG_CONTENT_API
-const MKTG_CONTENT_API_TOKEN = process.env.MKTG_CONTENT_API_TOKEN
-
-const DEFAULT_HEADERS = {
-  headers: {
-    Authorization: `Bearer ${MKTG_CONTENT_API_TOKEN}`,
-  },
-}
 
 // Courtesy helper for warning about missing env vars during development
 const checkEnvVarsInDev = () => {
   if (process.env.NODE_ENV === 'development') {
-    if (!MKTG_CONTENT_API || !MKTG_CONTENT_API_TOKEN) {
+    if (!MKTG_CONTENT_API) {
       const message = [
         'Missing environment variables required to fetch remote content:',
-        !MKTG_CONTENT_API ? '  - `MKTG_CONTENT_API`' : false, 
-        !MKTG_CONTENT_API_TOKEN ? '  - `MKTG_CONTENT_API_TOKEN`' : false,
-        'Reach out to #team-web-platform to get the proper values.'
-      ].filter(Boolean).join('\n')
+        !MKTG_CONTENT_API ? '  - `MKTG_CONTENT_API`' : false,
+        'Reach out to #team-web-platform to get the proper values.',
+      ]
+        .filter(Boolean)
+        .join('\n')
       throw new Error(message)
     }
+  }
+}
+
+export class ContentApiError extends Error {
+  name = 'ContentApiError' as const
+  constructor(message: string, public status: number) {
+    super(message)
   }
 }
 
@@ -31,14 +32,15 @@ export async function fetchNavData(
 
   const fullPath = `nav-data/${version}/${basePath}`
   const url = `${MKTG_CONTENT_API}/api/content/${product}/${fullPath}`
-  const response = await fetch(url, DEFAULT_HEADERS).then((res) => res.json())
 
-  if (response.meta.status_code !== 200) {
-    throw new Error(
-      `Failed to fetch: ${url} | ${JSON.stringify(response, null, 2)}`
-    )
+  const response = await fetch(url)
+
+  if (response.status !== 200) {
+    throw new ContentApiError(`Failed to fetch: ${url}`, response.status)
   }
-  return response.result
+
+  const { result } = await response.json()
+  return result
 }
 
 export async function fetchDocument(
@@ -48,26 +50,26 @@ export async function fetchDocument(
   checkEnvVarsInDev()
 
   const url = `${MKTG_CONTENT_API}/api/content/${product}/${fullPath}`
-  const response = await fetch(url, DEFAULT_HEADERS).then((res) => res.json())
+  const response = await fetch(url)
 
-  if (response.meta.status_code !== 200) {
-    throw new Error(
-      `Failed to fetch: ${url} | ${JSON.stringify(response, null, 2)}`
-    )
+  if (response.status !== 200) {
+    throw new ContentApiError(`Failed to fetch: ${url}`, response.status)
   }
-  return response.result
+
+  const { result } = await response.json()
+  return result
 }
 
 export async function fetchVersionMetadataList(product: string) {
   checkEnvVarsInDev()
 
   const url = `${MKTG_CONTENT_API}/api/content/${product}/version-metadata?partial=true`
-  const response = await fetch(url, DEFAULT_HEADERS).then((res) => res.json())
+  const response = await fetch(url)
 
-  if (response.meta.status_code !== 200) {
-    throw new Error(
-      `Failed to fetch: ${url} | ${JSON.stringify(response, null, 2)}`
-    )
+  if (response.status !== 200) {
+    throw new ContentApiError(`Failed to fetch: ${url}`, response.status)
   }
-  return response.result
+
+  const { result } = await response.json()
+  return result
 }

--- a/packages/docs-page/content-api/index.ts
+++ b/packages/docs-page/content-api/index.ts
@@ -5,12 +5,10 @@ const checkEnvVarsInDev = () => {
   if (process.env.NODE_ENV === 'development') {
     if (!MKTG_CONTENT_API) {
       const message = [
-        'Missing environment variables required to fetch remote content:',
-        !MKTG_CONTENT_API ? '  - `MKTG_CONTENT_API`' : false,
-        'Reach out to #team-web-platform to get the proper values.',
-      ]
-        .filter(Boolean)
-        .join('\n')
+        'Missing environment variable required to fetch remote content:',
+        '  - `MKTG_CONTENT_API`',
+        'Reach out to #team-web-platform to get the proper value.',
+      ].join('\n')
       throw new Error(message)
     }
   }

--- a/packages/docs-page/server/index.ts
+++ b/packages/docs-page/server/index.ts
@@ -45,10 +45,7 @@ export function getStaticGenerationFunctions(
     }
     case 'remote': {
       const { strategy, ...restOpts } = opts
-
-      loader = new RemoteContentLoader({
-        ...restOpts,
-      })
+      loader = new RemoteContentLoader({ ...restOpts })
     }
   }
 
@@ -68,10 +65,8 @@ export function getStaticGenerationFunctions(
           revalidate: opts.revalidate,
         }
       } catch (err) {
-        console.error(err)
-        return {
-          notFound: true,
-        }
+        console.error(`Failed to generate static props:`, err)
+        throw err
       }
     },
   }

--- a/packages/docs-page/server/index.ts
+++ b/packages/docs-page/server/index.ts
@@ -1,4 +1,5 @@
 import { GetStaticPaths, GetStaticProps, GetStaticPathsResult } from 'next'
+import { ContentApiError } from '../content-api'
 import FileSystemLoader from './loaders/file-system'
 import RemoteContentLoader from './loaders/remote-content'
 import { DataLoader } from './loaders/types'
@@ -66,6 +67,14 @@ export function getStaticGenerationFunctions(
         }
       } catch (err) {
         console.error(`Failed to generate static props:`, err)
+
+        if (err instanceof ContentApiError) {
+          if (err.status === 404) {
+            return {
+              notFound: true,
+            }
+          }
+        }
         throw err
       }
     },

--- a/packages/docs-page/server/loaders/remote-content.test.ts
+++ b/packages/docs-page/server/loaders/remote-content.test.ts
@@ -20,11 +20,7 @@ describe('RemoteContentLoader', () => {
 
     nock.disableNetConnect()
 
-    scope = nock(process.env.MKTG_CONTENT_API, {
-      reqheaders: {
-        authorization: `Bearer ${process.env.MKTG_CONTENT_API_TOKEN}`,
-      },
-    })
+    scope = nock(process.env.MKTG_CONTENT_API)
   })
 
   afterAll(() => {


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1201340096942828/f)
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This allows us to continue serving a cache/successfully built page, in the event that `getStaticProps` errors.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
