### PR TITLE
fix: dismiss overflow dropdown on anchor click

### DIFF
--- a/.changeset/eighty-pigs-agree.md
+++ b/.changeset/eighty-pigs-agree.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-subnav': minor
+---
+
+Automatically dismiss open overflow navigation dropdown menus when the user clicks on an anchor element

--- a/packages/subnav/partials/MenuItemsOverflow/index.js
+++ b/packages/subnav/partials/MenuItemsOverflow/index.js
@@ -23,7 +23,13 @@ class MenuItemsOverflow extends React.Component {
     //  If we're not collapsed, and the click is outside the component,
     //  we should ensure that the modal closes
     const isClickOutside = !this.parentRef.current.contains(event.target)
-    if (isClickOutside) this.setState({ isCollapsed: true })
+    //  If we're not collapsed, and the click is on an anchor element with an
+    //  href attribute, we're likely performing a navigation, and should ensure
+    //  that the modal closes
+    const isClickNavigation = event.target.tagName === 'A' && event.target.href
+    if (isClickOutside || isClickNavigation) {
+      this.setState({ isCollapsed: true })
+    }
   }
 
   componentDidMount() {


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/0/1201476871035773/f)
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This extends the behavior added in https://github.com/hashicorp/react-components/pull/426 to the MenuItemsOverflow component, which is used on mobile devices.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
