### PR TITLE
enhancement: Reduce product-download-page card margin

### DIFF
--- a/.changeset/tricky-kiwis-sin.md
+++ b/.changeset/tricky-kiwis-sin.md
@@ -2,4 +2,4 @@
 '@hashicorp/react-product-downloads-page': patch
 ---
 
-Reduce padding above and below the download cards partial
+Reduce margin below the download cards partial

--- a/.changeset/tricky-kiwis-sin.md
+++ b/.changeset/tricky-kiwis-sin.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-product-downloads-page': patch
+---
+
+Reduce padding above and below the download cards partial

--- a/packages/product-download-page/partials/download-cards/style.module.css
+++ b/packages/product-download-page/partials/download-cards/style.module.css
@@ -24,7 +24,7 @@
   }
 
   @media (--medium-up) {
-    margin: 64px 0;
+    margin: 48px 0;
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-column-gap: 48px;

--- a/packages/product-download-page/partials/download-cards/style.module.css
+++ b/packages/product-download-page/partials/download-cards/style.module.css
@@ -24,7 +24,8 @@
   }
 
   @media (--medium-up) {
-    margin: 48px 0;
+    margin-top: 64px;
+    margin-bottom: 48px;
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-column-gap: 48px;


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/0/1200164665926606/f)
🔍 [Preview Link](https://react-components-git-nqdownloader-margin-update-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR reduces the bottom margin of the `.downloadCards` element in the `product-download-page` component, to better align its spacing with the rest of the page.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
