### PR TITLE
chore: convert to `appearance` prop for light/dark modes

### DIFF
--- a/.changeset/tough-laws-smile.md
+++ b/.changeset/tough-laws-smile.md
@@ -1,0 +1,9 @@
+---
+'@hashicorp/react-actions': minor
+'@hashicorp/react-author-byline': minor
+'@hashicorp/react-intro': minor
+'@hashicorp/react-quote': minor
+'@hashicorp/react-radio-group': minor
+---
+
+Convert to use appearance prop

--- a/packages/actions/docs.mdx
+++ b/packages/actions/docs.mdx
@@ -17,6 +17,55 @@ componentName: 'Actions'
   ]}
 />`}</LiveComponent>
 
+## Examples
+
+<h3 className="g-type-label" style={{ color: 'var(--gray-3)' }}>
+  Light theme
+</h3>
+
+<div style={{padding: "24px", border: "1px solid var(--gray-6)"}}>
+
+<Actions
+  ctas={[
+    {
+      title: 'View tutorials',
+      url: '/tutorials',
+      variant: 'primary',
+    },
+    {
+      title: 'View documentation',
+      url: '/docs',
+      variant: 'tertiary-neutral',
+    },
+  ]}
+/>
+
+</div>
+
+<h3 className="g-type-label" style={{ color: 'var(--gray-3)' }}>
+  Dark theme
+</h3>
+
+<div style={{padding: "24px", background: "black"}}>
+
+<Actions
+  appearance="dark"
+  ctas={[
+    {
+      title: 'View tutorials',
+      url: '/tutorials',
+      variant: 'primary',
+    },
+    {
+      title: 'View documentation',
+      url: '/docs',
+      variant: 'tertiary-neutral',
+    },
+  ]}
+/>
+
+</div>
+
 ### Props
 
 <PropsTable props={componentProps} />

--- a/packages/actions/index.tsx
+++ b/packages/actions/index.tsx
@@ -4,6 +4,7 @@ import type { ActionsProps } from './types'
 import s from './style.module.css'
 
 export default function Actions({
+  appearance = 'light',
   layout = 'inline',
   brand = 'hashicorp',
   size = 'medium',
@@ -25,6 +26,7 @@ export default function Actions({
             theme={{
               brand: brand,
               variant: cta.variant || 'primary',
+              background: appearance === 'dark' ? 'dark' : undefined,
             }}
           />
         )

--- a/packages/actions/props.js
+++ b/packages/actions/props.js
@@ -1,4 +1,9 @@
 module.exports = {
+  appearance: {
+    type: 'string',
+    description: 'Display actions on light or dark background.',
+    options: ['light', 'dark'],
+  },
   layout: {
     type: 'string',
     description: 'Display buttons inline or stacked by default.',

--- a/packages/actions/types.ts
+++ b/packages/actions/types.ts
@@ -24,6 +24,10 @@ type DuoCta = [CtaProps, CtaProps]
 
 export interface ActionsProps {
   /**
+   * Display actions on light or dark background.
+   */
+  appearance?: 'light' | 'dark'
+  /**
    * Display buttons inline or stacked by default.
    */
   layout?: 'inline' | 'stacked'

--- a/packages/author-byline/docs.mdx
+++ b/packages/author-byline/docs.mdx
@@ -10,14 +10,36 @@ componentName: 'AuthorByline'
   />
 </div>`}</LiveComponent>
 
-<LiveComponent>{`<div style={{ padding: 24, background: 'black' }}>
-  <AuthorByline
-    appearance="dark"
-    avatar="https://www.datocms-assets.com/2885/1560891392-cropped0000armon.jpg"
-    name="Name"
-    role="Company, Role"
-  />
-</div>`}</LiveComponent>
+## Examples
+
+<h3 className="g-type-label" style={{ color: 'var(--gray-3)' }}>
+  Light theme
+</h3>
+
+<div style={{padding: "24px", border: "1px solid var(--gray-6)"}}>
+
+<AuthorByline
+  avatar="https://www.datocms-assets.com/2885/1560891392-cropped0000armon.jpg"
+  name="Name"
+  role="Company, Role"
+/>
+
+</div>
+
+<h3 className="g-type-label" style={{ color: 'var(--gray-3)' }}>
+  Dark theme
+</h3>
+
+<div style={{padding: "24px", background: "black"}}>
+
+<AuthorByline
+  appearance="dark"
+  avatar="https://www.datocms-assets.com/2885/1560891392-cropped0000armon.jpg"
+  name="Name"
+  role="Company, Role"
+/>
+
+</div>
 
 ### Props
 

