### PR TITLE
feat(RemoteContentLoader): navDataPrefix option

### DIFF
--- a/.changeset/chilled-hairs-reply.md
+++ b/.changeset/chilled-hairs-reply.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-page': minor
+---
+
+This version adds a navDataPrefix option to the RemoteContentLoader to make nav-data lookup more flexible.

--- a/packages/docs-page/server/loaders/remote-content.test.ts
+++ b/packages/docs-page/server/loaders/remote-content.test.ts
@@ -41,8 +41,8 @@ describe('RemoteContentLoader', () => {
     expect(paths).toMatchSnapshot()
   })
 
-  test.only("allows 'navDataPrefix' to look up nav data", async () => {
-    loader = new RemoteContentLoader({
+  test("allows 'navDataPrefix' to look up nav data", async () => {
+    const loader = new RemoteContentLoader({
       basePath: 'plugin/mux',
       navDataPrefix: 'plugin-mux',
       product: 'terraform-plugin-mux',

--- a/packages/docs-page/server/loaders/remote-content.test.ts
+++ b/packages/docs-page/server/loaders/remote-content.test.ts
@@ -41,6 +41,85 @@ describe('RemoteContentLoader', () => {
     expect(paths).toMatchSnapshot()
   })
 
+  test.only("allows 'navDataPrefix' to look up nav data", async () => {
+    loader = new RemoteContentLoader({
+      basePath: 'plugin/mux',
+      navDataPrefix: 'plugin-mux',
+      product: 'terraform-plugin-mux',
+    })
+
+    scope
+      .get('/api/content/terraform-plugin-mux/version-metadata')
+      .query({ partial: 'true' })
+      .reply(200, {
+        meta: {
+          status_code: 200,
+          status_text: 'OK',
+        },
+        result: [
+          {
+            product: 'terraform-plugin-mux',
+            ref: 'refs/heads/main',
+            version: 'v0.6.x',
+            created_at: '2022-05-05T20:45:15.560Z',
+            display: 'v0.6.x',
+            sha: 'b20cf6618b0bdf4c9eb8895b1d30eca11cc3eae5',
+            sk: 'version-metadata/v0.6.x',
+            isLatest: true,
+            pk: 'terraform-plugin-mux#version-metadata',
+          },
+        ],
+      })
+
+    // NOTE: The key assertion is the 'plugin-mux' segment in this URL
+    scope
+      .get('/api/content/terraform-plugin-mux/nav-data/v0.6.x/plugin-mux')
+      .reply(200, {
+        meta: {
+          status_code: 200,
+          status_text: 'OK',
+        },
+        result: {
+          product: 'terraform-plugin-mux',
+          githubFile: 'website/docs/plugin-mux-nav-data.json',
+          version: 'v0.6.x',
+          created_at: '2022-05-05T20:45:15.438Z',
+          sha: 'b20cf6618b0bdf4c9eb8895b1d30eca11cc3eae5',
+          sk: 'nav-data/v0.6.x/plugin-mux',
+          subpath: 'plugin-mux',
+          pk: 'terraform-plugin-mux#nav-data/v0.6.x/plugin-mux',
+          navData: [
+            {
+              heading: 'Combining and Translating',
+            },
+            {
+              title: 'Overview',
+              path: '',
+            },
+            {
+              title: 'Combining Protocol v5 Providers',
+              path: 'combining-protocol-version-5-providers',
+            },
+            {
+              title: 'Combining Protocol v6 Providers',
+              path: 'combining-protocol-version-6-providers',
+            },
+            {
+              title: 'Translating Protocol v5 to v6',
+              path: 'translating-protocol-version-5-to-6',
+            },
+            {
+              title: 'Translating Protocol v6 to v5',
+              path: 'translating-protocol-version-6-to-5',
+            },
+          ],
+        },
+      })
+
+    const paths = await loader.loadStaticPaths()
+    expect(paths).toHaveLength(6)
+  })
+
   test('generates props from remote data', async () => {
     scope
       .get('/api/content/waypoint/version-metadata')
@@ -64,40 +143,40 @@ describe('RemoteContentLoader', () => {
         navData: expect.any(Array),
       },
       `
-Object {
-  "currentPath": "",
-  "frontMatter": Object {
-    "layout": "commands",
-    "page_title": "Waypoint Commands (CLI)",
-  },
-  "githubFileUrl": "https://github.com/hashicorp/waypoint/blob/main/website/content/commands/index.mdx",
-  "mdxSource": Object {
-    "compiledSource": Any<String>,
-    "scope": Object {},
-  },
-  "navData": Any<Array>,
-  "versions": Array [
-    Object {
-      "isLatest": true,
-      "label": "v0.5.2 (latest)",
-      "name": "latest",
-      "version": "v0.5.x",
-    },
-    Object {
-      "isLatest": false,
-      "label": "v0.4.x",
-      "name": "v0.4.x",
-      "version": "v0.4.x",
-    },
-    Object {
-      "isLatest": false,
-      "label": "v0.3.x",
-      "name": "v0.3.x",
-      "version": "v0.3.x",
-    },
-  ],
-}
-`
+      Object {
+        "currentPath": "",
+        "frontMatter": Object {
+          "layout": "commands",
+          "page_title": "Waypoint Commands (CLI)",
+        },
+        "githubFileUrl": "https://github.com/hashicorp/waypoint/blob/main/website/content/commands/index.mdx",
+        "mdxSource": Object {
+          "compiledSource": Any<String>,
+          "scope": Object {},
+        },
+        "navData": Any<Array>,
+        "versions": Array [
+          Object {
+            "isLatest": true,
+            "label": "v0.5.2 (latest)",
+            "name": "latest",
+            "version": "v0.5.x",
+          },
+          Object {
+            "isLatest": false,
+            "label": "v0.4.x",
+            "name": "v0.4.x",
+            "version": "v0.4.x",
+          },
+          Object {
+            "isLatest": false,
+            "label": "v0.3.x",
+            "name": "v0.3.x",
+            "version": "v0.3.x",
+          },
+        ],
+      }
+    `
     )
   })
 
@@ -150,75 +229,75 @@ describe('mapVersionList', () => {
     const versionList = mapVersionList(list as any)
 
     expect(versionList).toMatchInlineSnapshot(`
-Array [
-  Object {
-    "isLatest": false,
-    "label": "v2.11.x",
-    "name": "v2.11.x",
-    "version": "v2.11.x",
-  },
-  Object {
-    "isLatest": false,
-    "label": "v1.10.x",
-    "name": "v1.10.x",
-    "version": "v1.10.x",
-  },
-  Object {
-    "isLatest": false,
-    "label": "v1.9.x",
-    "name": "v1.9.x",
-    "version": "v1.9.x",
-  },
-  Object {
-    "isLatest": false,
-    "label": "v1.1.x",
-    "name": "v1.1.x",
-    "version": "v1.1.x",
-  },
-  Object {
-    "isLatest": false,
-    "label": "v0.11.x",
-    "name": "v0.11.x",
-    "version": "v0.11.x",
-  },
-  Object {
-    "isLatest": false,
-    "label": "v0.10.x",
-    "name": "v0.10.x",
-    "version": "v0.10.x",
-  },
-  Object {
-    "isLatest": false,
-    "label": "v0.9.x",
-    "name": "v0.9.x",
-    "version": "v0.9.x",
-  },
-]
-`)
+      Array [
+        Object {
+          "isLatest": false,
+          "label": "v2.11.x",
+          "name": "v2.11.x",
+          "version": "v2.11.x",
+        },
+        Object {
+          "isLatest": false,
+          "label": "v1.10.x",
+          "name": "v1.10.x",
+          "version": "v1.10.x",
+        },
+        Object {
+          "isLatest": false,
+          "label": "v1.9.x",
+          "name": "v1.9.x",
+          "version": "v1.9.x",
+        },
+        Object {
+          "isLatest": false,
+          "label": "v1.1.x",
+          "name": "v1.1.x",
+          "version": "v1.1.x",
+        },
+        Object {
+          "isLatest": false,
+          "label": "v0.11.x",
+          "name": "v0.11.x",
+          "version": "v0.11.x",
+        },
+        Object {
+          "isLatest": false,
+          "label": "v0.10.x",
+          "name": "v0.10.x",
+          "version": "v0.10.x",
+        },
+        Object {
+          "isLatest": false,
+          "label": "v0.9.x",
+          "name": "v0.9.x",
+          "version": "v0.9.x",
+        },
+      ]
+    `)
   })
 
   test('should map a list of version-metadata to a format for <VersionSelect/>', () => {
     expect(versionList).toMatchInlineSnapshot(`
-Array [
-  Object {
-    "isLatest": true,
-    "label": "v0.5.2 (latest)",
-    "name": "latest",
-    "version": "v0.5.x",
-  },
-  Object {
-    "isLatest": false,
-    "label": "v0.4.x",
-    "name": "v0.4.x",
-    "version": "v0.4.x",
-  },
-  Object {
-    "isLatest": false,
-    "label": "v0.3.x",
-    "name": "v0.3.x",
-    "version": "v0.3.x",
-  },
-]
-`)
+      Array [
+        Object {
+          "isLatest": true,
+          "label": "v0.5.2 (latest)",
+          "name": "latest",
+          "version": "v0.5.x",
+        },
+        Object {
+          "isLatest": false,
+          "label": "v0.4.x",
+          "name": "v0.4.x",
+          "version": "v0.4.x",
+        },
+        Object {
+          "isLatest": false,
+          "label": "v0.3.x",
+          "name": "v0.3.x",
+          "version": "v0.3.x",
+        },
+      ]
+    `)
   })
 })

--- a/packages/docs-page/server/loaders/remote-content.ts
+++ b/packages/docs-page/server/loaders/remote-content.ts
@@ -17,6 +17,13 @@ import { getPathsFromNavData } from '../get-paths-from-nav-data'
 
 interface RemoteContentLoaderOpts extends DataLoaderOpts {
   basePath: string
+  /**
+   * In most cases, `basePath` should suffice when resolving nav-data, because
+   * it happens to match the prefix of nav-data file.
+   *
+   * If it does not, `navDataPrefix` will serve as an optional override.
+   */
+  navDataPrefix?: string
   enabledVersionedDocs?: boolean
   remarkPlugins?: ((params?: ParsedUrlQuery) => $TSFixMe[]) | $TSFixMe[]
   mainBranch?: string // = 'main',
@@ -86,6 +93,8 @@ export function mapVersionList(
 }
 
 export default class RemoteContentLoader implements DataLoader {
+  private navDataPrefix: string
+
   constructor(public opts: RemoteContentLoaderOpts) {
     if (typeof this.opts.enabledVersionedDocs === 'undefined')
       this.opts.enabledVersionedDocs =
@@ -95,6 +104,8 @@ export default class RemoteContentLoader implements DataLoader {
     if (!this.opts.mainBranch) this.opts.mainBranch = 'main'
     if (!this.opts.scope) this.opts.scope = {}
     if (!this.opts.remarkPlugins) this.opts.remarkPlugins = []
+
+    this.navDataPrefix = this.opts.navDataPrefix || this.opts.basePath
   }
 
   loadStaticPaths = async (): Promise<$TSFixMe> => {
@@ -102,15 +113,19 @@ export default class RemoteContentLoader implements DataLoader {
     const versionMetadataList = await cachedFetchVersionMetadataList(
       this.opts.product
     )
-    const latest =
+
+    const latest: string =
       this.opts.latestVersionRef ??
       versionMetadataList.find((e) => e.isLatest).version
+
     // Fetch and parse navigation data
-    return getPathsFromNavData(
-      (await cachedFetchNavData(this.opts.product, this.opts.basePath, latest))
-        .navData,
-      this.opts.paramId
+    const navDataResponse = await cachedFetchNavData(
+      this.opts.product,
+      this.navDataPrefix,
+      latest
     )
+    const navData = navDataResponse.navData
+    return getPathsFromNavData(navData, this.opts.paramId)
   }
 
   loadStaticProps = async ({
@@ -148,9 +163,8 @@ export default class RemoteContentLoader implements DataLoader {
       params![this.opts.paramId!] as string[]
     )
 
-    const versionMetadataList: VersionMetadataItem[] = await cachedFetchVersionMetadataList(
-      this.opts.product
-    )
+    const versionMetadataList: VersionMetadataItem[] =
+      await cachedFetchVersionMetadataList(this.opts.product)
     // remove trailing index to ensure we fetch the right document from the DB
     const pathParamsNoIndex = paramsNoVersion.filter(
       (param, idx, arr) => !(param === 'index' && idx === arr.length - 1)
@@ -179,7 +193,7 @@ export default class RemoteContentLoader implements DataLoader {
     const documentPromise = fetchDocument(this.opts.product, fullPath)
     const navDataPromise = cachedFetchNavData(
       this.opts.product,
-      this.opts.basePath,
+      this.navDataPrefix,
       versionToFetch
     )
 

--- a/packages/docs-page/server/loaders/remote-content.ts
+++ b/packages/docs-page/server/loaders/remote-content.ts
@@ -93,8 +93,6 @@ export function mapVersionList(
 }
 
 export default class RemoteContentLoader implements DataLoader {
-  private navDataPrefix: string
-
   constructor(public opts: RemoteContentLoaderOpts) {
     if (typeof this.opts.enabledVersionedDocs === 'undefined')
       this.opts.enabledVersionedDocs =
@@ -104,8 +102,7 @@ export default class RemoteContentLoader implements DataLoader {
     if (!this.opts.mainBranch) this.opts.mainBranch = 'main'
     if (!this.opts.scope) this.opts.scope = {}
     if (!this.opts.remarkPlugins) this.opts.remarkPlugins = []
-
-    this.navDataPrefix = this.opts.navDataPrefix || this.opts.basePath
+    if (!this.opts.navDataPrefix) this.opts.navDataPrefix = this.opts.basePath
   }
 
   loadStaticPaths = async (): Promise<$TSFixMe> => {
@@ -121,7 +118,7 @@ export default class RemoteContentLoader implements DataLoader {
     // Fetch and parse navigation data
     const navDataResponse = await cachedFetchNavData(
       this.opts.product,
-      this.navDataPrefix,
+      this.opts.navDataPrefix!,
       latest
     )
     const navData = navDataResponse.navData
@@ -193,7 +190,7 @@ export default class RemoteContentLoader implements DataLoader {
     const documentPromise = fetchDocument(this.opts.product, fullPath)
     const navDataPromise = cachedFetchNavData(
       this.opts.product,
-      this.navDataPrefix,
+      this.opts.navDataPrefix!,
       versionToFetch
     )
 


### PR DESCRIPTION
# Description

This adds a `navDataPrefix` option to our `RemoteContentLoader`.

This helps to address a previous assumption that `basePath` would always be the same for `doc` and `nav-data` lookups from our API, which is not necessarily going to be the case going forward.

🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Describe this pull request: what is it aiming to achieve? What should someone reviewing this PR know? If this PR includes visual changes, consider including before / after screenshots, or an animated gif showing interactions.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
