### PR TITLE
fix(code-block): fix manual code copy issue

### DIFF
--- a/.changeset/many-birds-smile.md
+++ b/.changeset/many-birds-smile.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-code-block': patch
+---
+
+Fixes a Firefox-specific issue where manually selected and then copied code does not contain the newlines it should.

--- a/packages/code-block/partials/code-lines/index.js
+++ b/packages/code-block/partials/code-lines/index.js
@@ -59,7 +59,8 @@ function CodeLines({
                   isNotHighlighted={isNotHighlighted}
                   hasFloatingCopyButton={hasFloatingCopyButton}
                 >
-                  {lineChildren == '' ? '\n' : lineChildren}
+                  {lineChildren}
+                  {'\n'}
                 </LineOfCode>
               )
             })}


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1200794405240290/f)
🔍 [Preview Link](https://react-components-git-zsfix-code-manual-copy-hashicorp.vercel.app/components/codeblock)

---

## Description

This PR fixes an issue where selecting and then copying code in Firefox would result in a lack of newlines in the copied code. It also fixes an issue where empty newlines were not always reproduced correctly when rendering.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.

### Preview of changes

This work has been proven out via:
- https://github.com/hashicorp/web-platform-packages/pull/18
    - Pulls in this work on `@hashicorp/react-code-block` via canary release from this PR
    - Cuts canary release of `@hashicorp/platform-docs-mdx`
- https://github.com/hashicorp/react-components/pull/504
    - Pulls in canary release of `@hashicorp/platform-docs-mdx`
    - Cuts canary release of `@hashicorp/react-docs-page`
- https://github.com/hashicorp/packer/pull/11538
    - Pulls in canary release of `@hashicorp/react-docs-page`
    - Shows fix in action

The preview video below shows a document on the Packer site before & after the fix:

https://user-images.githubusercontent.com/4624598/151643312-0e64a0bd-f33c-4c61-93a3-66ab9c3dc8f7.mp4

### Review Suggestions

First, to reproduce the issue:

- Navigate to https://react-components.vercel.app/components/codeblock, and scroll to the tabbed examples near the bottom of the page*.
- Use the `Copy` button to copy code, then paste it into a plain text editor, and you should see an example with newlines as expected.
- Manually select the code to copy it, and paste it into a plain text editor, and the copied code should be missing all newlines.
- As a separate but related issue, the "Go" tab of the "arbitrary tab names" example does not show empty lines as expected

> * any example with newlines on the page should work to reproduce the issue, _except_ the very last example of passing JSX children to the `code` prop

To confirm this PR fixes the change:

- Navigate to [this PR's Swingset preview link](https://react-components-git-zsfix-code-manual-copy-hashicorp.vercel.app/components/codeblock) and perform the same steps.
- The manual select-and-copy method should now contain newlines as expected.
- As well, the "Go" tab in the "arbitrary tab names" example should show the correct newlines in the "Go" example

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1200794405240290