### PR TITLE
fix(consent-manager): add events dependency

### DIFF
--- a/.changeset/olive-otters-reflect.md
+++ b/.changeset/olive-otters-reflect.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-consent-manager': patch
+---
+
+Adds missing events dependency to avoid webpack > 5 errors.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11935,6 +11935,7 @@
     },
     "node_modules/events": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "engines": {
         "node": ">=0.8.x"
@@ -31168,7 +31169,7 @@
     },
     "packages/accordion": {
       "name": "@hashicorp/react-accordion",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/react-inline-svg": "^6.0.3",
@@ -31194,7 +31195,7 @@
     },
     "packages/alert-banner": {
       "name": "@hashicorp/react-alert-banner",
-      "version": "7.0.1",
+      "version": "7.0.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
@@ -31226,7 +31227,7 @@
     },
     "packages/button": {
       "name": "@hashicorp/react-button",
-      "version": "6.0.3",
+      "version": "6.1.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
@@ -31236,6 +31237,7 @@
       },
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",
+        "next": ">=11.x",
         "react": ">=16.x"
       }
     },
@@ -31249,10 +31251,10 @@
     },
     "packages/call-to-action": {
       "name": "@hashicorp/react-call-to-action",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "license": "MPL-2.0",
       "dependencies": {
-        "@hashicorp/react-button": "^6.0.3"
+        "@hashicorp/react-button": "^6.0.4"
       },
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",
@@ -31261,11 +31263,11 @@
     },
     "packages/callouts": {
       "name": "@hashicorp/react-callouts",
-      "version": "8.0.1",
+      "version": "8.0.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
-        "@hashicorp/react-button": "^6.0.3",
+        "@hashicorp/react-button": "^6.0.4",
         "@hashicorp/react-inline-svg": "^6.0.3",
         "classnames": "^2.3.1"
       },
