### PR TITLE
kevin/fix docs page type

### DIFF
--- a/.changeset/swift-parrots-dress.md
+++ b/.changeset/swift-parrots-dress.md
@@ -1,5 +1,6 @@
 ---
 '@hashicorp/react-docs-page': patch
+'@hashicorp/react-docs-sidenav': minor
 ---
 
 Fix type error during build

--- a/.changeset/swift-parrots-dress.md
+++ b/.changeset/swift-parrots-dress.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-page': patch
+---
+
+Fix type error during build

--- a/packages/docs-page/server/resolve-nav-data.ts
+++ b/packages/docs-page/server/resolve-nav-data.ts
@@ -2,8 +2,12 @@ import path from 'path'
 import fs from 'fs'
 
 import { validateNavData } from './validate-nav-data'
+import type { NavNode } from 'packages/docs-sidenav/types'
 
-export async function resolveNavData(filePath, localContentDir) {
+export async function resolveNavData(
+  filePath: string,
+  localContentDir: string
+): Promise<NavNode[]> {
   const navDataFile = path.join(process.cwd(), filePath)
   const navDataRaw = JSON.parse(fs.readFileSync(navDataFile, 'utf8'))
   const withFilePaths = await validateNavData(navDataRaw, localContentDir)

--- a/packages/docs-page/server/resolve-nav-data.ts
+++ b/packages/docs-page/server/resolve-nav-data.ts
@@ -1,8 +1,9 @@
 import path from 'path'
 import fs from 'fs'
 
+import type { NavNode } from '@hashicorp/react-docs-sidenav/types'
+
 import { validateNavData } from './validate-nav-data'
-import type { NavNode } from 'packages/docs-sidenav/types'
 
 export async function resolveNavData(
   filePath: string,

--- a/packages/docs-page/server/validate-nav-data.ts
+++ b/packages/docs-page/server/validate-nav-data.ts
@@ -1,8 +1,12 @@
 import validateFilePaths from '@hashicorp/react-docs-sidenav/utils/validate-file-paths'
 import validateRouteStructure from '@hashicorp/react-docs-sidenav/utils/validate-route-structure'
 import validateUnlinkedContent from '@hashicorp/react-docs-sidenav/utils/validate-unlinked-content'
+import type { NavNode } from '@hashicorp/react-docs-sidenav/types'
 
-export async function validateNavData(navData, localContentDir) {
+export async function validateNavData(
+  navData: NavNode[],
+  localContentDir: string
+): Promise<NavNode[]> {
   const withFilePaths = await validateFilePaths(navData, localContentDir)
   // Validate unlinked content checks for content files that are NOT
   // included in the provided navData. This requires filesystem access,

--- a/packages/docs-sidenav/types.ts
+++ b/packages/docs-sidenav/types.ts
@@ -9,46 +9,52 @@ export type NavNode =
   | NavHeading
   | NavBranch
 
-// A NavLeaf represents a page with content.
-//
-// The "path" refers to the URL route from the content subpath.
-// For all current docs sites, this "path" also
-// corresponds to the content location in the filesystem.
-//
-// Note that "path" can refer to either "named" or "index" files.
-// For example, we will automatically resolve the path
-// "commands" to either "commands.mdx" or "commands/index.mdx".
-// If both exist, we will throw an error to alert authors
-// to the ambiguity.
-interface NavLeaf {
+/**
+ * A NavLeaf represents a page with content.
+ *
+ * The "path" refers to the URL route from the content subpath.
+ * For all current docs sites, this "path" also
+ * corresponds to the content location in the filesystem.
+ *
+ * Note that "path" can refer to either "named" or "index" files.
+ * For example, we will automatically resolve the path
+ * "commands" to either "commands.mdx" or "commands/index.mdx".
+ * If both exist, we will throw an error to alert authors
+ * to the ambiguity.
+ */
+export interface NavLeaf {
   title: string
   path: string
 }
 
-// A NavDirectLink allows linking outside the content subpath.
-//
-// This includes links on the same domain,
-// for example, where the content subpath is `/docs`,
-// one can create a direct link with href `/use-cases`.
-//
-// This also allows for linking to external URLs,
-// for example, one could link to `https://hashiconf.com/`.
-interface NavDirectLink {
+/**
+ * A NavDirectLink allows linking outside the content subpath.
+ *
+ * This includes links on the same domain,
+ * for example, where the content subpath is `/docs`,
+ * one can create a direct link with href `/use-cases`.
+ *
+ * This also allows for linking to external URLs,
+ * for example, one could link to `https://hashiconf.com/`.
+ */
+export interface NavDirectLink {
   title: string
   href: string
 }
 
 // A NavDivider represents a divider line
-interface NavDivider {
+export interface NavDivider {
   divider: true
 }
 
-interface NavHeading {
+export interface NavHeading {
   heading: string
 }
 
-// A NavBranch represents nested navigation data.
-interface NavBranch {
+/**
+ * A NavBranch represents nested navigation data.
+ */
+export interface NavBranch {
   title: string
   routes: NavNode[]
 }

--- a/packages/docs-sidenav/types.ts
+++ b/packages/docs-sidenav/types.ts
@@ -25,6 +25,7 @@ export type NavNode =
 export interface NavLeaf {
   title: string
   path: string
+  filePath?: string
 }
 
 /**

--- a/packages/docs-sidenav/utils/validate-file-paths/index.test.ts
+++ b/packages/docs-sidenav/utils/validate-file-paths/index.test.ts
@@ -1,6 +1,8 @@
 import path from 'path'
 import validateFilePaths from './'
 
+import type { NavBranch, NavLeaf } from '../../types'
+
 // We have a content folder fixture set up so that
 // we can properly test this function
 const CONTENT_DIR = 'packages/docs-sidenav/fixtures/content'
@@ -14,7 +16,7 @@ describe('<DocsSidenav /> - validate-file-paths', () => {
       },
     ]
     const withFilePaths = await validateFilePaths(navData, CONTENT_DIR)
-    const resolvedPath = withFilePaths[0].filePath
+    const resolvedPath = (withFilePaths[0] as NavLeaf).filePath
     expect(resolvedPath).toBe(path.join(CONTENT_DIR, 'what-is-vault.mdx'))
   })
 
@@ -31,7 +33,8 @@ describe('<DocsSidenav /> - validate-file-paths', () => {
       },
     ]
     const withFilePaths = await validateFilePaths(navData, CONTENT_DIR)
-    const resolvedPath = withFilePaths[0].routes[0].filePath
+    const resolvedPath = ((withFilePaths[0] as NavBranch).routes[0] as NavLeaf)
+      .filePath
     expect(resolvedPath).toBe(path.join(CONTENT_DIR, 'agent', 'index.mdx'))
   })
 

--- a/packages/docs-sidenav/utils/validate-file-paths/index.ts
+++ b/packages/docs-sidenav/utils/validate-file-paths/index.ts
@@ -1,7 +1,9 @@
 import * as fs from 'fs'
 import * as path from 'path'
 
-async function validateFilePaths(navNodes, localDir) {
+import type { NavNode, NavLeaf } from '../../types'
+
+async function validateFilePaths(navNodes: NavNode[], localDir: string) {
   //  Clone the nodes, and validate each one
   return await Promise.all(
     navNodes.slice(0).map(async (navNode) => {
@@ -10,14 +12,12 @@ async function validateFilePaths(navNodes, localDir) {
   )
 }
 
-async function validateNode(navNode, localDir) {
-  // Ignore remote leaf nodes, these already
-  // have their content file explicitly defined
-  // (note: remote leaf nodes are currently only used
-  // for Packer plugin documentation)
-  if (navNode.remoteFile) return navNode
+async function validateNode(
+  navNode: NavNode,
+  localDir: string
+): Promise<NavNode> {
   // Handle local leaf nodes
-  if (typeof navNode.path == 'string') {
+  if ('path' in navNode) {
     const indexFilePath = path.join(navNode.path, 'index.mdx')
     const namedFilePath = `${navNode.path}.mdx`
     const hasIndexFile = fs.existsSync(
@@ -40,10 +40,10 @@ async function validateNode(navNode, localDir) {
       localDir,
       hasIndexFile ? indexFilePath : namedFilePath
     )
-    return { ...navNode, filePath }
+    return { ...navNode, filePath } as NavLeaf
   }
   //  Handle local branch nodes
-  if (navNode.routes) {
+  if ('routes' in navNode) {
     const routesWithFilePaths = await validateFilePaths(
       navNode.routes,
       localDir


### PR DESCRIPTION
- fix(docs-page): internal types
- chore: changeset

This addresses the following build time error:

```console
Failed to compile.
--
18:31:24.715 |  
18:31:24.715 | ./node_modules/@hashicorp/react-docs-page/server/loaders/file-system.ts:39:32
18:31:24.716 | Type error: Argument of type '[unknown, unknown, unknown, unknown, unknown, unknown, unknown, unknown, unknown, unknown]' is not assignable to parameter of type 'NavNode[]'.
18:31:24.716 | Type 'unknown' is not assignable to type 'NavNode'.
18:31:24.716 | Type '{}' is missing the following properties from type 'NavBranch': title, routes
18:31:24.716 |  
18:31:24.716 | 37 \|       this.opts.localContentDir
18:31:24.716 | 38 \|     )
18:31:24.716 | > 39 \|     return getPathsFromNavData(navData, this.opts.paramId)
18:31:24.716 | \|                                ^
18:31:24.716 | 40 \|   }
18:31:24.717 | 41 \|
18:31:24.717 | 42 \|   loadStaticProps = async ({
```