### PR TITLE
update wording on 32/64-bit arch downloads

### DIFF
--- a/.changeset/afraid-penguins-yell.md
+++ b/.changeset/afraid-penguins-yell.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-product-downloads-page': minor
+---
+
+change wording on 32 and 64 bit downloads

--- a/packages/product-download-page/utils/downloader.ts
+++ b/packages/product-download-page/utils/downloader.ts
@@ -27,11 +27,9 @@ export function prettyArch(arch: string): string {
     case 'i386':
     case '686':
     case '386':
-      return '32-bit'
     case 'x86_64':
     case '86_64':
     case 'amd64':
-      return '64-bit'
     default:
       if (/-/.test(arch)) {
         const parts = arch.split(/-(.+)/)


### PR DESCRIPTION
As discussed with the release engineering team internally ([ref](https://hashicorp.slack.com/archives/CKJV0JLRX/p1639432100139300)), removing the pretty arch specifiers for 32/64 bit on downloads pages!
