### PR TITLE
fix: specify node 16 in canary-release workflow

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@master
 
-      - name: Setup Node.js 15.x
+      - name: Setup Node.js 16.x
         uses: actions/setup-node@master
         with:
-          node-version: 15.x
+          node-version: 16.x
 
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
> N / A -- 🎟️ Asana Task
🔍 [Preview Link](https://react-components-git-zsspecify-node-16-hashicorp.vercel.app)

---

This PR specifies node `16.x` in our `canary-release` workflow in order to avoid errors like https://github.com/hashicorp/react-components/runs/5428667254?check_suite_focus=true .

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
