### PR TITLE
feat(docs-page): support latestVersionRef option to RemoteContentLoader

### DIFF
--- a/.changeset/large-comics-change.md
+++ b/.changeset/large-comics-change.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-page': minor
+---
+
+Add latestVersionRef option to RemoteContentLoader

--- a/packages/docs-page/server/loaders/file-system.ts
+++ b/packages/docs-page/server/loaders/file-system.ts
@@ -52,6 +52,9 @@ export default class FileSystemLoader implements DataLoader {
           '`remarkPlugins:` When specified as a function, must return an array of remark plugins'
         )
       }
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we default this in the constructor, so it must be defined
+      remarkPlugins = this.opts.remarkPlugins!
     }
 
     const mdxRenderer = (mdx) =>

--- a/packages/docs-page/server/loaders/remote-content.ts
+++ b/packages/docs-page/server/loaders/remote-content.ts
@@ -200,7 +200,7 @@ export default class RemoteContentLoader implements DataLoader {
       // Link latest version to `main`
       // Hide link on older versions
       const isLatest =
-        Boolean(this.opts.latestVersionRef) ??
+        (versionFromPath === 'latest' && Boolean(this.opts.latestVersionRef)) ||
         versionMetadataList.find((e) => e.version === document.version)!
           .isLatest
       if (isLatest) {

--- a/packages/docs-page/server/loaders/remote-content.ts
+++ b/packages/docs-page/server/loaders/remote-content.ts
@@ -132,6 +132,9 @@ export default class RemoteContentLoader implements DataLoader {
           '`remarkPlugins:` When specified as a function, must return an array of remark plugins'
         )
       }
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we default this in the constructor, so it must be defined
+      remarkPlugins = this.opts.remarkPlugins!
     }
 
     const mdxRenderer = (mdx) =>
@@ -196,9 +199,10 @@ export default class RemoteContentLoader implements DataLoader {
     if (document.githubFile) {
       // Link latest version to `main`
       // Hide link on older versions
-      const isLatest = versionMetadataList.find(
-        (e) => e.version === document.version
-      )!.isLatest
+      const isLatest =
+        Boolean(this.opts.latestVersionRef) ??
+        versionMetadataList.find((e) => e.version === document.version)!
+          .isLatest
       if (isLatest) {
         // GitHub only allows you to modify a file if you are on a branch, not a commit
         githubFileUrl = `https://github.com/hashicorp/${this.opts.product}/blob/${this.opts.mainBranch}/${document.githubFile}`


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Supports a `latestVersionRef` option for `RemoteContentLoader` which forces the "latest" version to fetch from a specific ref.

e.g. if we're viewing `waypointproject.io/docs` and we pass `latestVersionRef: 'dev-portal'`, the loader would attempt to load content from `/api/content/waypoint/doc/dev-portal/docs` instead of whatever the latest version is (maybe `/api/content/waypoint/doc/v0.7.x/docs`).

I also fixed a bug with the recent addition to support passing `remarkPlugins` as a function.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
