### PR TITLE
enh: Add support for 'hashicorp' titleLink logo

### DIFF
--- a/.changeset/silver-spies-dream.md
+++ b/.changeset/silver-spies-dream.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-subnav': patch
+---
+
+Add support for adding the HashiCorp primary logo in TitleLink via the 'hashicorp' string, similarly to other products.

--- a/packages/subnav/partials/TitleLink/index.js
+++ b/packages/subnav/partials/TitleLink/index.js
@@ -6,6 +6,7 @@ import classNames from 'classnames'
 /* main logos, for light theme */
 import ConsulLogo from '@hashicorp/mktg-logos/product/consul/primary/color.svg?include'
 import ConsulLogoAttr from '@hashicorp/mktg-logos/product/consul/primary/attributed_color.svg?include'
+import HashiCorpLogo from '@hashicorp/mktg-logos/corporate/hashicorp/primary/black.svg?include'
 import HCPLogo from '@hashicorp/mktg-logos/product/hcp/primary/black.svg?include'
 import NomadLogo from '@hashicorp/mktg-logos/product/nomad/primary/color.svg?include'
 import PackerLogo from '@hashicorp/mktg-logos/product/packer/primary/color.svg?include'
@@ -19,6 +20,7 @@ import TerraformCloudLogo from '@hashicorp/mktg-logos/product/terraform-cloud/pr
 /* white logos, for dark theme */
 import ConsulLogoWhite from '@hashicorp/mktg-logos/product/consul/primary/colorwhite.svg?include'
 import ConsulLogoWhiteAttr from '@hashicorp/mktg-logos/product/consul/primary/attributed_colorwhite.svg?include'
+import HashiCorpLogoWhite from '@hashicorp/mktg-logos/corporate/hashicorp/primary/white.svg?include'
 import HCPLogoWhite from '@hashicorp/mktg-logos/product/hcp/primary/white.svg?include'
 import NomadLogoWhite from '@hashicorp/mktg-logos/product/nomad/primary/colorwhite.svg?include'
 import PackerLogoWhite from '@hashicorp/mktg-logos/product/packer/primary/colorwhite.svg?include'
@@ -35,6 +37,7 @@ const logoDict = {
     boundary: BoundaryLogo,
     consul: ConsulLogo,
     hashiCorpConsul: ConsulLogoAttr,
+    hashicorp: HashiCorpLogo,
     hcp: HCPLogo,
     nomad: NomadLogo,
     packer: PackerLogo,
@@ -48,6 +51,7 @@ const logoDict = {
   dark: {
     boundary: BoundaryLogoWhite,
     consul: ConsulLogoWhite,
+    hashicorp: HashiCorpLogoWhite,
     hashiCorpConsul: ConsulLogoWhiteAttr,
     hcp: HCPLogoWhite,
     nomad: NomadLogoWhite,


### PR DESCRIPTION
🔍 [Preview Link](https://react-components-git-nqsubnav-enable-hashicorp-logo-hashicorp.vercel.app/components/subnav)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR adds support for using our company logo in the `<TitleLink />` component of `<Subnav />`.  Now a consumer can pass `titleLink={{ text: 'hashicorp' }}` to the `<Subnav />` and the HashiCorp logo will appear, much like how our other product options operate.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
