### PR TITLE
chore(radiogroup): prop type update

### DIFF
--- a/.changeset/metal-coins-reply.md
+++ b/.changeset/metal-coins-reply.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-radio-group': patch
+---
+
+Make layout and variant props optional

--- a/packages/radio-group/types.ts
+++ b/packages/radio-group/types.ts
@@ -2,11 +2,11 @@ export interface RadioGroupProps {
   /**
    * Render radios inline or stacked.
    */
-  layout: 'stacked' | 'inline'
+  layout?: 'stacked' | 'inline'
   /**
    * Render on light or dark backgrounds.
    */
-  variant: 'light' | 'dark'
+  variant?: 'light' | 'dark'
   /**
    * A label that describes the radio options.
    */

--- a/packages/radio-group/types.ts
+++ b/packages/radio-group/types.ts
@@ -27,7 +27,7 @@ export interface RadioGroupProps {
   /**
    * A function that will be called when a radio option is clicked. Returns the radio options value.
    */
-  onChange: (value: string) => string
+  onChange: (value: string) => void
   /**
    * If true, renders an error message.
    */


### PR DESCRIPTION
🔍 [Preview Link](https://react-components-git-acradio-group-optional-props-hashicorp.vercel.app/components/radiogroup)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

- Makes layout and variant props optional
- Fixes onChange type

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
