### PR TITLE
Support non-jump-to-section tagged H2 in DocsPage

### DIFF
--- a/.changeset/eighty-walls-promise.md
+++ b/.changeset/eighty-walls-promise.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-page': patch
+---
+
+Ignore non-jump-to-section tagged H2 elements within the content of a DocsPage

--- a/packages/docs-page/temporary_jump-to-section.js
+++ b/packages/docs-page/temporary_jump-to-section.js
@@ -4,19 +4,28 @@
 export default function temporary_injectJumpToSection(node) {
   const root = node.querySelector('.g-content')
   const firstH1 = root.querySelector('h1')
-  const otherH2s = [].slice.call(root.querySelectorAll('h2')) // NodeList -> array
+  // Build our array of headline objects
+  const headlines = Array.from(root.querySelectorAll('h2')).reduce(
+    (acc, h2) => {
+      // Query for headlines containing our jump-to-section targets that are
+      // inserted by Remark
+      const target = h2.querySelector('.__target-h')
+      if (target) {
+        // The given H2 has a JTS target, so add it to our accumulator
+        acc.push({
+          id: target.id,
+          text: h2.textContent.slice(1), // slice removes permalink » character
+        })
+      }
+
+      return acc
+    },
+    []
+  )
 
   // if there's no h1 or no 3 h2s, don't render jump to section
   if (!firstH1) return
-  if (otherH2s.length < 1) return
-
-  const headlines = otherH2s.map((h2) => {
-    // slice removes the anchor link character
-    return {
-      id: h2.querySelector('.__target-h').id,
-      text: h2.textContent.slice(1), // slice removes permalink » character
-    }
-  })
+  if (headlines.length < 1) return
 
   // build the html
   const html = `


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR refactors the headline extraction logic of our Jump to Section code to ignore H2 elements on DocsPage that aren't tagged with the appropriate Remark plugin.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
