### PR TITLE
Constrain iframes to width of container

### DIFF
--- a/.changeset/odd-numbers-lay.md
+++ b/.changeset/odd-numbers-lay.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-content': minor
+---
+
+Constrain the width of iframe elements to the width of their container

--- a/packages/content/style.module.css
+++ b/packages/content/style.module.css
@@ -10,6 +10,7 @@
   composes: codeInline from './styles/code-inline.module.css';
   composes: headings from './styles/headings.module.css';
   composes: hr from './styles/hr.module.css';
+  composes: iframe from './styles/iframe.module.css';
   composes: img from './styles/img.module.css';
   composes: olUlLists from './styles/ol-ul-lists.module.css';
   composes: p from './styles/p.module.css';

--- a/packages/content/styles/iframe.module.css
+++ b/packages/content/styles/iframe.module.css
@@ -1,0 +1,6 @@
+.iframe {
+  & iframe:not([class]) {
+    margin: 1rem auto;
+    max-width: 100%;
+  }
+}


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/0/1201476871035774/f)
🔍 [Preview Link](https://react-components-git-dscontent-iframe-hashicorp.vercel.app/components/content?id=LTEyMjU5MjYwNTA&values=IjxDb250ZW50XG4gIHByb2R1Y3Q9J3RlcnJhZm9ybSdcbiAgY29udGVudD17PGlmcmFtZSBzcmM9XCJodHRwczovL3d3dy55b3V0dWJlLmNvbS9lbWJlZC9oOTcwWkJnS0lOZ1wiIGZyYW1lQm9yZGVyPXswfSBhbGxvd0Z1bGxTY3JlZW4gd2lkdGg9ezE5MjB9IGhlaWdodD17MTA4MH0gLz59XG4vPiI%3D)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR adds a `max-width: 100%` rule to iframe elements so that they don't cause the content container to be wider than expected.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