--- a/packages/author-byline/docs.mdx
+++ b/packages/author-byline/docs.mdx
@@ -12,7 +12,7 @@ componentName: 'AuthorByline'
 
 <LiveComponent>{`<div style={{ padding: 24, background: 'black' }}>
   <AuthorByline
-    variant="dark"
+    appearance="dark"
     avatar="https://www.datocms-assets.com/2885/1560891392-cropped0000armon.jpg"
     name="Name"
     role="Company, Role"

--- a/packages/author-byline/index.test.js
+++ b/packages/author-byline/index.test.js
@@ -16,10 +16,10 @@ describe('<AuthorByline />', () => {
     expect(screen.getByAltText('Name avatar')).toBeInTheDocument()
   })
 
-  it('should render variant', () => {
+  it('should render dark appearance', () => {
     render(
       <AuthorByline
-        variant="dark"
+        appearance="dark"
         avatar="https://www.datocms-assets.com/2885/1560891392-cropped0000armon.jpg"
         name="Name"
         role="Company, Role"

--- a/packages/author-byline/index.tsx
+++ b/packages/author-byline/index.tsx
@@ -8,12 +8,11 @@ export default function AuthorByline({
   avatar,
   name,
   role,
-  variant = 'light',
   appearance = 'light',
 }: AuthorBylineProps): React.ReactElement {
   return (
     <div
-      className={classNames(s.authorByline, s[variant], s[appearance])}
+      className={classNames(s.authorByline, s[appearance])}
       data-testid="author-byline"
     >
       {avatar ? (

--- a/packages/author-byline/index.tsx
+++ b/packages/author-byline/index.tsx
@@ -9,10 +9,11 @@ export default function AuthorByline({
   name,
   role,
   variant = 'light',
+  appearance = 'light',
 }: AuthorBylineProps): React.ReactElement {
   return (
     <div
-      className={classNames(s.authorByline, s[variant])}
+      className={classNames(s.authorByline, s[variant], s[appearance])}
       data-testid="author-byline"
     >
       {avatar ? (

--- a/packages/author-byline/props.js
+++ b/packages/author-byline/props.js
@@ -18,4 +18,9 @@ module.exports = {
     options: ['light', 'dark'],
     description: 'Render on light or dark backgrounds',
   },
+  appearance: {
+    type: 'string',
+    options: ['light', 'dark'],
+    description: 'Render on light or dark backgrounds',
+  },
 }

--- a/packages/author-byline/types.ts
+++ b/packages/author-byline/types.ts
@@ -12,11 +12,6 @@ export interface AuthorBylineProps {
    */
   role: string
   /**
-   * @deprecated Use `appearance` instead
-   * Render on light or dark backgrounds
-   */
-  variant?: 'light' | 'dark'
-  /**
    * Render on light or dark backgrounds
    */
   appearance?: 'light' | 'dark'

--- a/packages/author-byline/types.ts
+++ b/packages/author-byline/types.ts
@@ -12,7 +12,12 @@ export interface AuthorBylineProps {
    */
   role: string
   /**
+   * @deprecated Use `appearance` instead
    * Render on light or dark backgrounds
    */
   variant?: 'light' | 'dark'
+  /**
+   * Render on light or dark backgrounds
+   */
+  appearance?: 'light' | 'dark'
 }

--- a/packages/intro/docs.mdx
+++ b/packages/intro/docs.mdx
@@ -22,6 +22,65 @@ componentName: 'Intro'
   }}
 />`}</LiveComponent>
 
