### PR TITLE
feat(search): expose algolia config as props, fallback to env

### DIFF
--- a/.changeset/breezy-eyes-attend.md
+++ b/.changeset/breezy-eyes-attend.md
@@ -1,5 +1,5 @@
 ---
-'@hashicorp/react-docs-page': patch
+'@hashicorp/react-docs-page': minor
 ---
 
 Add support for Algolia config via algoliaConfig DocsPage prop

--- a/.changeset/breezy-eyes-attend.md
+++ b/.changeset/breezy-eyes-attend.md
@@ -2,4 +2,4 @@
 '@hashicorp/react-docs-page': minor
 ---
 
-Add support for Algolia config via algoliaConfig DocsPage prop
+Add support for Algolia config, through an optional algoliaConfig prop, which is passed to react-search. This prop can be omitted, or provided with incomplete properties, and react-search will fall back to environment variables.

--- a/.changeset/breezy-eyes-attend.md
+++ b/.changeset/breezy-eyes-attend.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-page': patch
+---
+
+Add support for Algolia config via algoliaConfig DocsPage prop

--- a/.changeset/itchy-kangaroos-admire.md
+++ b/.changeset/itchy-kangaroos-admire.md
@@ -2,4 +2,4 @@
 '@hashicorp/react-search': minor
 ---
 
-Add support for Algolia config via SearchProvider props
+Add support for Algolia config, through an optional algoliaConfig prop on SearchProvider. This prop can be omitted, or provided with incomplete properties, and react-search will fall back to environment variables.

--- a/.changeset/itchy-kangaroos-admire.md
+++ b/.changeset/itchy-kangaroos-admire.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-search': minor
+---
+
+Add support for Algolia config via SearchProvider props

