### PR TITLE
Allow null values for `canonicalUrl`

### DIFF
--- a/.changeset/great-pugs-help.md
+++ b/.changeset/great-pugs-help.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-page': patch
+---
+
+Update TypeScript types to allow `null` as a value for `canonicalUrl`

--- a/packages/docs-page/index.tsx
+++ b/packages/docs-page/index.tsx
@@ -25,7 +25,7 @@ import s from './style.module.css'
 import type { VersionSelectItem } from './server/loaders/remote-content'
 
 interface DocsPageInnerProps {
-  canonicalUrl: string
+  canonicalUrl: string | null
   description: string
   navData: NavData
   currentPath: string
@@ -96,7 +96,7 @@ export const DocsPageInner: FunctionComponent<DocsPageInnerProps> = ({
     <div id="p-docs">
       {/* render the page's data to the document head */}
       <HashiHead
-        canonicalUrl={canonicalUrl}
+        canonicalUrl={canonicalUrl ?? undefined}
         description={description}
         siteName={`${name} by HashiCorp`}
         title={`${pageTitle} | ${name} by HashiCorp`}
@@ -169,7 +169,7 @@ export interface DocsPageProps {
   staticProps: {
     mdxSource: MDXRemoteSerializeResult
     frontMatter: {
-      canonical_url: string
+      canonical_url: string | null
       description: string
       page_title: string
     }


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR modifies the TypeScript types for `DocsPage` to allow passing `null` for `canonicalUrl`.

Packer plugins are rendered with an undefined `canonicalUrl`, which normally works since the JSON serialization that's performed as part of `getStaticProps` doesn't serialize undefined properties. However, when attempting to pass a typecheck, we're requiring a string value for `canonicalUrl`. Setting it to `undefined` doesn't work since Next can detect that you've defined a property as `undefined`, and returns an error. This change allows passing in a `null` to signify that you don't have a `canonicalUrl` and still satisfy the typechecker.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