+## Examples
+
+<h3 className="g-type-label" style={{ color: 'var(--gray-3)' }}>
+  Light theme
+</h3>
+
+<div style={{padding: "24px", border: "1px solid var(--gray-6)"}}>
+
+<Intro
+  eyebrow="Volutpat enim fusce tempor"
+  heading="Sit et bibendum adipiscing non mi tempor neque"
+  description="Cras ullamcorper duis nunc velit commodo etiam. Auctor tincidunt pellentesque ullamcorper nisi integer. Mattis quisque porta vel euismod velit id. Arcu bibendum neque adipiscing et cras facilisi."
+  actions={{
+    ctas: [
+      {
+        title: 'View tutorials',
+        url: '/tutorials',
+        variant: 'primary',
+      },
+      {
+        title: 'View documentation',
+        url: '/docs',
+        variant: 'tertiary-neutral',
+      },
+    ],
+  }}
+/>
+
+</div>
+
+<h3 className="g-type-label" style={{ color: 'var(--gray-3)' }}>
+  Dark theme
+</h3>
+
+<div style={{padding: "24px", background: "black"}}>
+
+<Intro
+  appearance="dark"
+  eyebrow="Volutpat enim fusce tempor"
+  heading="Sit et bibendum adipiscing non mi tempor neque"
+  description="Cras ullamcorper duis nunc velit commodo etiam. Auctor tincidunt pellentesque ullamcorper nisi integer. Mattis quisque porta vel euismod velit id. Arcu bibendum neque adipiscing et cras facilisi."
+  actions={{
+    ctas: [
+      {
+        title: 'View tutorials',
+        url: '/tutorials',
+        variant: 'primary',
+      },
+      {
+        title: 'View documentation',
+        url: '/docs',
+        variant: 'tertiary-neutral',
+      },
+    ],
+  }}
+/>
+
+</div>
+
 ## Props
 
 <PropsTable props={componentProps} />