--- a/packages/docs-page/index.test.tsx
+++ b/packages/docs-page/index.test.tsx
@@ -30,7 +30,7 @@ describe('<DocsPage />', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     useRouterMock.mockImplementation(() => routerMock)
-    headMock.mockImplementation(({ children }) => children)
+    headMock.mockImplementation(({ children }) => <>{children}</>)
   })
 
   it('passes `title`, `description`, and `siteName` correctly to <HashiHead>', () => {

--- a/packages/docs-page/index.test.tsx
+++ b/packages/docs-page/index.test.tsx
@@ -87,12 +87,8 @@ describe('<DocsPage />', () => {
       return <strong>Text in custom component</strong>
     }
     const additionalComponents = { CustomComponent }
-    const {
-      mdxSource,
-      frontMatter,
-    } = await renderPageMdx(
-      "## Heading Two\n\nHere's a paragraph of content.\n\n<CustomComponent />",
-      { productName: 'Terraform', additionalComponents }
+    const { mdxSource, frontMatter } = await renderPageMdx(
+      "## Heading Two\n\nHere's a paragraph of content.\n\n<CustomComponent />"
     )
     render(
       <DocsPage
@@ -112,12 +108,8 @@ describe('<DocsPage />', () => {
   })
 
   it('initializes jump to section UI if there is an h1 and two or more h2s', async () => {
-    const {
-      mdxSource,
-      frontMatter,
-    } = await renderPageMdx(
-      "---\n\npage_title: Test Title\ndescription: Test description\n---\n\n# Heading One\n\nAn intro paragraph.\n\n## Heading Two\n\nHere's a paragraph of content.\n\n## Here a second heading\n\nAnd another paragraph.",
-      { productName: 'Terraform' }
+    const { mdxSource, frontMatter } = await renderPageMdx(
+      "---\n\npage_title: Test Title\ndescription: Test description\n---\n\n# Heading One\n\nAn intro paragraph.\n\n## Heading Two\n\nHere's a paragraph of content.\n\n## Here a second heading\n\nAnd another paragraph."
     )
     render(
       <DocsPage

--- a/packages/docs-page/index.tsx
+++ b/packages/docs-page/index.tsx
@@ -21,6 +21,12 @@ import LoadingSkeleton from './components/loading-skeleton'
 import useIsMobile from './use-is-mobile'
 import s from './style.module.css'
 
+interface AlgoliaConfigObject {
+  algoliaAppId?: string
+  algoliaIndex?: string
+  algoliaSearchOnlyApiKey?: string
+}
+
 interface DocsPageWrapperProps {
   canonicalUrl: string
   description: string
@@ -34,6 +40,7 @@ interface DocsPageWrapperProps {
   showEditPage: boolean
   showVersionSelect: boolean
   versions: { name: string; label: string }[]
+  algoliaConfig?: AlgoliaConfigObject
 }
 
 export const DocsPageWrapper: FunctionComponent<DocsPageWrapperProps> = ({
@@ -49,6 +56,7 @@ export const DocsPageWrapper: FunctionComponent<DocsPageWrapperProps> = ({
   showEditPage = true,
   showVersionSelect = process.env.ENABLE_VERSIONED_DOCS?.toString() === 'true',
   versions,
+  algoliaConfig,
 }) => {
   const isMobile = useIsMobile()
   const { asPath } = useRouter()
@@ -63,7 +71,7 @@ export const DocsPageWrapper: FunctionComponent<DocsPageWrapperProps> = ({
   }, [children])
 
   const search = (
-    <SearchProvider>
+    <SearchProvider {...(algoliaConfig || {})}>
       <SearchBar
         product={name}
         className={classNames({ [s.mobileSearch]: isMobile })}
@@ -152,6 +160,7 @@ export interface DocsPageProps {
   showEditPage?: boolean
   showVersionSelect?: boolean
   additionalComponents?: MDXProviderComponentsProp
+  algoliaConfig?: AlgoliaConfigObject
   staticProps: {
     mdxSource: MDXRemoteSerializeResult
     frontMatter: {
@@ -172,6 +181,7 @@ export default function DocsPage({
   showEditPage = true,
   showVersionSelect = false,
   additionalComponents,
+  algoliaConfig,
   staticProps: {
     mdxSource,
     frontMatter,
@@ -206,6 +216,7 @@ export default function DocsPage({
       showVersionSelect={showVersionSelect}
       baseRoute={baseRoute}
       versions={versions}
+      algoliaConfig={algoliaConfig}
     >
       {content}
     </DocsPageWrapper>

--- a/packages/docs-page/index.tsx
+++ b/packages/docs-page/index.tsx
@@ -22,9 +22,9 @@ import useIsMobile from './use-is-mobile'
 import s from './style.module.css'
 
 interface AlgoliaConfigObject {
-  algoliaAppId?: string
-  algoliaIndex?: string
-  algoliaSearchOnlyApiKey?: string
+  appId?: string
+  indexName?: string
+  searchOnlyApiKey?: string
 }
 
 interface DocsPageWrapperProps {

--- a/packages/docs-page/index.tsx
+++ b/packages/docs-page/index.tsx
@@ -8,6 +8,7 @@ import { NavData } from '@hashicorp/react-docs-sidenav/types'
 import HashiHead from '@hashicorp/react-head'
 import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote'
 import { SearchProvider } from '@hashicorp/react-search'
+import { AlgoliaConfigObject } from '@hashicorp/react-search/types'
 
 import VersionSelect from '@hashicorp/react-version-select'
 import { getVersionFromPath } from '@hashicorp/react-version-select/util'
@@ -20,12 +21,6 @@ import temporary_injectJumpToSection from './temporary_jump-to-section'
 import LoadingSkeleton from './components/loading-skeleton'
 import useIsMobile from './use-is-mobile'
 import s from './style.module.css'
-
-interface AlgoliaConfigObject {
-  appId?: string
-  indexName?: string
-  searchOnlyApiKey?: string
-}
 
 interface DocsPageWrapperProps {
   canonicalUrl: string

--- a/packages/docs-page/index.tsx
+++ b/packages/docs-page/index.tsx
@@ -71,7 +71,7 @@ export const DocsPageWrapper: FunctionComponent<DocsPageWrapperProps> = ({
   }, [children])
 
   const search = (
-    <SearchProvider {...(algoliaConfig || {})}>
+    <SearchProvider algoliaConfig={algoliaConfig}>
       <SearchBar
         product={name}
         className={classNames({ [s.mobileSearch]: isMobile })}

--- a/packages/docs-page/props.js
+++ b/packages/docs-page/props.js
@@ -179,4 +179,24 @@ module.exports = {
     },
     testValue: {},
   },
+  algoliaConfig: {
+    type: 'object',
+    description:
+      'Optional Algolia configuration to pass to the react-search component. If omitted, will default to .env variables. Any of the properties can be omitted, and will fall back to .env variables.',
+    properties: {
+      appId: {
+        type: 'string',
+        description:
+          'The Algolia application ID. In many setups, this ID is consistent across indices.',
+      },
+      indexName: {
+        type: 'string',
+        description: 'The name of the index to use.',
+      },
+      searchOnlyApiKey: {
+        type: 'string',
+        description: 'A publishable search-only API key.',
+      },
+    },
+  },
 }

--- a/packages/docs-page/props.js
+++ b/packages/docs-page/props.js
@@ -186,16 +186,16 @@ module.exports = {
     properties: {
       appId: {
         type: 'string',
-        description:
-          'The Algolia application ID. In many setups, this ID is consistent across indices.',
+        description: 'The ID of the target Algolia application.',
       },
       indexName: {
         type: 'string',
-        description: 'The name of the index to use.',
+        description: 'The name of the index to search.',
       },
       searchOnlyApiKey: {
         type: 'string',
-        description: 'A publishable search-only API key.',
+        description:
+          'A publishable search-only API key that can access the provided application and index.',
       },
     },
   },

--- a/packages/search/index.test.js
+++ b/packages/search/index.test.js
@@ -22,13 +22,13 @@ function setupEnv() {
   process.env = { ...originalEnv } //  copy original environment
 }
 
-function restoreEnv() {
+function teardownEnv() {
   process.env = originalEnv //  restore original environment
 }
 
 describe('<Search />', () => {
   beforeAll(setupEnv)
-  afterAll(restoreEnv)
+  afterAll(teardownEnv)
   beforeEach(setDummyVars)
 
   it('should pass className to the root element', () => {
@@ -58,7 +58,7 @@ describe('<Search />', () => {
 
 describe('<Hits />', () => {
   beforeAll(setupEnv)
-  afterAll(restoreEnv)
+  afterAll(teardownEnv)
   beforeEach(setDummyVars)
 
   it('should display no results with invalid input', () => {
@@ -129,7 +129,7 @@ describe('<SearchProvider /> configuration', () => {
     //  Restore console.error for further tests
     global.console.error.mockRestore()
     // Restore the original .env for further tests
-    restoreEnv()
+    teardownEnv()
   })
 
   it('should allow mixed use of Algolia config props and .env', () => {
@@ -153,13 +153,13 @@ describe('<SearchProvider /> configuration', () => {
     expect(screen.getByText(testIndexName)).toBeInTheDocument()
 
     // Restore the original .env for further tests
-    restoreEnv()
+    teardownEnv()
   })
 })
 
 describe('<SearchProvider /> context', () => {
   beforeAll(setupEnv)
-  afterAll(restoreEnv)
+  afterAll(teardownEnv)
   beforeEach(setDummyVars)
 
   it('should provide a context object', () => {
@@ -207,7 +207,7 @@ describe('<SearchProvider /> context', () => {
 
 describe('search tools', () => {
   beforeAll(setupEnv)
-  afterAll(restoreEnv)
+  afterAll(teardownEnv)
 
   let algoliaConfig = {}
 

--- a/packages/search/index.test.js
+++ b/packages/search/index.test.js
@@ -9,10 +9,6 @@ import Search, {
 import { HitsComponent } from './hits'
 import { indexContent } from './tools'
 
-const renderWithProvider = (ui) => {
-  return render(<SearchProvider>{ui}</SearchProvider>)
-}
-
 const originalEnv = process.env
 
 const setDummyVars = () => {
@@ -26,19 +22,21 @@ function setupEnv() {
   process.env = { ...originalEnv } //  copy original environment
 }
 
-function teardownEnv() {
+function restoreEnv() {
   process.env = originalEnv //  restore original environment
 }
 
 describe('<Search />', () => {
   beforeAll(setupEnv)
-  afterAll(teardownEnv)
+  afterAll(restoreEnv)
   beforeEach(setDummyVars)
 
   it('should pass className to the root element', () => {
     const className = 'special-class-name'
-    const { container } = renderWithProvider(
-      <Search className={className} renderHitContent={() => {}} />
+    const { container } = render(
+      <SearchProvider>
+        <Search className={className} renderHitContent={() => {}} />
+      </SearchProvider>
     )
     const rootElem = container.firstChild
     expect(rootElem.tagName).toBe('DIV')
@@ -46,10 +44,11 @@ describe('<Search />', () => {
   })
 
   it('should render an empty input by default', () => {
-    const { container } = renderWithProvider(
-      <Search renderHitContent={() => {}} />
+    const { container } = render(
+      <SearchProvider>
+        <Search renderHitContent={() => {}} />
+      </SearchProvider>
     )
-
     const input = screen.getByRole('searchbox')
     expect(input).toHaveAttribute('id', SEARCH_BOX_ID)
     expect(input).toHaveAttribute('aria-activedescendant', '')
@@ -59,12 +58,15 @@ describe('<Search />', () => {
 
 describe('<Hits />', () => {
   beforeAll(setupEnv)
-  afterAll(teardownEnv)
+  afterAll(restoreEnv)
   beforeEach(setDummyVars)
 
   it('should display no results with invalid input', () => {
-    renderWithProvider(<HitsComponent hits={[]} renderHitContent={() => {}} />)
-
+    render(
+      <SearchProvider>
+        <HitsComponent hits={[]} renderHitContent={() => {}} />
+      </SearchProvider>
+    )
     expect(screen.queryByRole('listbox')).toBeNull()
     expect(
       screen.queryByText('No results for undefined...')
@@ -72,13 +74,14 @@ describe('<Hits />', () => {
   })
 
   it('should render results when given valid input', () => {
-    renderWithProvider(
-      <HitsComponent
-        hits={[{ objectID: 'foo' }, { objectID: 'bar' }]}
-        renderHitContent={({ objectID }) => <span>{objectID}</span>}
-      />
+    render(
+      <SearchProvider>
+        <HitsComponent
+          hits={[{ objectID: 'foo' }, { objectID: 'bar' }]}
+          renderHitContent={({ objectID }) => <span>{objectID}</span>}
+        />
+      </SearchProvider>
     )
-
     const resultsEl = screen.getByRole('listbox')
     expect(resultsEl).toHaveAttribute('id', SEARCH_RESULTS_ID)
     const hitItems = screen.getAllByTestId('hit-item')
@@ -86,9 +89,77 @@ describe('<Hits />', () => {
   })
 })
 
-describe('<SearchProvider />', () => {
+describe('<SearchProvider /> configuration', () => {
+  it('should throw an error if no Algolia config is accessible', () => {
+    //  Suppress console.error for this test, we expect errors
+    jest.spyOn(console, 'error')
+    global.console.error.mockImplementation(() => {})
+    // Set up a function to render the provider, we'll re-use this
+    function renderProvider() {
+      render(
+        <SearchProvider>
+          <p>Hi</p>
+        </SearchProvider>
+      )
+    }
+    // Test that when .env is present, we don't throw an error
+    expect(renderProvider).not.toThrowError()
+    // Test each .env var individually, if any are missing,
+    // an error should be thrown
+    const {
+      NEXT_PUBLIC_ALGOLIA_APP_ID,
+      NEXT_PUBLIC_ALGOLIA_INDEX,
+      NEXT_PUBLIC_ALGOLIA_SEARCH_ONLY_API_KEY,
+    } = originalEnv
+    // APP_ID missing
+    process.env = {
+      NEXT_PUBLIC_ALGOLIA_INDEX,
+      NEXT_PUBLIC_ALGOLIA_SEARCH_ONLY_API_KEY,
+    }
+    expect(renderProvider).toThrowError()
+    // INDEX missing
+    process.env = {
+      NEXT_PUBLIC_ALGOLIA_APP_ID,
+      NEXT_PUBLIC_ALGOLIA_SEARCH_ONLY_API_KEY,
+    }
+    expect(renderProvider).toThrowError()
+    // SEARCH_ONLY_API_KEY missing
+    process.env = { NEXT_PUBLIC_ALGOLIA_INDEX, NEXT_PUBLIC_ALGOLIA_APP_ID }
+    expect(renderProvider).toThrowError()
+    //  Restore console.error for further tests
+    global.console.error.mockRestore()
+    // Restore the original .env for further tests
+    restoreEnv()
+  })
+
+  it('should allow mixed use of Algolia config props and .env', () => {
+    // Set search-only API key and App ID in .env
+    process.env = {
+      NEXT_PUBLIC_ALGOLIA_APP_ID: process.env.NEXT_PUBLIC_ALGOLIA_APP_ID,
+      NEXT_PUBLIC_ALGOLIA_SEARCH_ONLY_API_KEY:
+        process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_ONLY_API_KEY,
+    }
+    // Render the provider, and a consumer to log out the index name
+    const testIndexName = 'my-very-special-index'
+    function IndexConsumer() {
+      const context = useSearch()
+      return <div>{context.indexName}</div>
+    }
+    render(
+      <SearchProvider algoliaConfig={{ indexName: testIndexName }}>
+        <IndexConsumer />
+      </SearchProvider>
+    )
+    expect(screen.getByText(testIndexName)).toBeInTheDocument()
+
+    // Restore the original .env for further tests
+    restoreEnv()
+  })
+})
+
+describe('<SearchProvider /> context', () => {
   beforeAll(setupEnv)
-  afterAll(teardownEnv)
+  afterAll(restoreEnv)
   beforeEach(setDummyVars)
 
   it('should provide a context object', () => {
@@ -96,7 +167,11 @@ describe('<SearchProvider />', () => {
       const context = useSearch()
       return <div>{typeof context}</div>
     }
-    renderWithProvider(<Consumer />)
+    render(
+      <SearchProvider>
+        <Consumer />
+      </SearchProvider>
+    )
     expect(screen.getByText('object')).toBeInTheDocument()
   })
 
@@ -113,7 +188,11 @@ describe('<SearchProvider />', () => {
       )
     }
 
-    const { container } = renderWithProvider(<SearchButton />)
+    const { container } = render(
+      <SearchProvider>
+        <SearchButton />
+      </SearchProvider>
+    )
 
     //  empty string by default
     expect(screen.getByText('query is')).toBeDefined()
@@ -128,7 +207,7 @@ describe('<SearchProvider />', () => {
 
 describe('search tools', () => {
   beforeAll(setupEnv)
-  afterAll(teardownEnv)
+  afterAll(restoreEnv)
 
   let algoliaConfig = {}
 

--- a/packages/search/provider.js
+++ b/packages/search/provider.js
@@ -17,7 +17,7 @@ export default function SearchProvider({
   const [query, setQuery] = useState('')
   const [isCancelled, setCancelled] = useState(false)
 
-  if (algoliaAppId || algoliaSearchOnlyApiKey || algoliaIndex) {
+  if (!algoliaAppId || !algoliaSearchOnlyApiKey || !algoliaIndex) {
     throw new Error(`Missing required Algolia arguments or .env variables for SearchProvider. If using environment variables, ensure the following are present in your environment:
 - NEXT_PUBLIC_ALGOLIA_APP_ID
 - NEXT_PUBLIC_ALGOLIA_SEARCH_ONLY_API_KEY

--- a/packages/search/provider.js
+++ b/packages/search/provider.js
@@ -1,72 +1,77 @@
-import { useState, createContext, useContext } from 'react'
-import search from 'algoliasearch'
-import aa from 'search-insights'
+import { useMemo, useState, createContext, useContext } from 'react'
+import algoliaSearch from 'algoliasearch'
+import searchInsights from 'search-insights'
 
 const SearchContext = createContext()
 
-export const useSearch = () => {
-  if (
-    !process.env.NEXT_PUBLIC_ALGOLIA_APP_ID ||
-    !process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_ONLY_API_KEY ||
-    !process.env.NEXT_PUBLIC_ALGOLIA_INDEX
-  ) {
-    throw new Error(`Missing required environment variables. Ensure the following are present in your environment:
-- NEXT_PUBLIC_ALGOLIA_APP_ID
-- NEXT_PUBLIC_ALGOLIA_SEARCH_ONLY_API_KEY
-- NEXT_PUBLIC_ALGOLIA_INDEX
-`)
-  }
+export function useSearch() {
   return useContext(SearchContext)
 }
 
-const algoliaClient = search(
-  process.env.NEXT_PUBLIC_ALGOLIA_APP_ID,
-  process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_ONLY_API_KEY
-)
-
-const client = {
-  search(requests) {
-    return algoliaClient.search(
-      requests.map((request) => {
-        //  instantsearch fires an empty query on page load to ensure results are immediately available
-        //  we exclude that result from our analytics to keep our clickthrough rate clean
-        //  ref: https://www.algolia.com/doc/guides/getting-insights-and-analytics/search-analytics/out-of-the-box-analytics/how-to/how-to-remove-empty-search-from-analytics/
-        if (!request.params.query || request.params.query.length === 0) {
-          request.params.analytics = false
-        }
-
-        return request
-      })
-    )
-  },
-}
-
-function initAlgoliaInsights() {
-  aa('init', {
-    appId: process.env.NEXT_PUBLIC_ALGOLIA_APP_ID,
-    apiKey: process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_ONLY_API_KEY,
-  })
-}
-
-function logClick(hit) {
-  return aa('clickedObjectIDsAfterSearch', {
-    eventName: 'CLICK_HIT',
-    index: process.env.NEXT_PUBLIC_ALGOLIA_INDEX,
-    queryID: hit.__queryID,
-    objectIDs: [hit.objectID],
-    positions: [hit.__position],
-  })
-}
-
-export default function SearchProvider({ children }) {
+export default function SearchProvider({
+  children,
+  algoliaAppId = process.env.NEXT_PUBLIC_ALGOLIA_APP_ID,
+  algoliaIndex = process.env.NEXT_PUBLIC_ALGOLIA_INDEX,
+  algoliaSearchOnlyApiKey = process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_ONLY_API_KEY,
+}) {
   const [query, setQuery] = useState('')
   const [isCancelled, setCancelled] = useState(false)
+
+  if (algoliaAppId || algoliaSearchOnlyApiKey || algoliaIndex) {
+    throw new Error(`Missing required Algolia arguments or .env variables for SearchProvider. If using environment variables, ensure the following are present in your environment:
+- NEXT_PUBLIC_ALGOLIA_APP_ID
+- NEXT_PUBLIC_ALGOLIA_SEARCH_ONLY_API_KEY
+- NEXT_PUBLIC_ALGOLIA_INDEX
+If passing arguments to SearchProvider, ensure the following are passed:
+- algoliaAppId
+- algoliaIndex
+- algoliaSearchOnlyApiKey
+`)
+  }
+
+  const algoliaClient = useMemo(
+    () => algoliaSearch(algoliaAppId, algoliaSearchOnlyApiKey),
+    [algoliaAppId, algoliaSearchOnlyApiKey]
+  )
+
+  const client = {
+    search(requests) {
+      return algoliaClient.search(
+        requests.map((request) => {
+          //  instantsearch fires an empty query on page load to ensure results are immediately available
+          //  we exclude that result from our analytics to keep our clickthrough rate clean
+          //  ref: https://www.algolia.com/doc/guides/getting-insights-and-analytics/search-analytics/out-of-the-box-analytics/how-to/how-to-remove-empty-search-from-analytics/
+          if (!request.params.query || request.params.query.length === 0) {
+            request.params.analytics = false
+          }
+          return request
+        })
+      )
+    },
+  }
+
+  function initAlgoliaInsights() {
+    searchInsights('init', {
+      appId: algoliaAppId,
+      apiKey: algoliaSearchOnlyApiKey,
+    })
+  }
+
+  function logClick(hit) {
+    return searchInsights('clickedObjectIDsAfterSearch', {
+      eventName: 'CLICK_HIT',
+      index: algoliaIndex,
+      queryID: hit.__queryID,
+      objectIDs: [hit.objectID],
+      positions: [hit.__position],
+    })
+  }
 
   return (
     <SearchContext.Provider
       value={{
         client,
-        indexName: process.env.NEXT_PUBLIC_ALGOLIA_INDEX,
+        indexName: algoliaIndex,
         initAlgoliaInsights,
         isCancelled,
         logClick,

--- a/packages/search/provider.tsx
+++ b/packages/search/provider.tsx
@@ -1,14 +1,32 @@
-import { useMemo, useState, createContext, useContext } from 'react'
-import algoliaSearch from 'algoliasearch'
+import React, { useMemo, useState, createContext, useContext } from 'react'
+import algoliaSearch, { SearchClient } from 'algoliasearch'
 import searchInsights from 'search-insights'
+import { AlgoliaConfigObject } from './types'
 
-const SearchContext = createContext()
+const SearchContext = createContext(null)
 
-export function useSearch() {
+interface SearchContextObject {
+  client: SearchClient
+  indexName: string
+  initAlgoliaInsights: () => void
+  isCancelled: boolean
+  logClick: () => void
+  query: string
+  setCancelled: () => void
+  setQuery: () => void
+}
+
+export function useSearch(): SearchContextObject {
   return useContext(SearchContext)
 }
 
-export default function SearchProvider({ children, algoliaConfig = {} }) {
+export default function SearchProvider({
+  children,
+  algoliaConfig = {},
+}: {
+  children: React.ReactNode
+  algoliaConfig: AlgoliaConfigObject
+}): React.ReactElement {
   const [query, setQuery] = useState('')
   const [isCancelled, setCancelled] = useState(false)
 
@@ -57,6 +75,18 @@ If passing the algoliaConfig prop to SearchProvider, ensure the following keys a
   }
 
   function logClick(hit) {
+    // --------------
+    // TODO: I was unable to resolve the TypeScript error here.
+    // It seems to be related to "overloads",
+    // which I understand as "the function has many arg signatures",
+    // but I'm not familiar enough with Typescript to understand
+    // how to correctly resolve this issue.
+    // (Note: this file was converted to TypeScript. Prior to
+    // conversion, the searchInsights call was identical and
+    // functioned as expected)
+    // --------------
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     return searchInsights('clickedObjectIDsAfterSearch', {
       eventName: 'CLICK_HIT',
       index: indexName,

--- a/packages/search/provider.tsx
+++ b/packages/search/provider.tsx
@@ -75,18 +75,8 @@ If passing the algoliaConfig prop to SearchProvider, ensure the following keys a
   }
 
   function logClick(hit) {
-    // --------------
-    // TODO: I was unable to resolve the TypeScript error here.
-    // It seems to be related to "overloads",
-    // which I understand as "the function has many arg signatures",
-    // but I'm not familiar enough with Typescript to understand
-    // how to correctly resolve this issue.
-    // (Note: this file was converted to TypeScript. Prior to
-    // conversion, the searchInsights call was identical and
-    // functioned as expected)
-    // --------------
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+    // @ts-expect-error - the type for this event is wrong, ref: https://github.com/algolia/search-insights.js/issues/271
+    // Fixed in 2.1.0 (cur 1.8.0)
     return searchInsights('clickedObjectIDsAfterSearch', {
       eventName: 'CLICK_HIT',
       index: indexName,

--- a/packages/search/provider.tsx
+++ b/packages/search/provider.tsx
@@ -92,21 +92,33 @@ If passing the algoliaConfig prop to SearchProvider, ensure the following keys a
     }
   }, [apiKey, appId, indexName])
 
+  // Memo-ize the full context value,
+  // if this is not done then the `value` object would
+  // change referentially, likely causing unnecessary re-renders
+  const contextValue = useMemo(() => {
+    return {
+      client,
+      initAlgoliaInsights,
+      logClick,
+      indexName,
+      query,
+      setQuery,
+      isCancelled,
+      setCancelled,
+    }
+  }, [
+    client,
+    initAlgoliaInsights,
+    logClick,
+    indexName,
+    query,
+    setQuery,
+    isCancelled,
+    setCancelled,
+  ])
+
   return (
-    <SearchContext.Provider
-      value={{
-        // Client
-        client,
-        indexName,
-        initAlgoliaInsights,
-        logClick,
-        // State
-        query,
-        setQuery,
-        isCancelled,
-        setCancelled,
-      }}
-    >
+    <SearchContext.Provider value={contextValue}>
       {children}
     </SearchContext.Provider>
   )

--- a/packages/search/types.ts
+++ b/packages/search/types.ts
@@ -1,0 +1,8 @@
+export interface AlgoliaConfigObject {
+  /** The ID of the target Algolia application. */
+  appId?: string
+  /** The name of the index to search. */
+  indexName?: string
+  /** A publishable search-only API key that can access the provided application and index. */
+  searchOnlyApiKey?: string
+}


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/0/1201348169048582/f)
🔍 [Preview Link](https://react-components-git-zssearch-flexibility-hashicorp.vercel.app)

This PR exposes `react-search`'s Algolia configuration as an `algoliaConfig` prop that can be passed to `<SearchProvider />`. This change has been proven out in https://github.com/hashicorp/dev-portal/pull/36. 

---

This change is intended to be non-breaking: the new `algoliaConfig` prop is optional, and `react-search` will continue to use `.env` variables if the `algoliaConfig` prop is not available. If neither form of configuration is available, we'll continue to throw an error (as we did previously if `.env` vars were not present).

This PR also modifies `react-docs-page` to expose the same configuration variable, which is passed to our use of `react-search` in `docs-page`. As with `react-search`, this is a non-breaking feature addition to `docs-page`.

---

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
