### PR TITLE
Dismiss nav dropdown on anchor click

### DIFF
--- a/.changeset/cuddly-impalas-grin.md
+++ b/.changeset/cuddly-impalas-grin.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-subnav': minor
+---
+
+Automatically dismiss open navigation dropdown menus when the user clicks on an anchor element.

--- a/packages/subnav/partials/MenuItemsDefault/index.js
+++ b/packages/subnav/partials/MenuItemsDefault/index.js
@@ -84,7 +84,13 @@ class NavLinkWithDropdown extends React.Component {
     //  If we're not collapsed, and the click is outside the component,
     //  we should ensure that the modal closes
     const isClickOutside = !this.parentRef.current.contains(event.target)
-    if (isClickOutside) this.setState({ isCollapsed: true })
+    //  If we're not collapsed, and the click is on an anchor element with an
+    //  href attribute, we're likely performing a navigation, and should ensure
+    //  that the modal closes
+    const isClickNavigation = event.target.tagName === 'A' && event.target.href
+    if (isClickOutside || isClickNavigation) {
+      this.setState({ isCollapsed: true })
+    }
   }
 
   componentDidMount() {


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1201377046756933/f)
🔍 [Preview Link](https://react-components-git-dsdismiss-subnav-dropdown-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Currently, when a dropdown nav menu item triggers a client-side navigation, the dropdown menu isn't dismissed. This PR updates the click handler for dropdown menu items to dismiss the menu when the clicked on element is an anchor tag with a truthy `href` property.

### Before
https://user-images.githubusercontent.com/88163/141869113-71ef7210-a4de-4558-9d83-56a4d5477936.mp4

### After
https://user-images.githubusercontent.com/88163/141869146-2d9afc25-7a9e-4767-82d1-19b81144e62d.mp4

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
