### PR TITLE
chore: Hide VersionAlert on DocsPage

### DIFF
--- a/.changeset/tough-moose-grab.md
+++ b/.changeset/tough-moose-grab.md
@@ -1,0 +1,13 @@
+---
+'@hashicorp/react-docs-page': minor
+'@hashicorp/react-glossary-page': patch
+---
+
+DocsPage
+
+- Rename `DocsPageWrapper` to `DocsPageInner`
+- Hide `VersionAlert` if version in path is "latest"
+
+GlossaryPage
+
+- Update internal import

--- a/packages/docs-page/docs.mdx
+++ b/packages/docs-page/docs.mdx
@@ -21,9 +21,12 @@ We have a lot of docs sites, all of which render content in exactly the same way
       currentPath: componentProps.staticProps.properties.currentPath.testValue,
       navData: componentProps.staticProps.properties.navData.testValue,
       versions: [
-        { name: 'latest', label: 'v0.5.2 (latest)' },
-        { name: 'v0.4.0', label: 'v0.4.0' },
-        { name: 'v0.1.0', label: 'v0.1.0' },
+        { name: 'latest', label: 'v0.6.x (latest)' },
+        { name: 'v0.5.x', label: 'v0.5.x' },
+        { name: 'v0.4.x', label: 'v0.4.x' },
+        { name: 'v0.3.x', label: 'v0.3.x' },
+        { name: 'v0.2.x', label: 'v0.2.x' },
+        { name: 'v0.1.x', label: 'v0.1.x' },
       ],
     },
   }}

--- a/packages/docs-page/docs.mdx
+++ b/packages/docs-page/docs.mdx
@@ -21,12 +21,17 @@ We have a lot of docs sites, all of which render content in exactly the same way
       currentPath: componentProps.staticProps.properties.currentPath.testValue,
       navData: componentProps.staticProps.properties.navData.testValue,
       versions: [
-        { name: 'latest', label: 'v0.6.x (latest)' },
-        { name: 'v0.5.x', label: 'v0.5.x' },
-        { name: 'v0.4.x', label: 'v0.4.x' },
-        { name: 'v0.3.x', label: 'v0.3.x' },
-        { name: 'v0.2.x', label: 'v0.2.x' },
-        { name: 'v0.1.x', label: 'v0.1.x' },
+        {
+          name: 'latest',
+          label: 'v0.6.x (latest)',
+          isLatest: true,
+          version: 'v0.6.x',
+        },
+        { name: 'v0.5.x', label: 'v0.5.x', isLatest: false, version: 'v0.5.x' },
+        { name: 'v0.4.x', label: 'v0.4.x', isLatest: false, version: 'v0.4.x' },
+        { name: 'v0.3.x', label: 'v0.3.x', isLatest: false, version: 'v0.3.x' },
+        { name: 'v0.2.x', label: 'v0.2.x', isLatest: false, version: 'v0.2.x' },
+        { name: 'v0.1.x', label: 'v0.1.x', isLatest: false, version: 'v0.1.x' },
       ],
     },
   }}

