### PR TITLE
Allow caller to override `githubFileUrl` in `generateStaticProps`

### DIFF
--- a/.changeset/hot-swans-think.md
+++ b/.changeset/hot-swans-think.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-page': minor
+---
+
+Allow caller to override githubFileUrl generation

--- a/packages/docs-page/server/index.ts
+++ b/packages/docs-page/server/index.ts
@@ -134,6 +134,7 @@ export interface GenerateStaticPropsContext {
   scope?: any // optional, I think?
   paramId?: string
   basePath: string // 'docs'
+  githubFileUrl?: (path: string) => string
 }
 
 /**
@@ -148,6 +149,7 @@ export function generateStaticProps({
   remarkPlugins,
   scope,
   mainBranch,
+  githubFileUrl,
 }: GenerateStaticPropsContext) {
   const loader = new FileSystemLoader({
     navDataFile,
@@ -157,6 +159,7 @@ export function generateStaticProps({
     scope,
     remarkPlugins,
     mainBranch,
+    githubFileUrl,
   })
 
   return loader.loadStaticProps({ params })

--- a/packages/docs-page/server/loaders/file-system.test.ts
+++ b/packages/docs-page/server/loaders/file-system.test.ts
@@ -57,4 +57,39 @@ describe('FileSystemLoader', () => {
     `
     )
   })
+
+  test('uses provided githubFileUrl if provided', async () => {
+    const l = new FileSystemLoader({
+      navDataFile: 'test',
+      localContentDir: CONTENT_DIR,
+      product: 'waypoint',
+      githubFileUrl(p) {
+        return `https://hashicorp.com/${p}`
+      },
+    })
+    const props = await l.loadStaticProps({ params: {} })
+
+    expect(props).toMatchInlineSnapshot(
+      {
+        mdxSource: { compiledSource: expect.any(String) },
+        navData: expect.any(Array),
+      },
+      `
+      Object {
+        "currentPath": "",
+        "frontMatter": Object {
+          "description": "Welcome to the intro guide to Vault! This guide is the best place to start with Vault. We cover what Vault is, what problems it can solve, how it compares to existing software, and contains a quick start for using Vault.",
+          "page_title": "Introduction",
+        },
+        "githubFileUrl": "https://hashicorp.com/packages/docs-page/server/__fixtures__/index.mdx",
+        "mdxSource": Object {
+          "compiledSource": Any<String>,
+          "scope": Object {},
+        },
+        "navData": Any<Array>,
+        "versions": Array [],
+      }
+    `
+    )
+  })
 })

--- a/packages/docs-page/server/loaders/file-system.ts
+++ b/packages/docs-page/server/loaders/file-system.ts
@@ -19,6 +19,7 @@ interface FileSystemLoaderOpts extends DataLoaderOpts {
   remarkPlugins?: $TSFixMe[]
   scope?: Record<string, $TSFixMe>
   localPartialsDir?: string
+  githubFileUrl?: (path: string) => string
 }
 
 export default class FileSystemLoader implements DataLoader {
@@ -70,7 +71,9 @@ export default class FileSystemLoader implements DataLoader {
     const normalizedFilePath = navNode.filePath
       .split(path.sep)
       .join(path.posix.sep)
-    const githubFileUrl = `https://github.com/hashicorp/${this.opts.product}/blob/${this.opts.mainBranch}/website/${normalizedFilePath}`
+    const githubFileUrl = this.opts.githubFileUrl
+      ? this.opts.githubFileUrl(normalizedFilePath)
+      : `https://github.com/hashicorp/${this.opts.product}/blob/${this.opts.mainBranch}/website/${normalizedFilePath}`
     // Return all the props
     return {
       currentPath,


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR allows the caller to pass in a `githubFileUrl` function to the `@hashicorp/react-docs-page` `generateStaticProps` method, which overrides the default `githubFileUrl` property on the returned pages. This gives special projects (like terraform-website) the ability to link to docs stored outside a `website` folder.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
