### PR TITLE
adds versioned error view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2405,6 +2405,10 @@
       "resolved": "packages/enterprise-alert",
       "link": true
     },
+    "node_modules/@hashicorp/react-error-view": {
+      "resolved": "packages/error-view",
+      "link": true
+    },
     "node_modules/@hashicorp/react-featured-slider": {
       "resolved": "packages/featured-slider",
       "link": true
@@ -28005,7 +28009,7 @@
     },
     "packages/content": {
       "name": "@hashicorp/react-content",
-      "version": "8.1.1",
+      "version": "8.2.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
@@ -28145,6 +28149,14 @@
         "@hashicorp/platform-product-meta": "^0.1.0",
         "classnames": "^2.3.1"
       },
+      "peerDependencies": {
+        "@hashicorp/mktg-global-styles": ">=3.x",
+        "react": ">=16.x"
+      }
+    },
+    "packages/error-view": {
+      "version": "0.0.0",
+      "license": "MPL-2.0",
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",
         "react": ">=16.x"
@@ -31014,6 +31026,10 @@
         "@hashicorp/platform-product-meta": "^0.1.0",
         "classnames": "^2.3.1"
       }
+    },
+    "@hashicorp/react-error-view": {
+      "version": "file:packages/error-view",
+      "requires": {}
     },
     "@hashicorp/react-featured-slider": {
       "version": "file:packages/featured-slider",

--- a/packages/error-view/index.tsx
+++ b/packages/error-view/index.tsx
@@ -1,6 +1,7 @@
-import s from './style.module.css'
+import React from 'react'
 import Link from 'next/link'
 import useErrorPageAnalytics from './use-error-page-analytics'
+import s from './style.module.css'
 
 interface ErrorPageProps {
   /** Error code to be recorded via window.analytics.track.  */

--- a/packages/error-view/index.tsx
+++ b/packages/error-view/index.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import useErrorPageAnalytics from './use-error-page-analytics'
 import s from './style.module.css'
 
-interface ErrorPageProps {
+export interface ErrorPageProps {
   /** Error code to be recorded via window.analytics.track.  */
   statusCode: number
 }

--- a/packages/error-view/versioned-view.tsx
+++ b/packages/error-view/versioned-view.tsx
@@ -2,12 +2,12 @@ import React from 'react'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 import useErrorPageAnalytics from './use-error-page-analytics'
-import ErrorPage from '.'
+import ErrorPage, { ErrorPageProps } from '.'
 import s from './style.module.css'
 
 const versionPattern = /\/(?<version>v\d+[.]\d+[.](\d+|x))/
 
-function VersionNotFound({ version }): React.ReactElement {
+function VersionNotFound({ version }: { version: string }): React.ReactElement {
   const { asPath } = useRouter()
   useErrorPageAnalytics(404)
 
@@ -35,7 +35,21 @@ function VersionNotFound({ version }): React.ReactElement {
   )
 }
 
-function VersionedErrorPage({ statusCode, versions }): React.ReactElement {
+/**
+ * A Standalone error page component intended to be used on sites with versioned docs support.
+ * Exports a full, custom implementation of an pages/_error.tsx component.
+ *
+ * Example:
+ *
+ * ```tsx
+ * import { VersionedErrorPage } from '@hashicorp/react-error-view/versioned-view'
+ *
+ * export default VersionedErrorPage
+ * ```
+ */
+function VersionedErrorPage({
+  statusCode,
+}: ErrorPageProps): React.ReactElement {
   const { asPath } = useRouter()
 
   const versionMatches = versionPattern.exec(asPath)
@@ -43,7 +57,7 @@ function VersionedErrorPage({ statusCode, versions }): React.ReactElement {
   const versionInPath = versionMatches?.groups?.version
 
   return versionInPath && statusCode === 404 ? (
-    <VersionNotFound version={versionInPath} versions={versions} />
+    <VersionNotFound version={versionInPath} />
   ) : (
     <ErrorPage statusCode={statusCode} />
   )

--- a/packages/error-view/versioned-view.tsx
+++ b/packages/error-view/versioned-view.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { useRouter } from 'next/router'
+import Link from 'next/link'
+import useErrorPageAnalytics from './use-error-page-analytics'
+import ErrorPage from '.'
+import s from './style.module.css'
+
+const versionPattern = /\/(?<version>v\d+[.]\d+[.](\d+|x))/
+
+function VersionNotFound({ version }): React.ReactElement {
+  const { asPath } = useRouter()
+  useErrorPageAnalytics(404)
+
+  const pathWithoutVersion = asPath.replace(versionPattern, '')
+  const basePath = asPath.split('/')[1]
+
+  return (
+    <div className={s.root}>
+      <h1 className={s.heading}>
+        This page does not exist for version {version}.
+      </h1>
+      <p>
+        Please select either the{' '}
+        <Link href={pathWithoutVersion}>
+          <a>most recent version</a>
+        </Link>{' '}
+        or a valid version that includes the page you are looking for.
+      </p>
+      <p>
+        <Link href={`/${basePath}`}>
+          <a className={s.link}>← Go back to Documentation</a>
+        </Link>
+      </p>
+    </div>
+  )
+}
+
+function VersionedErrorPage({ statusCode, versions }): React.ReactElement {
+  const { asPath } = useRouter()
+
+  const versionMatches = versionPattern.exec(asPath)
+
+  const versionInPath = versionMatches?.groups?.version
+
+  return versionInPath && statusCode === 404 ? (
+    <VersionNotFound version={versionInPath} versions={versions} />
+  ) : (
+    <ErrorPage statusCode={statusCode} />
+  )
+}
+
+VersionedErrorPage.getInitialProps = async ({ res, err }) => {
+  const statusCode = res ? res.statusCode : err ? err.statusCode : 404
+  const props = { statusCode }
+
+  if (statusCode === 404 && typeof window === 'undefined') {
+    // cache 404 for one day
+    res.setHeader('Cache-Control', 's-maxage=86400')
+  }
+
+  return props
+}
+
+export { VersionedErrorPage }


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1201630522524202/f)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

**Note: this PR is targeting @zchsh's branch to add the error-view package. [The PR](https://github.com/hashicorp/react-components/pull/493)**

Adds a specific error view for use on docs sites with versioned docs. It's effectively a full, custom implementation of `pages/_error.tsx`. Implementation looks something like this:

```tsx
import { VersionedErrorPage } from '@hashicorp/react-error-view/versioned-view'

export default VersionedErrorPage
```

![Screen Shot 2022-01-25 at 12 18 48 PM](https://user-images.githubusercontent.com/1289701/151035742-8a110406-9cf4-4624-97ce-85067f085414.png)


### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