--- a/packages/docs-page/index.test.tsx
+++ b/packages/docs-page/index.test.tsx
@@ -128,12 +128,17 @@ describe('<DocsPage />', () => {
 
   describe('when versioned docs is enabled', () => {
     const versions = [
-      { name: 'latest', label: 'v0.6.x (latest)' },
-      { name: 'v0.5.x', label: 'v0.5.x' },
-      { name: 'v0.4.x', label: 'v0.4.x' },
-      { name: 'v0.3.x', label: 'v0.3.x' },
-      { name: 'v0.2.x', label: 'v0.2.x' },
-      { name: 'v0.1.x', label: 'v0.1.x' },
+      {
+        name: 'latest',
+        label: 'v0.6.x (latest)',
+        isLatest: true,
+        version: 'v0.6.x',
+      },
+      { name: 'v0.5.x', label: 'v0.5.x', isLatest: false, version: 'v0.5.x' },
+      { name: 'v0.4.x', label: 'v0.4.x', isLatest: false, version: 'v0.4.x' },
+      { name: 'v0.3.x', label: 'v0.3.x', isLatest: false, version: 'v0.3.x' },
+      { name: 'v0.2.x', label: 'v0.2.x', isLatest: false, version: 'v0.2.x' },
+      { name: 'v0.1.x', label: 'v0.1.x', isLatest: false, version: 'v0.1.x' },
     ]
 
     it('should allow crawlers to index latest pages', () => {

--- a/packages/docs-page/index.tsx
+++ b/packages/docs-page/index.tsx
@@ -22,7 +22,7 @@ import LoadingSkeleton from './components/loading-skeleton'
 import useIsMobile from './use-is-mobile'
 import s from './style.module.css'
 
-interface DocsPageWrapperProps {
+interface DocsPageInnerProps {
   canonicalUrl: string
   description: string
   navData: NavData
@@ -38,7 +38,7 @@ interface DocsPageWrapperProps {
   algoliaConfig?: AlgoliaConfigObject
 }
 
-export const DocsPageWrapper: FunctionComponent<DocsPageWrapperProps> = ({
+export const DocsPageInner: FunctionComponent<DocsPageInnerProps> = ({
   canonicalUrl,
   children,
   description,
@@ -56,6 +56,9 @@ export const DocsPageWrapper: FunctionComponent<DocsPageWrapperProps> = ({
   const isMobile = useIsMobile()
   const { asPath } = useRouter()
   const versionInPath = getVersionFromPath(asPath)
+
+  const versionIsLatest =
+    versionInPath && versions?.[0]?.label.includes(versionInPath)
 
   // TEMPORARY (https://app.asana.com/0/1100423001970639/1160656182754009)
   // activates the "jump to section" feature
@@ -80,9 +83,10 @@ export const DocsPageWrapper: FunctionComponent<DocsPageWrapperProps> = ({
     </div>
   ) : null
 
-  const versionAlert = showVersionSelect ? (
-    <VersionAlert product={name} />
-  ) : null
+  const versionAlert =
+    !versionIsLatest && showVersionSelect ? (
+      <VersionAlert product={name} />
+    ) : null
 
   return (
     <div id="p-docs">
@@ -199,7 +203,7 @@ export default function DocsPage({
   if (router.isFallback) return <LoadingSkeleton />
 
   return (
-    <DocsPageWrapper
+    <DocsPageInner
       canonicalUrl={frontMatter.canonical_url}
       description={frontMatter.description}
       githubFileUrl={githubFileUrl}
@@ -214,6 +218,6 @@ export default function DocsPage({
       algoliaConfig={algoliaConfig}
     >
       {content}
-    </DocsPageWrapper>
+    </DocsPageInner>
   )
 }

--- a/packages/docs-page/index.tsx
+++ b/packages/docs-page/index.tsx
@@ -21,6 +21,7 @@ import temporary_injectJumpToSection from './temporary_jump-to-section'
 import LoadingSkeleton from './components/loading-skeleton'
 import useIsMobile from './use-is-mobile'
 import s from './style.module.css'
+import type { VersionSelectItem } from './server/loaders/remote-content'
 
 interface DocsPageInnerProps {
   canonicalUrl: string
@@ -34,7 +35,7 @@ interface DocsPageInnerProps {
   /** @deprecated */
   showEditPage: boolean
   showVersionSelect: boolean
-  versions: { name: string; label: string }[]
+  versions: VersionSelectItem[]
   algoliaConfig?: AlgoliaConfigObject
 }
 
@@ -57,8 +58,10 @@ export const DocsPageInner: FunctionComponent<DocsPageInnerProps> = ({
   const { asPath } = useRouter()
   const versionInPath = getVersionFromPath(asPath)
 
+  // Future: Account for `tip` version
   const versionIsLatest =
-    versionInPath && versions?.[0]?.label.includes(versionInPath)
+    versionInPath &&
+    versions?.find((v) => v.isLatest)?.version === versionInPath
 
   // TEMPORARY (https://app.asana.com/0/1100423001970639/1160656182754009)
   // activates the "jump to section" feature
@@ -170,7 +173,7 @@ export interface DocsPageProps {
     currentPath: string
     navData: NavData
     githubFileUrl: string
-    versions: { name: string; label: string }[]
+    versions: VersionSelectItem[]
   }
 }
 

--- a/packages/docs-page/server/loaders/remote-content.test.ts
+++ b/packages/docs-page/server/loaders/remote-content.test.ts
@@ -64,34 +64,40 @@ describe('RemoteContentLoader', () => {
         navData: expect.any(Array),
       },
       `
-      Object {
-        "currentPath": "",
-        "frontMatter": Object {
-          "layout": "commands",
-          "page_title": "Waypoint Commands (CLI)",
-        },
-        "githubFileUrl": "https://github.com/hashicorp/waypoint/blob/main/website/content/commands/index.mdx",
-        "mdxSource": Object {
-          "compiledSource": Any<String>,
-          "scope": Object {},
-        },
-        "navData": Any<Array>,
-        "versions": Array [
-          Object {
-            "label": "v0.5.2 (latest)",
-            "name": "latest",
-          },
-          Object {
-            "label": "v0.4.x",
-            "name": "v0.4.x",
-          },
-          Object {
-            "label": "v0.3.x",
-            "name": "v0.3.x",
-          },
-        ],
-      }
-    `
+Object {
+  "currentPath": "",
+  "frontMatter": Object {
+    "layout": "commands",
+    "page_title": "Waypoint Commands (CLI)",
+  },
+  "githubFileUrl": "https://github.com/hashicorp/waypoint/blob/main/website/content/commands/index.mdx",
+  "mdxSource": Object {
+    "compiledSource": Any<String>,
+    "scope": Object {},
+  },
+  "navData": Any<Array>,
+  "versions": Array [
+    Object {
+      "isLatest": true,
+      "label": "v0.5.2 (latest)",
+      "name": "latest",
+      "version": "v0.5.x",
+    },
+    Object {
+      "isLatest": false,
+      "label": "v0.4.x",
+      "name": "v0.4.x",
+      "version": "v0.4.x",
+    },
+    Object {
+      "isLatest": false,
+      "label": "v0.3.x",
+      "name": "v0.3.x",
+      "version": "v0.3.x",
+    },
+  ],
+}
+`
     )
   })
 
@@ -146,32 +152,46 @@ describe('mapVersionList', () => {
     expect(versionList).toMatchInlineSnapshot(`
 Array [
   Object {
+    "isLatest": false,
     "label": "v2.11.x",
     "name": "v2.11.x",
+    "version": "v2.11.x",
   },
   Object {
+    "isLatest": false,
     "label": "v1.10.x",
     "name": "v1.10.x",
+    "version": "v1.10.x",
   },
   Object {
+    "isLatest": false,
     "label": "v1.9.x",
     "name": "v1.9.x",
+    "version": "v1.9.x",
   },
   Object {
+    "isLatest": false,
     "label": "v1.1.x",
     "name": "v1.1.x",
+    "version": "v1.1.x",
   },
   Object {
+    "isLatest": false,
     "label": "v0.11.x",
     "name": "v0.11.x",
+    "version": "v0.11.x",
   },
   Object {
+    "isLatest": false,
     "label": "v0.10.x",
     "name": "v0.10.x",
+    "version": "v0.10.x",
   },
   Object {
+    "isLatest": false,
     "label": "v0.9.x",
     "name": "v0.9.x",
+    "version": "v0.9.x",
   },
 ]
 `)
@@ -179,20 +199,26 @@ Array [
 
   test('should map a list of version-metadata to a format for <VersionSelect/>', () => {
     expect(versionList).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "label": "v0.5.2 (latest)",
-          "name": "latest",
-        },
-        Object {
-          "label": "v0.4.x",
-          "name": "v0.4.x",
-        },
-        Object {
-          "label": "v0.3.x",
-          "name": "v0.3.x",
-        },
-      ]
-    `)
+Array [
+  Object {
+    "isLatest": true,
+    "label": "v0.5.2 (latest)",
+    "name": "latest",
+    "version": "v0.5.x",
+  },
+  Object {
+    "isLatest": false,
+    "label": "v0.4.x",
+    "name": "v0.4.x",
+    "version": "v0.4.x",
+  },
+  Object {
+    "isLatest": false,
+    "label": "v0.3.x",
+    "name": "v0.3.x",
+    "version": "v0.3.x",
+  },
+]
+`)
   })
 })

--- a/packages/docs-page/server/loaders/remote-content.ts
+++ b/packages/docs-page/server/loaders/remote-content.ts
@@ -37,9 +37,11 @@ interface VersionMetadataItem {
   fullPath: string
 }
 
-interface VersionSelectItem {
+export interface VersionSelectItem {
   name: string
   label: string
+  version: string
+  isLatest: boolean
 }
 
 const moizeOpts: Options = { isPromise: true, maxSize: Infinity }
@@ -69,6 +71,8 @@ export function mapVersionList(
       return {
         name: isLatest ? 'latest' : version,
         label: isLatest ? `${displayValue} (latest)` : displayValue,
+        isLatest: isLatest || false,
+        version,
       }
     })
 
@@ -121,8 +125,9 @@ export default class RemoteContentLoader implements DataLoader {
       params![this.opts.paramId!] as string[]
     )
 
-    const versionMetadataList: VersionMetadataItem[] =
-      await cachedFetchVersionMetadataList(this.opts.product)
+    const versionMetadataList: VersionMetadataItem[] = await cachedFetchVersionMetadataList(
+      this.opts.product
+    )
     // remove trailing index to ensure we fetch the right document from the DB
     const pathParamsNoIndex = paramsNoVersion.filter(
       (param, idx, arr) => !(param === 'index' && idx === arr.length - 1)

--- a/packages/glossary-page/index.js
+++ b/packages/glossary-page/index.js
@@ -1,5 +1,5 @@
 import { MDXRemote } from 'next-mdx-remote'
-import { DocsPageWrapper } from '@hashicorp/react-docs-page'
+import { DocsPageInner } from '@hashicorp/react-docs-page'
 import generateComponents from '@hashicorp/react-docs-page/components'
 import s from './style.module.css'
 
@@ -22,7 +22,7 @@ export default function GlossaryPage({
   staticProps: { mdxSource, terms, navData, githubFileUrl },
 }) {
   return (
-    <DocsPageWrapper
+    <DocsPageInner
       navData={navData}
       description="Glossary"
       filePath="glossary"
@@ -47,6 +47,6 @@ export default function GlossaryPage({
           components={generateComponents(product.name, additionalComponents)}
         />
       </>
-    </DocsPageWrapper>
+    </DocsPageInner>
   )
 }


### PR DESCRIPTION
- chore(DocsPage): hide VersionAlert
- chore: changeset

🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1201619796458628/f)
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This updates `DocsPage` to **not** display the `VersionAlert` if the version in the path happens to be the "latest" version

Depends on 
- https://github.com/hashicorp/mktg-content-workflows/pull/103
- manually update DB data

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
