### PR TITLE
feat(docs-page): `navDataPath` to override basePath

### DIFF
--- a/.changeset/empty-tools-press.md
+++ b/.changeset/empty-tools-press.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-page': minor
+---
+
+expose `navDataPath` on DataLoader's "remote" interface

--- a/packages/docs-page/server/index.ts
+++ b/packages/docs-page/server/index.ts
@@ -24,13 +24,15 @@ interface BaseOpts {
 export function getStaticGenerationFunctions(
   opts:
     | ({
-        basePath: string
         strategy: 'remote'
+        basePath: string
+        /** An optional override when `basePath` doesn't match the nav-data file prefix */
+        navDataPath?: string
       } & BaseOpts)
     | ({
+        strategy: 'fs'
         localContentDir: string
         navDataFile: string
-        strategy: 'fs'
       } & BaseOpts)
 ): {
   getStaticPaths: GetStaticPaths

--- a/packages/docs-page/server/loaders/remote-content.ts
+++ b/packages/docs-page/server/loaders/remote-content.ts
@@ -152,9 +152,12 @@ export default class RemoteContentLoader implements DataLoader {
     ].join('/')
 
     const documentPromise = fetchDocument(this.opts.product, fullPath)
+
+    const navDataPath = this.opts.navDataPath || this.opts.basePath
+
     const navDataPromise = cachedFetchNavData(
       this.opts.product,
-      this.opts.basePath,
+      navDataPath,
       versionToFetch
     )
 

--- a/packages/docs-page/server/loaders/remote-content.ts
+++ b/packages/docs-page/server/loaders/remote-content.ts
@@ -16,6 +16,8 @@ import { getPathsFromNavData } from '../get-paths-from-nav-data'
 
 interface RemoteContentLoaderOpts extends DataLoaderOpts {
   basePath: string
+  /** An optional override when `basePath` doesn't match the nav-data file prefix */
+  navDataPath?: string
   enabledVersionedDocs?: boolean
   remarkPlugins?: $TSFixMe[]
   mainBranch?: string // = 'main',
@@ -93,9 +95,12 @@ export default class RemoteContentLoader implements DataLoader {
       this.opts.product
     )
     const latest = versionMetadataList.find((e) => e.isLatest).version
+
+    const navDataPath = this.opts.navDataPath || this.opts.basePath
+
     // Fetch and parse navigation data
     return getPathsFromNavData(
-      (await cachedFetchNavData(this.opts.product, this.opts.basePath, latest))
+      (await cachedFetchNavData(this.opts.product, navDataPath, latest))
         .navData,
       this.opts.paramId
     )


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1201460589940694/f)
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This exposes an optional `navDataPath` to override `basePath` on the 'remote' data-loader interface.

Why? For `sentinel`, the project structure doesn't match the other product repos, and causes data-fetching to logic to break, specifically for nav-data.


Related:
- https://github.com/hashicorp/mktg-content-workflows/pull/87

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
