### PR TITLE
fix(react-content): Fix mismatch between table width and child element widths

### DIFF
--- a/.changeset/spicy-geckos-type.md
+++ b/.changeset/spicy-geckos-type.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-content': patch
+---
+
+Update table styles so that the top-level table width and child table element widths do not get mismatched, while still retaining the max-width and x-axis scroll.

--- a/packages/content/styles/table.module.css
+++ b/packages/content/styles/table.module.css
@@ -1,13 +1,15 @@
 .table {
   & table {
-    display: inline-block;
+    display: block;
     overflow-x: auto;
     border-collapse: collapse;
     border-spacing: 0;
     border: 1px solid #ddd;
     border-right: 0;
     background-color: transparent;
+    width: max-content;
     max-width: 100%;
+    margin-bottom: 20px;
 
     & th {
       text-align: left;

--- a/packages/content/styles/table.module.css
+++ b/packages/content/styles/table.module.css
@@ -1,15 +1,13 @@
 .table {
   & table {
-    display: block;
+    display: inline-block;
     overflow-x: auto;
     border-collapse: collapse;
     border-spacing: 0;
     border: 1px solid #ddd;
     border-right: 0;
     background-color: transparent;
-    width: 100%;
     max-width: 100%;
-    margin-bottom: 20px;
 
     & th {
       text-align: left;


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

The adjustment to add x-axis overflow scrolling on tables caused some weird behavior:

![Screen Shot 2022-01-14 at 9 47 30 AM](https://user-images.githubusercontent.com/1289701/149544002-ffc3dec9-2aca-4b47-993a-e0fcb9b8168c.png)
(see https://www.consul.io/commands/join)

Largely this appears to be because of the change to `display: block` so that we could apply a `max-width`, but this is causing other issues.

I've changed the display to `inline-block`, which appears to fix the width issue while still allowing us to retain the x-axis scrolling.

I had to remove the `margin-bottom` because margin collapsing does not apply to `inline-block` elements, per spec.

After:
![Screen Shot 2022-01-14 at 9 50 00 AM](https://user-images.githubusercontent.com/1289701/149544427-c2b2a1aa-2fb0-45b0-8296-fece41e93a4d.png)
![Screen Shot 2022-01-14 at 9 49 43 AM](https://user-images.githubusercontent.com/1289701/149544430-a4b191f6-3062-441d-b468-7c0ca61af7bb.png)


### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201661195283485