### PR TITLE
feat(docs-page): support passing remarkPlugins as a fn

### DIFF
--- a/.changeset/tender-terms-mix.md
+++ b/.changeset/tender-terms-mix.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-page': minor
+---
+
+Support passing a function for remarkPlugins, which accepts the params for the current page being rendered.

--- a/packages/docs-page/server/index.ts
+++ b/packages/docs-page/server/index.ts
@@ -26,7 +26,8 @@ export function getStaticGenerationFunctions(
     | ({
         basePath: string
         strategy: 'remote'
-      } & BaseOpts)
+      } & BaseOpts &
+        Partial<ConstructorParameters<typeof RemoteContentLoader>[0]>)
     | ({
         localContentDir: string
         navDataFile: string
@@ -36,7 +37,8 @@ export function getStaticGenerationFunctions(
          * Passed to our resolveIncludes plugin.
          * Defaults to "content/partials". */
         localPartialsDir?: string
-      } & BaseOpts)
+      } & BaseOpts &
+        Partial<ConstructorParameters<typeof FileSystemLoader>[0]>)
 ): {
   getStaticPaths: GetStaticPaths
   getStaticProps: GetStaticProps

--- a/packages/docs-page/server/loaders/remote-content.ts
+++ b/packages/docs-page/server/loaders/remote-content.ts
@@ -120,6 +120,11 @@ export default class RemoteContentLoader implements DataLoader {
     // We support passing in a function to remarkPlugins, which gets the parameters of the current page
     if (typeof this.opts.remarkPlugins === 'function') {
       remarkPlugins = this.opts.remarkPlugins(params)
+      if (!Array.isArray(remarkPlugins)) {
+        throw new Error(
+          '`remarkPlugins:` When specified as a function, must return an array of remark plugins'
+        )
+      }
     }
 
     const mdxRenderer = (mdx) =>
@@ -133,9 +138,8 @@ export default class RemoteContentLoader implements DataLoader {
       params![this.opts.paramId!] as string[]
     )
 
-    const versionMetadataList: VersionMetadataItem[] = await cachedFetchVersionMetadataList(
-      this.opts.product
-    )
+    const versionMetadataList: VersionMetadataItem[] =
+      await cachedFetchVersionMetadataList(this.opts.product)
     // remove trailing index to ensure we fetch the right document from the DB
     const pathParamsNoIndex = paramsNoVersion.filter(
       (param, idx, arr) => !(param === 'index' && idx === arr.length - 1)

--- a/packages/docs-page/server/loaders/remote-content.ts
+++ b/packages/docs-page/server/loaders/remote-content.ts
@@ -1,3 +1,4 @@
+import type { ParsedUrlQuery } from 'querystring'
 import moize, { Options } from 'moize'
 import semver from 'semver'
 import { GetStaticPropsContext } from 'next'
@@ -17,7 +18,7 @@ import { getPathsFromNavData } from '../get-paths-from-nav-data'
 interface RemoteContentLoaderOpts extends DataLoaderOpts {
   basePath: string
   enabledVersionedDocs?: boolean
-  remarkPlugins?: $TSFixMe[]
+  remarkPlugins?: ((params?: ParsedUrlQuery) => $TSFixMe[]) | $TSFixMe[]
   mainBranch?: string // = 'main',
   scope?: Record<string, $TSFixMe>
 }
@@ -114,9 +115,16 @@ export default class RemoteContentLoader implements DataLoader {
         ? (params[this.opts.paramId] as string[]).join('/')
         : ''
 
+    let remarkPlugins: $TSFixMe[] = []
+
+    // We support passing in a function to remarkPlugins, which gets the parameters of the current page
+    if (typeof this.opts.remarkPlugins === 'function') {
+      remarkPlugins = this.opts.remarkPlugins(params)
+    }
+
     const mdxRenderer = (mdx) =>
       renderPageMdx(mdx, {
-        remarkPlugins: this.opts.remarkPlugins,
+        remarkPlugins,
         scope: this.opts.scope,
       })
 


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This updates both the `Remote` and `FileSystem` data loaders to accept a function for `remarkPlugins`. The function is called with the current pages params

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
