### PR TITLE
fix: mark versions as an optional property

### DIFF
--- a/.changeset/sour-icons-clean.md
+++ b/.changeset/sour-icons-clean.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-page': patch
+---
+
+Mark `versions` as an optional property

--- a/packages/docs-page/index.tsx
+++ b/packages/docs-page/index.tsx
@@ -36,7 +36,7 @@ interface DocsPageInnerProps {
   /** @deprecated */
   showEditPage: boolean
   showVersionSelect: boolean
-  versions: VersionSelectItem[]
+  versions?: VersionSelectItem[]
   algoliaConfig?: AlgoliaConfigObject
 }
 
@@ -83,7 +83,7 @@ export const DocsPageInner: FunctionComponent<DocsPageInnerProps> = ({
 
   const versionSelect = showVersionSelect ? (
     <div className={s.versionSelect}>
-      <VersionSelect versions={versions} basePath={baseRoute} />
+      <VersionSelect versions={versions ?? []} basePath={baseRoute} />
     </div>
   ) : null
 
@@ -176,7 +176,7 @@ export interface DocsPageProps {
     currentPath: string
     navData: NavData
     githubFileUrl: string
-    versions: VersionSelectItem[]
+    versions?: VersionSelectItem[]
   }
 }
 


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

`DocsPage` required a `versions` property for `staticProps` even when versioned docs weren't being used. This PR marks `versions` as optional!

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
