### PR TITLE
feat(product-download-page): make optional props optional

### DIFF
--- a/.changeset/rare-eggs-return.md
+++ b/.changeset/rare-eggs-return.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-product-downloads-page': minor
+---
+
+Fixes an issue where props that could be optional were required.

--- a/packages/product-download-page/index.tsx
+++ b/packages/product-download-page/index.tsx
@@ -46,10 +46,9 @@ export default function ProductDownloadsPage({
       `We went looking for version "${_latestVersion}" but could not find it in the release data. Please make sure that the "latestVersion" prop matches the version name of an existing release.`
     )
 
-  const sortedDownloads = useMemo(
-    () => sortPlatforms(currentRelease),
-    [currentRelease]
-  )
+  const sortedDownloads = useMemo(() => sortPlatforms(currentRelease), [
+    currentRelease,
+  ])
   const osKeys = Object.keys(sortedDownloads)
   const [osIndex, setSelectedOsIndex] = useState(0)
 
@@ -179,7 +178,7 @@ export default function ProductDownloadsPage({
 
 interface ProductDownloadsPageProps {
   tutorialLink: Link
-  merchandisingSlot: React.ReactElement
+  merchandisingSlot?: React.ReactElement
   logo: React.ReactElement
   getStartedLinks: Link[]
   getStartedDescription: string
@@ -190,7 +189,7 @@ interface ProductDownloadsPageProps {
   packageManagerOverrides?: PackageManagerConfig[]
   showPackageManagers?: boolean
   pageTitle?: string
-  enterpriseMode: boolean
+  enterpriseMode?: boolean
   product: HashiCorpProduct
   latestVersion: string
   releases: ReleasesAPIResponse

--- a/packages/product-download-page/partials/download-cards/index.tsx
+++ b/packages/product-download-page/partials/download-cards/index.tsx
@@ -8,7 +8,7 @@ export default function DownloadTabs({
   tabData,
   downloads,
   version,
-  merchandisingSlot,
+  merchandisingSlot = null,
   logo,
   tutorialLink,
 }: DownloadTabsProps): React.ReactElement {
@@ -124,7 +124,7 @@ interface DownloadTabsProps {
   }[]
   downloads: SortedReleases
   version: string
-  merchandisingSlot: React.ReactElement
+  merchandisingSlot?: React.ReactElement
   logo: React.ReactElement
   tutorialLink: Link
 }

--- a/packages/product-download-page/partials/download-cards/index.tsx
+++ b/packages/product-download-page/partials/download-cards/index.tsx
@@ -8,7 +8,7 @@ export default function DownloadTabs({
   tabData,
   downloads,
   version,
-  merchandisingSlot = null,
+  merchandisingSlot,
   logo,
   tutorialLink,
 }: DownloadTabsProps): React.ReactElement {
@@ -30,7 +30,7 @@ export default function DownloadTabs({
               logo={logo}
               tutorialLink={tutorialLink}
             />
-            {merchandisingSlot}
+            {merchandisingSlot ? merchandisingSlot : null}
           </div>
         </Tab>
       ))}


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1201915132498455/f)
🔍 [Preview Link](https://react-components-git-zsupdate-downloads-page-hashicorp.vercel.app)

---

This PR makes minor modifications to `@hashicorp/react-product-download-page` in order to more accurately mark `merchandisingSlot` and `enterpriseMode` as optional props. This prevents consumers who do not want to use features behind these props from having to pass `merchandisingSlot={null}` and `enterpriseMode={false}` respectively.

This PR relates to hashicorp/dev-portal#153 - see https://github.com/hashicorp/dev-portal/pull/153#discussion_r819108688. I've proven out a pre-release in hashicorp/dev-portal#158.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
