### PR TITLE
Adjust human-readable CPU architecture labels

### DIFF
--- a/.changeset/curvy-scissors-grin.md
+++ b/.changeset/curvy-scissors-grin.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-product-downloads-page': patch
+---
+
+Adjust human-readable CPU architecture labels

--- a/packages/product-download-page/utils/__tests__/downloader.test.ts
+++ b/packages/product-download-page/utils/__tests__/downloader.test.ts
@@ -1,0 +1,21 @@
+import { prettyArch } from '../downloader'
+
+describe('prettyArch', () => {
+  test('returns expected label for architecture', () => {
+    const mapping = {
+      // inputs that require special handling
+      all: 'Universal (386 and Amd64)',
+      x86_64: 'Amd64',
+      i686: '686',
+      // inputs that can use default handling
+      amd64: 'Amd64',
+      '386': '386',
+      arm: 'Arm',
+      arm64: 'Arm64',
+    }
+
+    for (const [input, expectedOutput] of Object.entries(mapping)) {
+      expect(prettyArch(input)).toBe(expectedOutput)
+    }
+  })
+})

--- a/packages/product-download-page/utils/downloader.ts
+++ b/packages/product-download-page/utils/downloader.ts
@@ -22,27 +22,13 @@ export function sortAndFilterReleases(releases: string[]): string[] {
 export function prettyArch(arch: string): string {
   switch (arch) {
     case 'all':
-      return 'Universal (32 and 64-bit)'
-    case 'i686':
-    case 'i386':
-    case '686':
-    case '386':
+      return 'Universal (386 and Amd64)'
     case 'x86_64':
-    case '86_64':
-    case 'amd64':
+      return 'Amd64'
+    case 'i686':
+      return '686'
     default:
-      if (/-/.test(arch)) {
-        const parts = arch.split(/-(.+)/)
-        return `${prettyArch(parts[0])} (${parts[1]})`
-      } else {
-        const parts = arch.split('_')
-        if (parts.length > 0) {
-          return (
-            parts[parts.length - 1].charAt(0).toUpperCase() +
-            parts[parts.length - 1].slice(1)
-          )
-        }
-      }
+      return `${arch.charAt(0).toUpperCase()}${arch.slice(1)}`
   }
 
   return ''


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR tweaks the returned human-readable labels used for CPU architectures to fix an issue where values like `x86_64` were being transformed to `64`.

After this PR, the following CPU architectures will receive special treatment:

- `all` will become `Universal (386 and Amd64)`
- `x86_64` will become `Amd64`
- `i686` will become `686`

All other architectures will have their first character capitalized (such as `Arm64`, `Mips`, `S390x`, etc).

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