--- a/packages/intro/index.tsx
+++ b/packages/intro/index.tsx
@@ -4,6 +4,7 @@ import type { IntroProps } from './types'
 import s from './style.module.css'
 
 export default function Intro({
+  appearance = 'light',
   textAlignment = 'left',
   eyebrow,
   heading,
@@ -18,7 +19,10 @@ export default function Intro({
     : 'g-type-body'
   const renderActions = actions && actions.ctas?.length > 0
   return (
-    <div className={classNames(s.intro, s[textAlignment])} data-testid="intro">
+    <div
+      className={classNames(s.intro, s[appearance], s[textAlignment])}
+      data-testid="intro"
+    >
       {eyebrow ? <p className={s.eyebrow}>{eyebrow}</p> : null}
       <HeadingElement className={classNames(s.heading, headingSizeClassname)}>
         {heading}
@@ -28,7 +32,7 @@ export default function Intro({
       </p>
       {renderActions ? (
         <div className={s.actions}>
-          <Actions {...actions} />
+          <Actions appearance={appearance} {...actions} />
         </div>
       ) : null}
     </div>

--- a/packages/intro/props.js
+++ b/packages/intro/props.js
@@ -1,4 +1,9 @@
 module.exports = {
+  appearance: {
+    type: 'string',
+    description: 'Display intro on light or dark backgrounds.',
+    options: ['light', 'dark'],
+  },
   textAlignment: {
     type: 'string',
     description: 'Controls the text alignment rendering.',

--- a/packages/intro/style.module.css
+++ b/packages/intro/style.module.css
@@ -10,19 +10,37 @@
 }
 
 .eyebrow {
+  --color: var(--gray-2);
+
   composes: g-type-label-strong from global;
   margin: 0 0 16px;
-  color: var(--gray-2);
+  color: var(--color);
+
+  @nest .dark & {
+    --color: var(--gray-4);
+  }
 }
 
 .heading {
+  --color: var(--black);
+
   margin: 0;
-  color: var(--black);
+  color: var(--color);
+
+  @nest .dark & {
+    --color: var(--white);
+  }
 }
 
 .description {
+  --color: var(--gray-2);
+
   margin: 16px 0 0;
-  color: var(--gray-2);
+  color: var(--color);
+
+  @nest .dark & {
+    --color: var(--gray-4);
+  }
 }
 
 .actions {

--- a/packages/intro/types.ts
+++ b/packages/intro/types.ts
@@ -1,6 +1,10 @@
 import type { ActionsProps } from '@hashicorp/react-actions/types'
 export interface IntroProps {
   /**
+   * Display intro on light or dark backgrounds.
+   */
+  appearance?: 'light' | 'dark'
+  /**
    * Controls the text alignment rendering.
    */
   textAlignment?: 'left' | 'center'

--- a/packages/quote/docs.mdx
+++ b/packages/quote/docs.mdx
@@ -11,15 +11,38 @@ componentName: 'Quote'
   />
 </div>`}</LiveComponent>
 
-<LiveComponent>{`<div style={{ padding: 24, background: 'black' }}>
-  <Quote
-    variant="dark"
-    text="Amet, nisl massa id egestas tincidunt urna tortor id bibendum. Mauris elit nunc fermentum elit mi varius suspendisse ut dictum. Nec a, massa vitae, viverra ultricies."
-    avatar="https://www.datocms-assets.com/2885/1560891392-cropped0000armon.jpg"
-    name="Name"
-    role="Company, Role"
-  />
-</div>`}</LiveComponent>
+## Examples
+
+<h3 className="g-type-label" style={{ color: 'var(--gray-3)' }}>
+  Light theme
+</h3>
+
+<div style={{padding: "24px", border: "1px solid var(--gray-6)"}}>
+
+<Quote
+  text="Amet, nisl massa id egestas tincidunt urna tortor id bibendum. Mauris elit nunc fermentum elit mi varius suspendisse ut dictum. Nec a, massa vitae, viverra ultricies."
+  avatar="https://www.datocms-assets.com/2885/1560891392-cropped0000armon.jpg"
+  name="Name"
+  role="Company, Role"
+/>
+
+</div>
+
+<h3 className="g-type-label" style={{ color: 'var(--gray-3)' }}>
+  Dark theme
+</h3>
+
+<div style={{padding: "24px", background: "black"}}>
+
+<Quote
+  appearance="dark"
+  text="Amet, nisl massa id egestas tincidunt urna tortor id bibendum. Mauris elit nunc fermentum elit mi varius suspendisse ut dictum. Nec a, massa vitae, viverra ultricies."
+  avatar="https://www.datocms-assets.com/2885/1560891392-cropped0000armon.jpg"
+  name="Name"
+  role="Company, Role"
+/>
+
+</div>
 
 ### Props
 

--- a/packages/quote/index.test.js
+++ b/packages/quote/index.test.js
@@ -18,10 +18,10 @@ describe('<Quote />', () => {
     expect(element).toHaveTextContent(text)
   })
 
-  it('should render variant', () => {
+  it('should render dark appearance', () => {
     render(
       <Quote
-        variant="dark"
+        appearance="dark"
         text="Sample quote text"
         avatar="https://www.datocms-assets.com/2885/1560891392-cropped0000armon.jpg"
         name="Name"

--- a/packages/quote/index.tsx
+++ b/packages/quote/index.tsx
@@ -8,10 +8,10 @@ export default function Quote({
   avatar,
   name,
   role,
-  variant = 'light',
+  appearance = 'light',
 }: QuoteProps) {
   return (
-    <figure className={classNames(s.quote, s[variant])} data-testid="quote">
+    <figure className={classNames(s.quote, s[appearance])} data-testid="quote">
       <blockquote className={s.text}>
         <p>{text}</p>
       </blockquote>
@@ -20,7 +20,7 @@ export default function Quote({
           avatar={avatar}
           name={name}
           role={role}
-          variant={variant}
+          appearance={appearance}
         />
       </figcaption>
     </figure>

--- a/packages/quote/props.js
+++ b/packages/quote/props.js
@@ -17,7 +17,7 @@ module.exports = {
     required: true,
     description: 'Renders as the second line of the byline',
   },
-  variant: {
+  appearance: {
     type: 'string',
     options: ['light', 'dark'],
     description: 'Render on light or dark backgrounds',

--- a/packages/radio-group/docs.mdx
+++ b/packages/radio-group/docs.mdx
@@ -69,7 +69,7 @@ componentName: 'RadioGroup'
 <div style={{padding: "24px", background: "black"}}>
 
 <RadioGroup
-  variant="dark"
+  appearance="dark"
   label="Label"
   helpText="Eu, tempor dignissim in nulla ligula ac ut. Tellus nibh cras nec blandit."
   name="example-two"

--- a/packages/radio-group/index.test.js
+++ b/packages/radio-group/index.test.js
@@ -77,10 +77,10 @@ describe('<RadioGroup />', () => {
     expect(screen.getByText(errorText)).toBeInTheDocument()
   })
 
-  it('should render variants', () => {
+  it('should render dark appearance', () => {
     render(
       <RadioGroup
-        variant="dark"
+        appearance="dark"
         label="Locations"
         name="location"
         value={null}

--- a/packages/radio-group/index.tsx
+++ b/packages/radio-group/index.tsx
@@ -6,7 +6,7 @@ import s from './style.module.css'
 
 export default function RadioGroup({
   layout = 'stacked',
-  variant = 'light',
+  appearance = 'light',
   label,
   helpText,
   name,
@@ -17,7 +17,7 @@ export default function RadioGroup({
 }: RadioGroupProps) {
   return (
     <fieldset
-      className={classNames(s.radioGroup, s[variant])}
+      className={classNames(s.radioGroup, s[appearance])}
       data-testid="radio-group"
     >
       <legend className={s.label}>{label}</legend>
@@ -32,8 +32,8 @@ export default function RadioGroup({
         {options.map((option, index) => {
           return (
             <RadioInput
-              variant={variant}
               key={index}
+              appearance={appearance}
               label={option.label}
               name={name}
               value={option.value}

--- a/packages/radio-group/props.js
+++ b/packages/radio-group/props.js
@@ -4,7 +4,7 @@ module.exports = {
     descrition: 'Render radios inline or stacked.',
     options: ['stacked', 'inline'],
   },
-  variant: {
+  appearance: {
     type: 'string',
     description: 'Render on light or dark backgrounds.',
     options: ['light', 'dark'],

--- a/packages/radio-group/radio-input/index.test.js
+++ b/packages/radio-group/radio-input/index.test.js
@@ -53,10 +53,10 @@ describe('<RadioInput />', () => {
     expect(input).toBeDisabled()
   })
 
-  it('should render variants', () => {
+  it('should render dark appearance', () => {
     render(
       <RadioInput
-        variant="dark"
+        appearance="dark"
         name="location"
         label="California"
         value="california"

--- a/packages/radio-group/radio-input/index.tsx
+++ b/packages/radio-group/radio-input/index.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 import s from './style.module.css'
 
 export default function RadioInput({
-  variant = 'light',
+  appearance = 'light',
   label,
   name,
   value,
@@ -15,7 +15,7 @@ export default function RadioInput({
   const id = useId()
   return (
     <label
-      className={classNames(s.radioInput, s[variant])}
+      className={classNames(s.radioInput, s[appearance])}
       htmlFor={id}
       data-testid="radio-input"
     >

--- a/packages/radio-group/radio-input/types.ts
+++ b/packages/radio-group/radio-input/types.ts
@@ -2,7 +2,7 @@ export interface RadioInputProps {
   /**
    * Render on light or dark backgrounds.
    */
-  variant?: 'light' | 'dark'
+  appearance?: 'light' | 'dark'
   /**
    * The name attribute that will be applied to the radio option.
    */

--- a/packages/radio-group/types.ts
+++ b/packages/radio-group/types.ts
@@ -4,11 +4,6 @@ export interface RadioGroupProps {
    */
   layout?: 'stacked' | 'inline'
   /**
-   * @deprecated Use `appearance` instead
-   * Render on light or dark backgrounds.
-   */
-  variant?: 'light' | 'dark'
-  /**
    * Render on light or dark backgrounds.
    */
   appearance?: 'light' | 'dark'

--- a/packages/radio-group/types.ts
+++ b/packages/radio-group/types.ts
@@ -4,9 +4,14 @@ export interface RadioGroupProps {
    */
   layout?: 'stacked' | 'inline'
   /**
+   * @deprecated Use `appearance` instead
    * Render on light or dark backgrounds.
    */
   variant?: 'light' | 'dark'
+  /**
+   * Render on light or dark backgrounds.
+   */
+  appearance?: 'light' | 'dark'
   /**
    * A label that describes the radio options.
    */


### PR DESCRIPTION
<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Align light/dark mode prop naming based on system preferences naming `appearance`.

<img width="496" alt="CleanShot 2022-04-18 at 11 41 47@2x" src="https://user-images.githubusercontent.com/825855/163833767-09bb7aeb-65aa-42e9-bd5f-3d3033c946c0.png">

**Previews:**
- [Actions](https://react-components-jnjaw36nz-hashicorp.vercel.app/components/actions)
- [AuthorByline](https://react-components-jnjaw36nz-hashicorp.vercel.app/components/authorbyline)
- [Intro](https://react-components-jnjaw36nz-hashicorp.vercel.app/components/intro)
- [Quote](https://react-components-jnjaw36nz-hashicorp.vercel.app/components/quote)
- [RadioGroup](https://react-components-jnjaw36nz-hashicorp.vercel.app/components/radiogroup)


### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
