### PR TITLE
feat(docs-page): add pathToPartials option to fs loader

### DIFF
--- a/.changeset/gold-toys-fry.md
+++ b/.changeset/gold-toys-fry.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-page': minor
+---
+
+Exposes new, optional pathToPartials option for the filesystem loader.

--- a/.changeset/gold-toys-fry.md
+++ b/.changeset/gold-toys-fry.md
@@ -2,4 +2,4 @@
 '@hashicorp/react-docs-page': minor
 ---
 
-Exposes new, optional pathToPartials option for the filesystem loader.
+Exposes new, optional localPartialsDir option for the filesystem loader.

--- a/packages/docs-page/render-page-mdx.js
+++ b/packages/docs-page/render-page-mdx.js
@@ -9,14 +9,14 @@ async function renderPageMdx(
     mdxContentHook = (c) => c,
     remarkPlugins = [],
     scope,
-    pathToPartials = 'content/partials',
+    localPartialsDir = 'content/partials',
   } = {}
 ) {
   const { data: frontMatter, content: rawContent } = grayMatter(mdxFileString)
   const content = mdxContentHook(rawContent)
   const mdxSource = await serialize(content, {
     mdxOptions: markdownDefaults({
-      resolveIncludes: path.join(process.cwd(), pathToPartials),
+      resolveIncludes: path.join(process.cwd(), localPartialsDir),
       addRemarkPlugins: remarkPlugins,
     }),
     scope,

--- a/packages/docs-page/render-page-mdx.js
+++ b/packages/docs-page/render-page-mdx.js
@@ -5,13 +5,18 @@ import grayMatter from 'gray-matter'
 
 async function renderPageMdx(
   mdxFileString,
-  { mdxContentHook = (c) => c, remarkPlugins = [], scope } = {}
+  {
+    mdxContentHook = (c) => c,
+    remarkPlugins = [],
+    scope,
+    pathToPartials = 'content/partials',
+  } = {}
 ) {
   const { data: frontMatter, content: rawContent } = grayMatter(mdxFileString)
   const content = mdxContentHook(rawContent)
   const mdxSource = await serialize(content, {
     mdxOptions: markdownDefaults({
-      resolveIncludes: path.join(process.cwd(), 'content/partials'),
+      resolveIncludes: path.join(process.cwd(), pathToPartials),
       addRemarkPlugins: remarkPlugins,
     }),
     scope,

--- a/packages/docs-page/server/index.ts
+++ b/packages/docs-page/server/index.ts
@@ -19,8 +19,6 @@ interface BaseOpts {
   revalidate?: number
   product: string
   scope?: Record<string, $TSFixMe>
-  /** Location of partials relative to the cwd. Passed to our resolveIncludes plugin.  */
-  pathToPartials?: string // = 'content/partials'
 }
 
 export function getStaticGenerationFunctions(
@@ -33,6 +31,8 @@ export function getStaticGenerationFunctions(
         localContentDir: string
         navDataFile: string
         strategy: 'fs'
+        /** Location of partials relative to the cwd. Passed to our resolveIncludes plugin.  */
+        pathToPartials?: string // = 'content/partials'
       } & BaseOpts)
 ): {
   getStaticPaths: GetStaticPaths

--- a/packages/docs-page/server/index.ts
+++ b/packages/docs-page/server/index.ts
@@ -35,7 +35,7 @@ export function getStaticGenerationFunctions(
          * relative to process.cwd().
          * Passed to our resolveIncludes plugin.
          * Defaults to "content/partials". */
-        pathToPartials?: string
+        localPartialsDir?: string
       } & BaseOpts)
 ): {
   getStaticPaths: GetStaticPaths

--- a/packages/docs-page/server/index.ts
+++ b/packages/docs-page/server/index.ts
@@ -31,8 +31,11 @@ export function getStaticGenerationFunctions(
         localContentDir: string
         navDataFile: string
         strategy: 'fs'
-        /** Location of partials relative to the cwd. Passed to our resolveIncludes plugin.  */
-        pathToPartials?: string // = 'content/partials'
+        /** Optional location of the partials directory
+         * relative to process.cwd().
+         * Passed to our resolveIncludes plugin.
+         * Defaults to "content/partials". */
+        pathToPartials?: string
       } & BaseOpts)
 ): {
   getStaticPaths: GetStaticPaths

--- a/packages/docs-page/server/index.ts
+++ b/packages/docs-page/server/index.ts
@@ -19,6 +19,8 @@ interface BaseOpts {
   revalidate?: number
   product: string
   scope?: Record<string, $TSFixMe>
+  /** Location of partials relative to the cwd. Passed to our resolveIncludes plugin.  */
+  pathToPartials?: string // = 'content/partials'
 }
 
 export function getStaticGenerationFunctions(

--- a/packages/docs-page/server/loaders/file-system.ts
+++ b/packages/docs-page/server/loaders/file-system.ts
@@ -18,6 +18,8 @@ interface FileSystemLoaderOpts extends DataLoaderOpts {
   mainBranch?: string // = 'main',
   remarkPlugins?: $TSFixMe[]
   scope?: Record<string, $TSFixMe>
+  /** Location of partials relative to the cwd. Passed to our resolveIncludes plugin.  */
+  pathToPartials?: string // = 'content/partials'
 }
 
 export default class FileSystemLoader implements DataLoader {
@@ -43,6 +45,7 @@ export default class FileSystemLoader implements DataLoader {
       renderPageMdx(mdx, {
         remarkPlugins: this.opts.remarkPlugins,
         scope: this.opts.scope,
+        pathToPartials: this.opts.pathToPartials,
       })
     // Build the currentPath from page parameters
     const currentPath = params[this.opts.paramId]

--- a/packages/docs-page/server/loaders/file-system.ts
+++ b/packages/docs-page/server/loaders/file-system.ts
@@ -18,8 +18,7 @@ interface FileSystemLoaderOpts extends DataLoaderOpts {
   mainBranch?: string // = 'main',
   remarkPlugins?: $TSFixMe[]
   scope?: Record<string, $TSFixMe>
-  /** Location of partials relative to the cwd. Passed to our resolveIncludes plugin.  */
-  pathToPartials?: string // = 'content/partials'
+  pathToPartials?: string
 }
 
 export default class FileSystemLoader implements DataLoader {

--- a/packages/docs-page/server/loaders/file-system.ts
+++ b/packages/docs-page/server/loaders/file-system.ts
@@ -18,7 +18,7 @@ interface FileSystemLoaderOpts extends DataLoaderOpts {
   mainBranch?: string // = 'main',
   remarkPlugins?: $TSFixMe[]
   scope?: Record<string, $TSFixMe>
-  pathToPartials?: string
+  localPartialsDir?: string
 }
 
 export default class FileSystemLoader implements DataLoader {
@@ -44,7 +44,7 @@ export default class FileSystemLoader implements DataLoader {
       renderPageMdx(mdx, {
         remarkPlugins: this.opts.remarkPlugins,
         scope: this.opts.scope,
-        pathToPartials: this.opts.pathToPartials,
+        localPartialsDir: this.opts.localPartialsDir,
       })
     // Build the currentPath from page parameters
     const currentPath = params[this.opts.paramId]


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1201465687264527/f)
🔍 [Preview Link](https://react-components-git-zsdocs-page-partials-fix-hashicorp.vercel.app)

---

This PR adds support to `docs-page` server utilities for a new, optional `localPartialsDir` option, when using the `fs` loader.

This option allows better support for varied `content/partials` folder locations relative to the current working directory.

Specifically, in the proposed `dev-portal` local preview setup within product repositories:
- our working directory is `website/cloned-dev-portal`
- the content partials we want to load are in `website/cloned-dev-portal/content/partials`
While we can use `docs-page`'s `localContentDir` option to configuration the filesystem location of our main content files as expected, the current version of `docs-page` has a strictly hard-coded partials location, which in this case would be `website/cloned-dev-portal/content/partials`. In order to work around this, we would have to set up content watcher and sync scripts (eg via `chokidar`) to sync content into the cloned repository.

By exposing this flexibility with `localPartialsDir`, we can avoid the need for a watcher. And, we match the expected `localContentDir` configuration option. Consumers of `docs-page` will now be able to load both their content and their partials from arbitrary locations.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
