### PR TITLE
chore(react-tabs): adds heap attribute to tab trigger

### DIFF
--- a/.changeset/unlucky-icons-sell.md
+++ b/.changeset/unlucky-icons-sell.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/react-tabs": patch
+---
+
+Adds heap data tracking attribute to tab trigger button.

--- a/packages/tabs/partials/tab-trigger/index.tsx
+++ b/packages/tabs/partials/tab-trigger/index.tsx
@@ -45,6 +45,7 @@ function TabTrigger({
         [s.isActiveTab]: isActiveTab,
         [s.hasOverflow]: hasOverflow,
       })}
+      data-heap-track="TabClick"
       data-tabindex={tab.index}
       onMouseDown={(e) => e.preventDefault()}
       onClick={() => setActiveTab(tab.index, tab.group)}


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1126685961643737/1201343249900617)
🔍 [Preview Link](https://react-components-git-ksadds-heap-attribute-tabs-hashicorp.vercel.app/components/tabs)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Learn was tracking tab clicks based on the `g-tab-trigger` class; now that this component was converted to used CSS modules, we've lost that tracking. This PR adds a `data-heap-track` attribute to the tab trigger button so we can reinstate the heap event. 

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
