### PR TITLE
feat(code-block): left-align tabs, fix valid children issue

### DIFF
--- a/.changeset/thirty-files-study.md
+++ b/.changeset/thirty-files-study.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-code-block': minor
+---
+
+Changes alignment of CodeTabs tab elements from right-aligned to left-aligned. Note that if the heading prop is used, then tab elements remained right-aligned, matching previous behaviour.

--- a/.changeset/thirty-files-study.md
+++ b/.changeset/thirty-files-study.md
@@ -2,4 +2,4 @@
 '@hashicorp/react-code-block': minor
 ---
 
-Changes alignment of CodeTabs tab elements from right-aligned to left-aligned. Note that if the heading prop is used, then tab elements remained right-aligned, matching previous behaviour.
+Changes alignment of CodeTabs tab elements from right-aligned to left-aligned. Note that if the heading prop is used, then tab elements remained right-aligned, matching previous behaviour. This release also fixes a bug in CodeTabs, where valid CodeBlock children would sometimes be incorrectly flagged as invalid.

--- a/packages/code-block/docs.mdx
+++ b/packages/code-block/docs.mdx
@@ -275,17 +275,41 @@ function hello() {
 
 The `CodeTabs` component, which is available in Learn and Docs MDX contexts, allows authors to create multi-snippet tabbed code blocks. `<CodeTabs>` is a wrapper component around child code blocks. Each child must be either a fenced code block, or must be a `<CodeBlockConfig>` which wraps a fenced code block.
 
+By default, the tab options are shown at the left of the component. When space is limited, tabs will automatically collapse into a dropdown menu. When a `heading` is provided to `CodeTabs`, the heading will be shown at left, and the tabs (or dropdown menu) will be shown at right.
+
+#### `CodeTabs` Playground
+
+<LiveComponent>{`
+<CodeTabs theme="dark">
+
+<CodeBlock
+  options={{ showClipboard: true, filename: 'hello-world.js' }}
+  language="javascript"
+  code={\`<span class="token console class-name">console</span><span class="token punctuation">.</span><span class="token method function property-access">log</span><span class="token punctuation">(</span><span class="token string">'hello world'</span><span class="token punctuation">)</span>\`}
+/>
+
+<CodeBlock
+  options={{ showClipboard: true }}
+  language="go"
+  code={\`<span class="token keyword">package</span> main<!-- -->
+<!-- -->
+<span class="token keyword">import</span> <span class="token string">"fmt"</span>
+<!-- -->
+<span class="token keyword">func</span> <span class="token function">main</span><span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
+<!-- -->  fmt<span class="token punctuation">.</span><span class="token function">Println</span><span class="token punctuation">(</span><span class="token string">"hello world"</span><span class="token punctuation">)</span>
+<span class="token punctuation">}</span>\`}
+/>
+
+</CodeTabs>
+`}</ LiveComponent>
+
 #### When to use `CodeTabs`
 
-Tabs should only be used when switching between similar content types such as:
+Tabs should only be used when switching between equivalent approaches to a particular task or workflow. Common examples include alternate configuration type, programming, languages, or operating systems:
 
 - Windows / macOS / Linux
 - HCL / JSON
 - JavaScript / BASH
-
-Essentially either similar languages or OSs, or more broadly, equivalent approaches to a particular task or workflow.
-
-Where space is limited, tabs will automatically collapse into a dropdown menu on the right side.
 
 #### With fenced code child tabs
 

--- a/packages/code-block/partials/code-tabs/index.js
+++ b/packages/code-block/partials/code-tabs/index.js
@@ -66,6 +66,9 @@ function CodeTabs({ children, heading, className, tabs, theme = 'dark' }) {
   // gather labels
   const tabLabels = parsedTabs.map((t) => t.label)
 
+  // if we have a heading, we align tabs right (and make some style tweaks)
+  const hasHeading = Boolean(heading)
+
   return (
     <div
       className={classNames(
@@ -78,7 +81,7 @@ function CodeTabs({ children, heading, className, tabs, theme = 'dark' }) {
         render={({ hasOverflow }, overflowRef) => {
           return (
             <div ref={overflowRef} className={classNames(s.topBar)}>
-              {heading ? (
+              {hasHeading ? (
                 <div
                   className={classNames(s.heading, {
                     [s.hasOverflow]: hasOverflow,
@@ -92,12 +95,14 @@ function CodeTabs({ children, heading, className, tabs, theme = 'dark' }) {
                   tabLabels={tabLabels}
                   activeTabIdx={activeTabIdx}
                   setActiveTabIdx={setActiveTabWithEvent}
+                  hasHeading={hasHeading}
                 />
               ) : (
                 <TabsAsTabs
                   tabLabels={tabLabels}
                   activeTabIdx={activeTabIdx}
                   setActiveTabIdx={setActiveTabWithEvent}
+                  hasHeading={hasHeading}
                 />
               )}
             </div>

--- a/packages/code-block/partials/code-tabs/index.js
+++ b/packages/code-block/partials/code-tabs/index.js
@@ -4,6 +4,8 @@ import resolveTabData from '../../utils/resolve-tab-data'
 import useIndexedTabs from '../../provider/use-indexed-tabs'
 import TabsAsDropdown from './partials/tabs-as-dropdown'
 import TabsAsTabs from './partials/tabs-as-tabs'
+import CodeBlock from '../../'
+import CodeBlockConfig from '../code-block-config'
 import OverflowDetector from './partials/overflow-detector'
 import themeDark from '../../theme-dark.module.css'
 import themeLight from '../../theme-light.module.css'
@@ -23,14 +25,31 @@ function CodeTabs({ children, heading, className, tabs, theme = 'dark' }) {
   // the expected CodeBlock, CodeBlockConfig, or pre
   const childTypes = validChildren.map((tabChild) => {
     let type
-    // For JSX primitives, the type of captured by the type property
-    if (typeof tabChild.type == 'string') type = tabChild.type
-    // For function components in JSX, ie CodeBlock and CodeBlockConfig,
-    // tabChild.type is a function whose name we need
-    if (typeof tabChild.type == 'function') type = tabChild.type.name
-    // In MDX contexts, the component type is captured in mdxType
-    if (typeof tabChild.props.mdxType === 'string')
+    // For JSX primitives, the type is captured by the type property
+    if (typeof tabChild.type == 'string' || typeof tabChild.type == 'number') {
+      type = tabChild.type
+      // For function components, accept CodeBlock or CodeBlockConfig.
+    } else if (typeof tabChild.type === 'function') {
+      // Note that function names may be minified, we repeat them here
+      // so that error messages are more helpful.
+      const validComponents = [
+        { component: CodeBlock, name: 'CodeBlock' },
+        { component: CodeBlockConfig, name: 'CodeBlockConfig' },
+      ]
+      const matchIdx = validComponents
+        .map((c) => c.component)
+        .indexOf(tabChild.type)
+      if (matchIdx >= 0) {
+        type = validComponents[matchIdx].name
+      } else {
+        type = 'Unrecognized component'
+      }
+    }
+    // In MDX contexts, the component type is captured in mdxType,
+    // and this should override any previously derived type.
+    if (typeof tabChild.props?.mdxType === 'string') {
       type = tabChild.props.mdxType
+    }
     return type
   })
   const validTypes = [

--- a/packages/code-block/partials/code-tabs/index.test.js
+++ b/packages/code-block/partials/code-tabs/index.test.js
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import CodeTabs from './'
 import CodeBlock from '../../'
+import CodeBlockConfig from '../code-block-config'
 import CodeTabsProvider from '../../provider'
 
 // getAllByText is needed, as we sometimes render dummy elements
@@ -8,7 +9,7 @@ import CodeTabsProvider from '../../provider'
 // and for simpler copy-to-clipboard logic
 function getSecondByText(text) {
   /* eslint-disable-next-line no-unused-vars */
-  const [firstElem, secondElem] = screen.getAllByText(text)
+  const [_firstElem, secondElem] = screen.getAllByText(text)
   return secondElem
 }
 
@@ -23,6 +24,35 @@ it('should accept a className prop, and place it on the root element', () => {
     </CodeTabsProvider>
   )
   expect(container.firstChild.className).toContain(customClassName)
+})
+
+it('should accept CodeBlockConfig or pre elements as children', () => {
+  // Note: we suppress console.error for this test.
+  // We expect a warning that React does not recognize the `hasBarAbove`
+  // prop on the first `pre` element. In MDX this is a non-issue since
+  // `pre` would be mapped to our `CodeBlock` component,
+  // via @hashicorp/react-code-block/mdx.
+  jest.spyOn(console, 'error')
+  global.console.error.mockImplementation(() => {})
+  expect(() => {
+    render(
+      <CodeTabsProvider>
+        <CodeTabs>
+          <pre>
+            <code>Hello world!</code>
+          </pre>
+          <CodeBlockConfig>
+            <pre mdxType="pre">
+              <code>Hello world!</code>
+            </pre>
+          </CodeBlockConfig>
+          <CodeBlock language="go" code="fmt.Println('Hello world!')" />
+        </CodeTabs>
+      </CodeTabsProvider>
+    )
+  }).not.toThrowError()
+  //  Restore console.error for further tests
+  global.console.error.mockRestore()
 })
 
 it('should render the heading prop', () => {

--- a/packages/code-block/partials/code-tabs/index.test.js
+++ b/packages/code-block/partials/code-tabs/index.test.js
@@ -9,7 +9,7 @@ import CodeTabsProvider from '../../provider'
 // and for simpler copy-to-clipboard logic
 function getSecondByText(text) {
   /* eslint-disable-next-line no-unused-vars */
-  const [_firstElem, secondElem] = screen.getAllByText(text)
+  const [, secondElem] = screen.getAllByText(text)
   return secondElem
 }
 

--- a/packages/code-block/partials/code-tabs/index.test.js
+++ b/packages/code-block/partials/code-tabs/index.test.js
@@ -42,6 +42,8 @@ it('should accept CodeBlockConfig or pre elements as children', () => {
             <code>Hello world!</code>
           </pre>
           <CodeBlockConfig>
+            {/* Note: do not use mdxType in JSX, this is here to mock what
+            would happen, without having to run the MDX processing chain */}
             <pre mdxType="pre">
               <code>Hello world!</code>
             </pre>

--- a/packages/code-block/partials/code-tabs/partials/tabs-as-dropdown/index.js
+++ b/packages/code-block/partials/code-tabs/partials/tabs-as-dropdown/index.js
@@ -5,14 +5,22 @@ import {
   ListboxList,
   ListboxOption,
 } from '@reach/listbox'
+import classNames from 'classnames'
 import InlineSvg from '@hashicorp/react-inline-svg'
 import svgChevronDown from './chevron-down.svg?include'
 import s from './style.module.css'
 
-function TabsAsDropdown({ tabLabels, activeTabIdx, setActiveTabIdx }) {
+function TabsAsDropdown({
+  tabLabels,
+  activeTabIdx,
+  setActiveTabIdx,
+  hasHeading,
+}) {
   const activeLabel = tabLabels.filter((_l, idx) => idx == activeTabIdx)[0]
   return (
-    <div className={s.tabsAsDropdown}>
+    <div
+      className={classNames(s.tabsAsDropdown, { [s.hasHeading]: hasHeading })}
+    >
       <ListboxInput className={s.listboxInput} onChange={setActiveTabIdx}>
         <ListboxButton className={s.listboxButton}>
           {activeLabel}

--- a/packages/code-block/partials/code-tabs/partials/tabs-as-dropdown/style.module.css
+++ b/packages/code-block/partials/code-tabs/partials/tabs-as-dropdown/style.module.css
@@ -6,9 +6,12 @@ to be present.
 
 .tabsAsDropdown {
   display: flex;
-  margin-left: auto;
   justify-content: flex-end;
   flex-wrap: wrap;
+
+  &.hasHeading {
+    margin-left: auto;
+  }
 }
 
 .listboxInput {

--- a/packages/code-block/partials/code-tabs/partials/tabs-as-tabs/index.js
+++ b/packages/code-block/partials/code-tabs/partials/tabs-as-tabs/index.js
@@ -2,16 +2,20 @@ import React from 'react'
 import classNames from 'classnames'
 import s from './style.module.css'
 
-function TabsAsTabs({ tabLabels, activeTabIdx, setActiveTabIdx }) {
+function TabsAsTabs({ tabLabels, activeTabIdx, setActiveTabIdx, hasHeading }) {
   return (
-    <div className={s.tabsAsTabs}>
+    <div className={classNames(s.tabsAsTabs, { [s.hasHeading]: hasHeading })}>
       {tabLabels.map((tabLabel, idx) => {
         const isActive = idx == activeTabIdx
         return (
           <button
             // eslint-disable-next-line react/no-array-index-key
             key={idx}
-            className={classNames(s.tabControl, { [s.isActive]: isActive })}
+            className={classNames(
+              s.tabControl,
+              { [s.isActive]: isActive },
+              { [s.hasHeading]: hasHeading }
+            )}
             onClick={() => setActiveTabIdx(idx)}
           >
             {tabLabel}

--- a/packages/code-block/partials/code-tabs/partials/tabs-as-tabs/style.module.css
+++ b/packages/code-block/partials/code-tabs/partials/tabs-as-tabs/style.module.css
@@ -22,6 +22,9 @@ to be present.
   min-height: var(--base-height);
   padding: 0 16px;
 
+  /* note that the parent `topBar` has corner rounding,
+  we need to round either the first or last tab depending on alignment.
+  without a heading, we're left-aligned, with heading, we're right-aligned. */
   &:not(.hasHeading) {
     &:first-child {
       border-top-left-radius: 4px;

--- a/packages/code-block/partials/code-tabs/partials/tabs-as-tabs/style.module.css
+++ b/packages/code-block/partials/code-tabs/partials/tabs-as-tabs/style.module.css
@@ -6,8 +6,11 @@ to be present.
 
 .tabsAsTabs {
   display: flex;
-  margin-left: auto;
   justify-content: flex-end;
+
+  &.hasHeading {
+    margin-left: auto;
+  }
 }
 
 .tabControl {
@@ -19,8 +22,16 @@ to be present.
   min-height: var(--base-height);
   padding: 0 16px;
 
-  &:last-child {
-    border-top-right-radius: 4px;
+  &:not(.hasHeading) {
+    &:first-child {
+      border-top-left-radius: 4px;
+    }
+  }
+
+  &.hasHeading {
+    &:last-child {
+      border-top-right-radius: 4px;
+    }
   }
 
   &:hover {

--- a/packages/code-block/partials/code-tabs/style.module.css
+++ b/packages/code-block/partials/code-tabs/style.module.css
@@ -15,7 +15,10 @@ to be present.
   align-items: center;
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;
-  padding-left: 4px;
+
+  &.hasHeading {
+    padding-left: 4px;
+  }
 }
 
 .heading {


### PR DESCRIPTION

🎟️ [Asana Task - Alignment](https://app.asana.com/0/1100423001970639/1201866381269498/f)
🎟️ [Asana Task - Children validation fix](https://app.asana.com/0/1100423001970639/1201881376116200/f)
🔍 [Preview Link](https://react-components-git-zscode-tabs-alignment-hashicorp.vercel.app/components/codeblock)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR...

This PR also fixes a bug in `CodeTabs` related to validation of children elements, which prevented some use in JSX. With this fix in place, `CodeTabs` should correctly validate the use of `CodeBlock` children in JSX.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201881376116200
  - https://app.asana.com/0/0/1201866381269498