### PR TITLE
fix(product-download-page): type error when @types/semver is present

### DIFF
--- a/.changeset/tiny-games-pull.md
+++ b/.changeset/tiny-games-pull.md
@@ -2,4 +2,4 @@
 '@hashicorp/react-product-downloads-page': patch
 ---
 
-Install `@types/semver`; Fix a type error
+Install `@types/semver`; Fix incorrect `semverValid` usage

--- a/.changeset/tiny-games-pull.md
+++ b/.changeset/tiny-games-pull.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-product-downloads-page': patch
+---
+
+Install `@types/semver`; Fix a type error

--- a/package-lock.json
+++ b/package-lock.json
@@ -31306,6 +31306,7 @@
       }
     },
     "packages/badge": {
+      "name": "@hashicorp/react-badge",
       "version": "0.1.0",
       "license": "MPL-2.0",
       "dependencies": {
@@ -31789,10 +31790,19 @@
         "@hashicorp/react-tabs": "^7.1.2",
         "semver": "^7.3.5"
       },
+      "devDependencies": {
+        "@types/semver": "^7.3.9"
+      },
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",
         "react": ">=16.x"
       }
+    },
+    "packages/product-download-page/node_modules/@types/semver": {
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+      "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==",
+      "dev": true
     },
     "packages/product-features-list": {
       "name": "@hashicorp/react-product-features-list",
@@ -35407,7 +35417,16 @@
         "@hashicorp/react-button": "^6.0.4",
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-tabs": "^7.1.2",
+        "@types/semver": "*",
         "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "@types/semver": {
+          "version": "7.3.9",
+          "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+          "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==",
+          "dev": true
+        }
       }
     },
     "@hashicorp/react-product-features-list": {

--- a/packages/product-download-page/package.json
+++ b/packages/product-download-page/package.json
@@ -21,5 +21,8 @@
   "license": "MPL-2.0",
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "@types/semver": "^7.3.9"
   }
 }

--- a/packages/product-download-page/utils/downloader.ts
+++ b/packages/product-download-page/utils/downloader.ts
@@ -12,7 +12,7 @@ export function getVersionLabel(
 }
 
 export function sortAndFilterReleases(releases: string[]): string[] {
-  const validReleases = releases.filter(semverValid)
+  const validReleases = releases.filter((rel) => semverValid(rel))
   // descending sort on releases, while filtering out pre-releases
   return semverRSort(validReleases).filter(
     (version) => !semverPrerelease(version)


### PR DESCRIPTION
## Description

This fixes a type error encountered in Dev-Portal (reported by @ashleemboyer), by adding `@types/semver` and fixing `semverValid` usage

<img width="1230" alt="image" src="https://user-images.githubusercontent.com/26389321/157914481-22d09540-44d4-488f-b3ad-5b51bc074b65.png">


### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201944395382131