### PR TITLE
fix: only set aria-activedescendant to an active ID

### DIFF
--- a/.changeset/five-comics-perform.md
+++ b/.changeset/five-comics-perform.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-search': patch
+---
+
+Fix usage of aria-activedescendant property

--- a/packages/search/index.test.js
+++ b/packages/search/index.test.js
@@ -51,7 +51,7 @@ describe('<Search />', () => {
     )
     const input = screen.getByRole('searchbox')
     expect(input).toHaveAttribute('id', SEARCH_BOX_ID)
-    expect(input).toHaveAttribute('aria-activedescendant', '')
+    expect(input).not.toHaveAttribute('aria-activedescendant')
     expect(container.querySelector('.c-hits')).toBeNull()
   })
 })

--- a/packages/search/search-box.js
+++ b/packages/search/search-box.js
@@ -89,7 +89,7 @@ function SearchBox({
           onKeyDown={onSearchBoxKeyDown}
           aria-autocomplete="list"
           aria-controls={SEARCH_RESULTS_ID}
-          aria-activedescendant={activeHit > 0 ? `hit-${activeHit}` : ''}
+          aria-activedescendant={activeHit > 0 ? `hit-${activeHit}` : undefined}
           data-heap-track={heapId}
         />
         <button


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

The `aria-activedescendant` must be set to an element ID as defined by the [spec](https://www.w3.org/TR/2017/REC-wai-aria-1.1-20171214/#aria-activedescendant). Setting it to an empty string renders the prop in the HTML, whereas setting it to `undefined` results in the property not being set on the element.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
