### PR TITLE
Add `use404Redirects` hook to error-view exports

### DIFF
--- a/packages/error-view/README.md
+++ b/packages/error-view/README.md
@@ -5,3 +5,19 @@ A component used to display an error view. For further details on this component
 ## `useErrorPageAnalytics`
 
 The `useErrorPageAnalytics` hook is used within the `ErrorView` component, and is provided as a named export from `@hashicorp/react-error-view`. This hook is intended for use cases where the opinionated, `g-grid-container`-based styles of the default `ErrorView` component are not suited to a project.
+
+## `use404Redirects`
+
+The `use404Redirects` hook can be used on a `page/404.js` page to handle redirects that aren't triggered via client-side navigations. It determines if the current page results in a server-side redirect by performing a HEAD request against the current URL, and performing a client-side navigation to the resulting URL.
+
+### Usage
+
+```tsx
+import ErrorPage, { use404Redirects } from '@hashicorp/react-error-view'
+
+export default function NotFound() {
+  use404Redirects()
+
+  return <ErrorView statusCode={404} />
+}
+```

--- a/packages/error-view/__tests__/use-404-redirects.test.tsx
+++ b/packages/error-view/__tests__/use-404-redirects.test.tsx
@@ -1,0 +1,83 @@
+import nock from 'nock'
+import { render, waitFor } from '@testing-library/react'
+import * as Router from 'next/router'
+import use404Redirects from '../use-404-redirects'
+
+function HookTestComponent() {
+  use404Redirects()
+  return <div>Testing the use404Redirects hook...</div>
+}
+
+const useRouter = jest.spyOn(Router, 'useRouter')
+
+describe('use404Redirects', () => {
+  let originalLocation: typeof window.location
+  let originalAnalytics: typeof window.analytics
+
+  beforeAll(() => {
+    originalLocation = window.location
+    originalAnalytics = window.analytics
+  })
+
+  beforeEach(() => {
+    nock('http://local.test')
+      .head('/testing')
+      .reply(308, '', { Location: '/new-destination' })
+      .head('/new-destination')
+      .reply(200, '')
+      .head('/valid')
+      .reply(200, '')
+
+    delete (window as any).location
+    window.location = {
+      // We use an absolute URL here since fetch in Jest can't use relative URLs
+      pathname: 'http://local.test/testing',
+      href: 'http://local.test/testing',
+    } as $TSFixMe
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+    window.location = originalLocation
+    window.analytics = originalAnalytics
+  })
+
+  afterAll(() => {
+    nock.restore()
+  })
+
+  it('tracks event and calls router.replace with resolved URL', async () => {
+    const useRouterMethods = { replace: jest.fn() } as $TSFixMe
+    useRouter.mockImplementationOnce(() => useRouterMethods)
+
+    window.analytics = { track: jest.fn() } as $TSFixMe
+
+    // Render and assert
+    render(<HookTestComponent />)
+    await waitFor(() =>
+      expect(useRouterMethods.replace).toHaveBeenCalledWith('/new-destination')
+    )
+    expect(window.analytics.track).toHaveBeenCalledTimes(1)
+    expect(window.analytics.track).toBeCalledWith('http://local.test/testing', {
+      category: 'Client-side Redirect',
+      label: 'http://local.test/new-destination',
+    })
+  })
+
+  it('does not call router.replace when current URL == resolved URL', async () => {
+    const useRouterMethods = { replace: jest.fn() } as $TSFixMe
+    useRouter.mockImplementationOnce(() => useRouterMethods)
+
+    window.analytics = { track: jest.fn() } as $TSFixMe
+
+    window.location = {
+      pathname: 'http://local.test/valid',
+      href: 'http://local.test/valid',
+    } as $TSFixMe
+
+    // Render and assert
+    render(<HookTestComponent />)
+    await waitFor(() => expect(useRouterMethods.replace).not.toHaveBeenCalled())
+    expect(window.analytics.track).not.toHaveBeenCalled()
+  })
+})

--- a/packages/error-view/index.tsx
+++ b/packages/error-view/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Link from 'next/link'
 import useErrorPageAnalytics from './use-error-page-analytics'
+import use404Redirects from './use-404-redirects'
 import s from './style.module.css'
 
 export interface ErrorPageProps {
@@ -37,5 +38,5 @@ function ErrorPage({ statusCode }: ErrorPageProps): React.ReactElement {
   )
 }
 
-export { useErrorPageAnalytics }
+export { useErrorPageAnalytics, use404Redirects }
 export default ErrorPage

--- a/packages/error-view/package.json
+++ b/packages/error-view/package.json
@@ -3,11 +3,14 @@
   "description": "error view for use on docs sites",
   "version": "0.0.0",
   "author": "HashiCorp",
-  "contributors": ["Zach Shilton"],
+  "contributors": [
+    "Zach Shilton"
+  ],
   "main": "index.tsx",
   "license": "MPL-2.0",
   "peerDependencies": {
     "@hashicorp/mktg-global-styles": ">=3.x",
+    "next": ">=11.x",
     "react": ">=16.x"
   },
   "publishConfig": {

--- a/packages/error-view/use-404-redirects.ts
+++ b/packages/error-view/use-404-redirects.ts
@@ -1,0 +1,42 @@
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+
+/**
+ * If the current URL results in a non-404 response from the server, log the
+ * event with window.analytics (if available) and perform a client-side
+ * navigation to the resolved URL. Only intended to be used in conjunction with
+ * Next.js's 404 page.
+ *
+ * Relies on window.analytics.track() being a valid function which can be
+ * called as window.analytics.track(href, { category, label }).
+ */
+export default function use404Redirects(): void {
+  const router = useRouter()
+
+  useEffect(() => {
+    ;(async () => {
+      const res = await fetch(window.location.pathname, { method: 'HEAD' })
+      if (res.ok) {
+        // res.url is the final URL that the redirect resolves to
+        const { href, pathname } = new URL(res.url)
+
+        // Prevent an infinite loop if hook is used on a page that the server
+        // doesn't respond with a 404.
+        if (pathname !== window.location.pathname) {
+          if (
+            typeof window !== 'undefined' &&
+            typeof window?.analytics?.track === 'function' &&
+            typeof window?.location?.href === 'string'
+          ) {
+            window.analytics.track(window.location.href, {
+              category: 'Client-side Redirect',
+              label: href,
+            })
+          }
+
+          router.replace(pathname)
+        }
+      }
+    })()
+  }, [])
+}


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR adds a new hook called `use404Redirects` to the exports of `@hashicorp/react-error-view`. When this hook is used on a 404 page, it checks to see if the current URL results in a 200 status from the server with a `pathname` different to the current value. If so, it performs a client-side redirect to that new `pathname`.

This hook allows us to cover the edge-case where the Next Router _thinks_ a URL can be resolved solely on the client, and thus doesn't run any redirects.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
