### PR TITLE
Calculate whether to show banner on initial render

### DIFF
--- a/.changeset/fast-ravens-ring.md
+++ b/.changeset/fast-ravens-ring.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-alert-banner': patch
+---
+
+Calculate whether to show banner on initial render

--- a/packages/alert-banner/index.tsx
+++ b/packages/alert-banner/index.tsx
@@ -39,7 +39,14 @@ function AlertBanner({
   url,
 }: AlertBannerProps): React.ReactElement {
   const dismissalCookieId = `banner_${name || slugify(text, { lower: true })}`
-  const [isShown, setIsShown] = useState(true)
+  // Set isShown to true/false based on the expirationDate initially. This
+  // ensures that the banner gets the correct CSS classes during SSR, which
+  // prevents CLS caused by rendering the banner, determining that it should be
+  // hidden, and then hiding it. This is necessary because Next.js doesn't run
+  // useEffect hooks during SSR.
+  const [isShown, setIsShown] = useState(
+    !(expirationDate && Date.now() > Date.parse(expirationDate))
+  )
   const { themeClass } = useProductMeta(product)
 
   /**


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-dsalert-initial-display-hashicorp.vercel.app/)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR updates `AlertBanner` to use an initial state value based on the expiration date, rather than always defaulting to `true`. This ensures that the banner isn't included in SSR HTML after the `expirationDate` has passed. This is because Next.js doesn't run `useEffect` hooks during SSR.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
