### PR TITLE
feat(docs-page): wrap docs page content with CodeTabsProvider

### DIFF
--- a/.changeset/big-bikes-deliver.md
+++ b/.changeset/big-bikes-deliver.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-page': patch
+---
+
+Adds CodeTabsProvider to DocsPage, which is necessary for syncing language selection across multiple CodeTabs instances.

--- a/packages/docs-page/index.tsx
+++ b/packages/docs-page/index.tsx
@@ -12,6 +12,7 @@ import { AlgoliaConfigObject } from '@hashicorp/react-search/types'
 
 import VersionSelect from '@hashicorp/react-version-select'
 import { getVersionFromPath } from '@hashicorp/react-version-select/util'
+import CodeTabsProvider from '@hashicorp/react-code-block/provider'
 import { MDXProviderComponentsProp } from '@mdx-js/react'
 
 import SearchBar from './components/search-bar'
@@ -131,16 +132,18 @@ export const DocsPageInner: FunctionComponent<DocsPageInnerProps> = ({
               process.env.ENABLE_VERSIONED_DOCS === 'true',
           })}
         >
-          <Content
-            className="g-content" // used in temporary_injectJumpToSection
-            product={slug}
-            content={
-              <>
-                {isMobile ? null : search}
-                {children}
-              </>
-            }
-          />
+          <CodeTabsProvider>
+            <Content
+              className="g-content" // used in temporary_injectJumpToSection
+              product={slug}
+              content={
+                <>
+                  {isMobile ? null : search}
+                  {children}
+                </>
+              }
+            />
+          </CodeTabsProvider>
         </div>
       </div>
       {/* if desired, show an "edit this page" link on the bottom right, linking to github */}


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1201819583341205)
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Wrap the content rendered by `DocsPage` in `CodeTabsProvider` to ensure that tab syncing can function across multiple instances of `CodeTabs`.

Validated here: https://vault-git-brkfeat-code-tabs-sync-hashicorp.vercel.app/docs/get-started/developer-qs

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