@@ -31276,10 +31278,10 @@
     },
     "packages/case-study-slider": {
       "name": "@hashicorp/react-case-study-slider",
-      "version": "7.0.2",
+      "version": "7.0.3",
       "dependencies": {
-        "@hashicorp/react-featured-slider": "^5.0.1",
-        "@hashicorp/react-image": "^4.0.3"
+        "@hashicorp/react-featured-slider": "^5.0.2",
+        "@hashicorp/react-image": "^4.0.4"
       },
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",
@@ -31308,7 +31310,7 @@
     },
     "packages/code-block": {
       "name": "@hashicorp/react-code-block",
-      "version": "4.4.0",
+      "version": "4.4.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/react-inline-svg": "^6.0.3",
@@ -31322,7 +31324,7 @@
     },
     "packages/combobox": {
       "name": "@hashicorp/react-combobox",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@reach/combobox": "0.16.5",
@@ -31336,12 +31338,13 @@
     },
     "packages/consent-manager": {
       "name": "@hashicorp/react-consent-manager",
-      "version": "7.1.0",
+      "version": "7.1.1",
       "license": "MPL-2.0",
       "dependencies": {
-        "@hashicorp/react-button": "^6.0.3",
+        "@hashicorp/react-button": "^6.0.4",
         "@hashicorp/react-toggle": "^4.0.1",
         "classnames": "^2.3.1",
+        "events": "^3.3.0",
         "js-cookie": "^2.2.1"
       },
       "peerDependencies": {
@@ -31352,7 +31355,7 @@
     },
     "packages/content": {
       "name": "@hashicorp/react-content",
-      "version": "8.2.0",
+      "version": "8.2.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
@@ -31365,11 +31368,11 @@
     },
     "packages/content-cta": {
       "name": "@hashicorp/react-content-cta",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
-        "@hashicorp/react-button": "^6.0.3",
+        "@hashicorp/react-button": "^6.0.4",
         "classnames": "^2.3.1"
       },
       "peerDependencies": {
@@ -31379,17 +31382,17 @@
     },
     "packages/docs-page": {
       "name": "@hashicorp/react-docs-page",
-      "version": "14.14.0",
+      "version": "14.14.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-docs-mdx": "^0.1.4",
         "@hashicorp/platform-markdown-utils": "^0.2.0",
         "@hashicorp/react-alert": "^6.0.2",
-        "@hashicorp/react-content": "^8.2.0",
+        "@hashicorp/react-content": "^8.2.1",
         "@hashicorp/react-docs-sidenav": "^8.4.1",
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-placeholder": "^0.1.0",
-        "@hashicorp/react-search": "^6.4.0",
+        "@hashicorp/react-search": "^6.4.1",
         "@hashicorp/react-version-select": "^0.3.0",
         "classnames": "^2.3.1",
         "fs-exists-sync": "^0.1.0",
@@ -31422,20 +31425,6 @@
       },
       "peerDependencies": {
         "react": ">= 16.x"
-      }
-    },
-    "packages/docs-page/node_modules/@hashicorp/react-code-block": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.4.2.tgz",
-      "integrity": "sha512-isnojue1SuTaq4jjh6C03jxVLCGmHaSK6D/m3OdEsUeV5PovZ7uNF9MFfhwHErIHKZztxOuIePepqaAB5sMHCw==",
-      "dependencies": {
-        "@hashicorp/react-inline-svg": "^6.0.3",
-        "@reach/listbox": "0.16.2",
-        "shellwords": "^0.1.1"
-      },
-      "peerDependencies": {
-        "@hashicorp/mktg-global-styles": ">=3.x",
-        "react": ">=16.x"
       }
     },
     "packages/docs-page/node_modules/@types/semver": {
@@ -31482,20 +31471,22 @@
       }
     },
     "packages/error-view": {
-      "version": "0.0.0",
+      "name": "@hashicorp/react-error-view",
+      "version": "0.0.1",
       "license": "MPL-2.0",
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",
+        "next": ">=11.x",
         "react": ">=16.x"
       }
     },
     "packages/featured-slider": {
       "name": "@hashicorp/react-featured-slider",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "MPL-2.0",
       "dependencies": {
-        "@hashicorp/react-button": "^6.0.3",
-        "@hashicorp/react-image": "^4.0.3",
+        "@hashicorp/react-button": "^6.0.4",
+        "@hashicorp/react-image": "^4.0.4",
         "classnames": "^2.3.1"
       },
       "peerDependencies": {
@@ -31505,10 +31496,10 @@
     },
     "packages/feedback-form": {
       "name": "@hashicorp/react-feedback-form",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MPL-2.0",
       "dependencies": {
-        "@hashicorp/react-button": "^6.0.3",
+        "@hashicorp/react-button": "^6.0.4",
         "shortid": "^2.2.16"
       },
       "peerDependencies": {
@@ -31518,10 +31509,10 @@
     },
     "packages/glossary-page": {
       "name": "@hashicorp/react-glossary-page",
-      "version": "2.5.5",
+      "version": "2.5.6",
       "license": "MPL-2.0",
       "dependencies": {
-        "@hashicorp/react-docs-page": "^14.14.0",
+        "@hashicorp/react-docs-page": "^14.14.1",
         "@hashicorp/remark-plugins": "^3.3.1"
       },
       "peerDependencies": {
@@ -31532,7 +31523,7 @@
     },
     "packages/hashi-stack-menu": {
       "name": "@hashicorp/react-hashi-stack-menu",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/react-inline-svg": "^6.0.3",
@@ -31564,14 +31555,14 @@
     },
     "packages/hero": {
       "name": "@hashicorp/react-hero",
-      "version": "8.0.3",
+      "version": "8.0.4",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/js-utils": "^1.0.10",
         "@hashicorp/platform-product-meta": "^0.1.0",
         "@hashicorp/react-alert": "^6.0.2",
-        "@hashicorp/react-button": "^6.0.3",
-        "@hashicorp/react-image": "^4.0.3",
+        "@hashicorp/react-button": "^6.0.4",
+        "@hashicorp/react-image": "^4.0.4",
         "@hashicorp/react-text-input": "^5.0.1",
         "classnames": "^2.3.1",
         "formik": "^2.2.9",
@@ -31585,7 +31576,7 @@
     },
     "packages/image": {
       "name": "@hashicorp/react-image",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "license": "MPL-2.0",
       "dependencies": {
         "object-assign": "^4.1.1",
@@ -31607,11 +31598,11 @@
     },
     "packages/learn-callout": {
       "name": "@hashicorp/react-learn-callout",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
-        "@hashicorp/react-button": "^6.0.3",
+        "@hashicorp/react-button": "^6.0.4",
         "classnames": "^2.3.1"
       },
       "peerDependencies": {
@@ -31630,11 +31621,11 @@
     },
     "packages/logo-grid": {
       "name": "@hashicorp/react-logo-grid",
-      "version": "5.0.2",
+      "version": "5.0.3",
       "license": "MPL-2.0",
       "dependencies": {
-        "@hashicorp/react-button": "^6.0.3",
-        "@hashicorp/react-image": "^4.0.3",
+        "@hashicorp/react-button": "^6.0.4",
+        "@hashicorp/react-image": "^4.0.4",
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@reach/popover": "^0.16.2",
         "@reach/portal": "^0.16.2",
@@ -31649,11 +31640,11 @@
     },
     "packages/markdown-page": {
       "name": "@hashicorp/react-markdown-page",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-markdown-utils": "^0.2.0",
-        "@hashicorp/react-content": "^8.2.0",
+        "@hashicorp/react-content": "^8.2.1",
         "@hashicorp/react-head": "^3.1.2",
         "gray-matter": "4.0.3",
         "next-mdx-remote": ">=3.x"
@@ -31673,13 +31664,13 @@
     },
     "packages/open-api-page": {
       "name": "@hashicorp/react-open-api-page",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.9",
         "@hashicorp/flight-icons": "^2.0.2",
         "@hashicorp/platform-markdown-utils": "^0.2.0",
-        "@hashicorp/react-content": "^8.2.0",
+        "@hashicorp/react-content": "^8.2.1",
         "@hashicorp/react-docs-sidenav": "^8.4.1",
         "@hashicorp/react-head": "^3.1.2",
         "change-case": "^4.1.2",
@@ -31697,13 +31688,13 @@
     },
     "packages/product-download-page": {
       "name": "@hashicorp/react-product-downloads-page",
-      "version": "2.7.0",
+      "version": "2.7.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
-        "@hashicorp/react-button": "^6.0.3",
+        "@hashicorp/react-button": "^6.0.4",
         "@hashicorp/react-head": "^3.1.2",
-        "@hashicorp/react-tabs": "^7.1.1",
+        "@hashicorp/react-tabs": "^7.1.2",
         "semver": "^7.3.5"
       },
       "peerDependencies": {
@@ -31713,11 +31704,11 @@
     },
     "packages/product-features-list": {
       "name": "@hashicorp/react-product-features-list",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "MPL-2.0",
       "dependencies": {
-        "@hashicorp/react-button": "^6.0.3",
-        "@hashicorp/react-image": "^4.0.3",
+        "@hashicorp/react-button": "^6.0.4",
+        "@hashicorp/react-image": "^4.0.4",
         "classnames": "^2.3.1"
       },
       "peerDependencies": {
@@ -31727,7 +31718,7 @@
     },
     "packages/search": {
       "name": "@hashicorp/react-search",
-      "version": "6.4.0",
+      "version": "6.4.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/react-inline-svg": "^6.0.3",
@@ -31830,7 +31821,7 @@
     },
     "packages/sentinel-embedded": {
       "name": "@hashicorp/react-sentinel-embedded",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/sentinel-embedded": "^0.0.14"
@@ -31857,7 +31848,7 @@
     },
     "packages/stepped-feature-list": {
       "name": "@hashicorp/react-stepped-feature-list",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "license": "MPL-2.0",
       "dependencies": {
         "nuka-carousel": "^4.8.4"
@@ -31869,12 +31860,12 @@
     },
     "packages/subnav": {
       "name": "@hashicorp/react-subnav",
-      "version": "9.3.3",
+      "version": "9.3.4",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/mktg-logos": "^1.2.0",
         "@hashicorp/platform-product-meta": "^0.1.0",
-        "@hashicorp/react-button": "^6.0.3",
+        "@hashicorp/react-button": "^6.0.4",
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@hashicorp/react-link-wrap": "^3.0.3",
         "@reach/visually-hidden": "^0.16.0",
@@ -31889,11 +31880,11 @@
     },
     "packages/tabbed-accordion": {
       "name": "@hashicorp/react-tabbed-accordion",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "MPL-2.0",
       "dependencies": {
-        "@hashicorp/react-accordion": "^3.0.1",
-        "@hashicorp/react-tabs": "^7.1.1",
+        "@hashicorp/react-accordion": "^3.0.2",
+        "@hashicorp/react-tabs": "^7.1.2",
         "classnames": "^2.3.1"
       },
       "peerDependencies": {
@@ -31903,7 +31894,7 @@
     },
     "packages/tabs": {
       "name": "@hashicorp/react-tabs",
-      "version": "7.1.1",
+      "version": "7.1.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/react-inline-svg": "^6.0.3",
@@ -31950,11 +31941,11 @@
     },
     "packages/text-split": {
       "name": "@hashicorp/react-text-split",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
-        "@hashicorp/react-button": "^6.0.3",
+        "@hashicorp/react-button": "^6.0.4",
         "@hashicorp/react-inline-svg": "^6.0.3",
         "classnames": "^2.3.1"
       },
@@ -31965,11 +31956,11 @@
     },
     "packages/text-split-with-code": {
       "name": "@hashicorp/react-text-split-with-code",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "MPL-2.0",
       "dependencies": {
-        "@hashicorp/react-code-block": "^4.4.0",
-        "@hashicorp/react-text-split": "^4.0.0"
+        "@hashicorp/react-code-block": "^4.4.1",
+        "@hashicorp/react-text-split": "^4.0.1"
       },
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",
@@ -32005,10 +31996,10 @@
     },
     "packages/text-splits": {
       "name": "@hashicorp/react-text-splits",
-      "version": "3.2.7",
+      "version": "3.2.8",
       "license": "MPL-2.0",
       "dependencies": {
-        "@hashicorp/react-text-split-with-code": "^3.4.0",
+        "@hashicorp/react-text-split-with-code": "^3.4.1",
         "@hashicorp/react-text-split-with-image": "^4.3.0",
         "@hashicorp/react-text-split-with-logo-grid": "^5.1.5"
       },
@@ -32056,11 +32047,11 @@
     },
     "packages/vertical-text-block-list": {
       "name": "@hashicorp/react-vertical-text-block-list",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
-        "@hashicorp/react-image": "^4.0.3",
+        "@hashicorp/react-image": "^4.0.4",
         "@hashicorp/react-link-wrap": "^3.0.3",
         "classnames": "^2.3.1"
       },
@@ -35106,14 +35097,14 @@
     "@hashicorp/react-call-to-action": {
       "version": "file:packages/call-to-action",
       "requires": {
-        "@hashicorp/react-button": "^6.0.3"
+        "@hashicorp/react-button": "^6.0.4"
       }
     },
     "@hashicorp/react-callouts": {
       "version": "file:packages/callouts",
       "requires": {
         "@hashicorp/platform-product-meta": "^0.1.0",
-        "@hashicorp/react-button": "^6.0.3",
+        "@hashicorp/react-button": "^6.0.4",
         "@hashicorp/react-inline-svg": "^6.0.3",
         "classnames": "^2.3.1"
       }
@@ -35121,8 +35112,8 @@
     "@hashicorp/react-case-study-slider": {
       "version": "file:packages/case-study-slider",
       "requires": {
-        "@hashicorp/react-featured-slider": "^5.0.1",
-        "@hashicorp/react-image": "^4.0.3"
+        "@hashicorp/react-featured-slider": "^5.0.2",
+        "@hashicorp/react-image": "^4.0.4"
       }
     },
     "@hashicorp/react-checkbox-input": {
@@ -35164,9 +35155,10 @@
     "@hashicorp/react-consent-manager": {
       "version": "file:packages/consent-manager",
       "requires": {
-        "@hashicorp/react-button": "^6.0.3",
+        "@hashicorp/react-button": "^6.0.4",
         "@hashicorp/react-toggle": "^4.0.1",
         "classnames": "^2.3.1",
+        "events": "*",
         "js-cookie": "^2.2.1"
       }
     },
@@ -35181,21 +35173,21 @@
       "version": "file:packages/content-cta",
       "requires": {
         "@hashicorp/platform-product-meta": "^0.1.0",
-        "@hashicorp/react-button": "^6.0.3",
+        "@hashicorp/react-button": "^6.0.4",
         "classnames": "^2.3.1"
       }
     },
     "@hashicorp/react-docs-page": {
       "version": "file:packages/docs-page",
       "requires": {
-        "@hashicorp/platform-docs-mdx": "0.1.4",
+        "@hashicorp/platform-docs-mdx": "^0.1.4",
         "@hashicorp/platform-markdown-utils": "^0.2.0",
         "@hashicorp/react-alert": "^6.0.2",
-        "@hashicorp/react-content": "^8.2.0",
+        "@hashicorp/react-content": "^8.2.1",
         "@hashicorp/react-docs-sidenav": "^8.4.1",
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-placeholder": "^0.1.0",
-        "@hashicorp/react-search": "^6.4.0",
+        "@hashicorp/react-search": "^6.4.1",
         "@hashicorp/react-version-select": "^0.3.0",
         "@types/mdx-js__react": "^1.5.5",
         "@types/semver": "^7.3.9",
@@ -35218,16 +35210,6 @@
             "@hashicorp/react-enterprise-alert": "^6.0.1",
             "@hashicorp/react-tabs": "^7.0.1",
             "@mdx-js/react": "1.6.22"
-          }
-        },
-        "@hashicorp/react-code-block": {
-          "version": "4.4.2",
-          "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.4.2.tgz",
-          "integrity": "sha512-isnojue1SuTaq4jjh6C03jxVLCGmHaSK6D/m3OdEsUeV5PovZ7uNF9MFfhwHErIHKZztxOuIePepqaAB5sMHCw==",
-          "requires": {
-            "@hashicorp/react-inline-svg": "^6.0.3",
-            "@reach/listbox": "0.16.2",
-            "shellwords": "^0.1.1"
           }
         },
         "@types/semver": {
@@ -35267,22 +35249,22 @@
     "@hashicorp/react-featured-slider": {
       "version": "file:packages/featured-slider",
       "requires": {
-        "@hashicorp/react-button": "^6.0.3",
-        "@hashicorp/react-image": "^4.0.3",
+        "@hashicorp/react-button": "^6.0.4",
+        "@hashicorp/react-image": "^4.0.4",
         "classnames": "^2.3.1"
       }
     },
     "@hashicorp/react-feedback-form": {
       "version": "file:packages/feedback-form",
       "requires": {
-        "@hashicorp/react-button": "^6.0.3",
+        "@hashicorp/react-button": "^6.0.4",
         "shortid": "^2.2.16"
       }
     },
     "@hashicorp/react-glossary-page": {
       "version": "file:packages/glossary-page",
       "requires": {
-        "@hashicorp/react-docs-page": "^14.14.0",
+        "@hashicorp/react-docs-page": "^14.14.1",
         "@hashicorp/remark-plugins": "^3.3.1"
       }
     },
@@ -35311,8 +35293,8 @@
         "@hashicorp/js-utils": "^1.0.10",
         "@hashicorp/platform-product-meta": "^0.1.0",
         "@hashicorp/react-alert": "^6.0.2",
-        "@hashicorp/react-button": "^6.0.3",
-        "@hashicorp/react-image": "^4.0.3",
+        "@hashicorp/react-button": "^6.0.4",
+        "@hashicorp/react-image": "^4.0.4",
         "@hashicorp/react-text-input": "^5.0.1",
         "classnames": "^2.3.1",
         "formik": "^2.2.9",
@@ -35335,7 +35317,7 @@
       "version": "file:packages/learn-callout",
       "requires": {
         "@hashicorp/platform-product-meta": "^0.1.0",
-        "@hashicorp/react-button": "^6.0.3",
+        "@hashicorp/react-button": "^6.0.4",
         "classnames": "^2.3.1"
       }
     },
@@ -35346,8 +35328,8 @@
     "@hashicorp/react-logo-grid": {
       "version": "file:packages/logo-grid",
       "requires": {
-        "@hashicorp/react-button": "^6.0.3",
-        "@hashicorp/react-image": "^4.0.3",
+        "@hashicorp/react-button": "^6.0.4",
+        "@hashicorp/react-image": "^4.0.4",
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@reach/popover": "^0.16.2",
         "@reach/portal": "^0.16.2",
@@ -35360,7 +35342,7 @@
       "version": "file:packages/markdown-page",
       "requires": {
         "@hashicorp/platform-markdown-utils": "^0.2.0",
-        "@hashicorp/react-content": "^8.2.0",
+        "@hashicorp/react-content": "^8.2.1",
         "@hashicorp/react-head": "^3.1.2",
         "gray-matter": "4.0.3",
         "next-mdx-remote": ">=3.x"
@@ -35378,7 +35360,7 @@
         "@apidevtools/json-schema-ref-parser": "^9.0.9",
         "@hashicorp/flight-icons": "^2.0.2",
         "@hashicorp/platform-markdown-utils": "^0.2.0",
-        "@hashicorp/react-content": "^8.2.0",
+        "@hashicorp/react-content": "^8.2.1",
         "@hashicorp/react-docs-sidenav": "^8.4.1",
         "@hashicorp/react-head": "^3.1.2",
         "change-case": "^4.1.2",
@@ -35393,17 +35375,17 @@
       "version": "file:packages/product-download-page",
       "requires": {
         "@hashicorp/platform-product-meta": "^0.1.0",
-        "@hashicorp/react-button": "^6.0.3",
+        "@hashicorp/react-button": "^6.0.4",
         "@hashicorp/react-head": "^3.1.2",
-        "@hashicorp/react-tabs": "^7.1.1",
+        "@hashicorp/react-tabs": "^7.1.2",
         "semver": "^7.3.5"
       }
     },
     "@hashicorp/react-product-features-list": {
       "version": "file:packages/product-features-list",
       "requires": {
-        "@hashicorp/react-button": "^6.0.3",
-        "@hashicorp/react-image": "^4.0.3",
+        "@hashicorp/react-button": "^6.0.4",
+        "@hashicorp/react-image": "^4.0.4",
         "classnames": "^2.3.1"
       }
     },
@@ -35500,7 +35482,7 @@
       "requires": {
         "@hashicorp/mktg-logos": "^1.2.0",
         "@hashicorp/platform-product-meta": "^0.1.0",
-        "@hashicorp/react-button": "^6.0.3",
+        "@hashicorp/react-button": "^6.0.4",
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@hashicorp/react-link-wrap": "^3.0.3",
         "@reach/visually-hidden": "^0.16.0",
@@ -35512,8 +35494,8 @@
     "@hashicorp/react-tabbed-accordion": {
       "version": "file:packages/tabbed-accordion",
       "requires": {
-        "@hashicorp/react-accordion": "^3.0.1",
-        "@hashicorp/react-tabs": "^7.1.1",
+        "@hashicorp/react-accordion": "^3.0.2",
+        "@hashicorp/react-tabs": "^7.1.2",
         "classnames": "^2.3.1"
       }
     },
@@ -35543,7 +35525,7 @@
       "version": "file:packages/text-split",
       "requires": {
         "@hashicorp/platform-product-meta": "^0.1.0",
-        "@hashicorp/react-button": "^6.0.3",
+        "@hashicorp/react-button": "^6.0.4",
         "@hashicorp/react-inline-svg": "^6.0.3",
         "classnames": "^2.3.1"
       }
@@ -35551,8 +35533,8 @@
     "@hashicorp/react-text-split-with-code": {
       "version": "file:packages/text-split-with-code",
       "requires": {
-        "@hashicorp/react-code-block": "^4.4.0",
-        "@hashicorp/react-text-split": "^4.0.0"
+        "@hashicorp/react-code-block": "^4.4.1",
+        "@hashicorp/react-text-split": "^4.0.1"
       }
     },
     "@hashicorp/react-text-split-with-image": {
@@ -35573,7 +35555,7 @@
     "@hashicorp/react-text-splits": {
       "version": "file:packages/text-splits",
       "requires": {
-        "@hashicorp/react-text-split-with-code": "^3.4.0",
+        "@hashicorp/react-text-split-with-code": "^3.4.1",
         "@hashicorp/react-text-split-with-image": "^4.3.0",
         "@hashicorp/react-text-split-with-logo-grid": "^5.1.5"
       }
@@ -35602,7 +35584,7 @@
       "version": "file:packages/vertical-text-block-list",
       "requires": {
         "@hashicorp/platform-product-meta": "^0.1.0",
-        "@hashicorp/react-image": "^4.0.3",
+        "@hashicorp/react-image": "^4.0.4",
         "@hashicorp/react-link-wrap": "^3.0.3",
         "classnames": "^2.3.1"
       }
@@ -41723,6 +41705,7 @@
     },
     "events": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "evp_bytestokey": {

--- a/packages/consent-manager/package.json
+++ b/packages/consent-manager/package.json
@@ -11,13 +11,14 @@
     "@hashicorp/react-button": "^6.0.4",
     "@hashicorp/react-toggle": "^4.0.1",
     "classnames": "^2.3.1",
+    "events": "^3.3.0",
     "js-cookie": "^2.2.1"
   },
   "license": "MPL-2.0",
   "peerDependencies": {
     "@hashicorp/mktg-global-styles": ">=3.x",
-    "react": ">=16.x",
-    "next": ">=11.x"
+    "next": ">=11.x",
+    "react": ">=16.x"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1200794405240290/f)
🔍 [Preview Link](https://react-components-git-zsadd-events-dep-to-consent-manager-hashicorp.vercel.app)

---

This PR attempts to fix the following NextJS deploy error from hashicorp/nomad#12117:

<img width="1078" alt="CleanShot 2022-02-24 at 10 48 30@2x" src="https://user-images.githubusercontent.com/4624598/155562576-7e23bd95-8ca4-4088-bff3-659048b8408a.png">

I'm not sure why this error came up at the specific time it did, but it seems to be related to [this change in Webpack > 5](https://webpack.js.org/blog/2020-10-10-webpack-5-release/#automatic-nodejs-polyfills-removed). This fix adds the `events` package as an explicit dependency of `@hashicorp/react-consent-manager` in an attempt to avoid this error.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
