### PR TITLE
feat: redirect to brand page when right-clicking HashiCorp logo

### DIFF
--- a/.changeset/tender-apples-cross.md
+++ b/.changeset/tender-apples-cross.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-hashi-stack-menu': minor
+---
+
+Redirect to brand page when right-clicking HashiCorp logo

--- a/packages/hashi-stack-menu/index.jsx
+++ b/packages/hashi-stack-menu/index.jsx
@@ -16,6 +16,13 @@ export default function HashiStackMenu({ onPanelChange }) {
     }
   }, [activePanelKey])
 
+  // Redirect to the branding page when someone right-clicks on the
+  // HashiCorp logo
+  const logoOnContextMenu = (e) => {
+    e.preventDefault()
+    window.location.href = 'https://www.hashicorp.com/brand'
+  }
+
   return (
     <header className={styles.hashiStackMenu}>
       <nav
@@ -26,6 +33,7 @@ export default function HashiStackMenu({ onPanelChange }) {
           aria-label="To main HashiCorp website"
           href="https://www.hashicorp.com/"
           className={styles.logoLink}
+          onContextMenu={logoOnContextMenu}
         >
           <Logo />
         </a>


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1200616393941326/f)
🔍 [Preview Link](https://react-components-git-dsright-click-brand-subnav-hashicorp.vercel.app/)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR adds a context menu handler to the HashiCorp logo in HashiStackMenu to redirect the user to HashiCorp's brand page when right-clicking.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
