### PR TITLE
fix(react-content): set text-align: inherit on base table element

### DIFF
--- a/.changeset/eight-peaches-swim.md
+++ b/.changeset/eight-peaches-swim.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-content': patch
+---
+
+Set text-align: inherit; on our table styles so that table headings are not center align by default, but we can still use the markdown alignment short-hand.

--- a/packages/content/styles/table.module.css
+++ b/packages/content/styles/table.module.css
@@ -11,6 +11,12 @@
     max-width: 100%;
     margin-bottom: 20px;
 
+    /**
+      we're setting this here so that th elements are not left-aligned by default (default UA styling),
+      and we're still able to use the markdown table alignment shorthand
+    **/
+    text-align: inherit;
+
     & td,
     & th {
       border-right: 1px solid #ddd;


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Adjusting the table styles again. Apparently the user agent default styles center text in table headings. Our preference would be that the text is left aligned by default. We want this while still retaining the ability to use markdown short-hand for alignment (with `:`).

Due to cascading, we can't set `text-align: left;` on the `th` elements explicitly, otherwise it overrides the `align` HTML attribute. To get around this I'm setting the rule `text-align: inherit` on our styles for the base `table` element. This also gives us flexibility to tweak the alignment from outside of the element.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
