### PR TITLE
feat(code-block): onCopyCallback

### DIFF
--- a/.changeset/shy-houses-unite.md
+++ b/.changeset/shy-houses-unite.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-code-block': minor
+---
+
+Adds support for an onCopyCallback prop.

--- a/packages/code-block/index.test.js
+++ b/packages/code-block/index.test.js
@@ -6,6 +6,7 @@ import {
   waitFor,
 } from '@testing-library/react'
 import CodeBlock from './'
+import { heapAttributes } from './analytics'
 // Mock copy-to-clipboard
 import copyToClipboard from './partials/clipboard-button/copy-to-clipboard'
 jest.mock('./partials/clipboard-button/copy-to-clipboard', () =>
@@ -76,6 +77,7 @@ it('should have a data-heap-track="code-block-clipboard-icon" attribute on the C
   )
   const copyButton = screen.getByText('Copy')
   expect(copyButton.tagName).toBe('BUTTON')
+  expect(copyButton.getAttribute('data-heap-track')).toBe(heapAttributes.copy)
 })
 
 it('should render a keyboard-focusable `Copy` button', () => {
@@ -129,6 +131,29 @@ it('should track a "Copy" event when the "Copy" button is clicked', async () => 
   })
   // Cleanup
   window.analytics = forMockRestore
+  copyToClipboard.mockClear()
+})
+
+it('should call "onCopyCallback" when the "Copy" button is clicked', async () => {
+  // Set up a mock
+  const onCopyCallback = jest.fn()
+  // Render
+  render(
+    <CodeBlock
+      code={`console.log("Hello world");`}
+      onCopyCallBack={onCopyCallback}
+      options={{ showClipboard: true }}
+    />
+  )
+  // Find and click the copy button
+  const buttonElem = screen.getByText('Copy')
+  expect(buttonElem.tagName).toBe('BUTTON')
+  expect(buttonElem).toBeInTheDocument()
+  fireEvent.click(buttonElem)
+  //  Expect onCopyCallback to have been called
+  await waitFor(() => expect(onCopyCallback).toHaveBeenCalledTimes(1))
+  expect(onCopyCallback).toBeCalledWith(true)
+  copyToClipboard.mockClear()
 })
 
 it('should track a "Click" event when the root element is clicked', async () => {
@@ -168,4 +193,5 @@ it('should use process-snippet to strip the leading $ from shell snippets', asyn
   const expectedCode = processSnippet(codeString)
   await waitFor(() => expect(copyToClipboard).toHaveBeenCalledTimes(1))
   expect(copyToClipboard).toHaveBeenCalledWith(expectedCode)
+  copyToClipboard.mockClear()
 })

--- a/packages/code-block/index.tsx
+++ b/packages/code-block/index.tsx
@@ -22,7 +22,6 @@ export interface CodeBlockOptions {
   showWindowBar?: boolean
   filename?: string
   heading?: string
-  onCopyCallBack?: ClipboardButtonProps['onCopyCallback']
 }
 
 export interface CodeBlockProps {
@@ -31,6 +30,7 @@ export interface CodeBlockProps {
   language?: string
   theme?: 'light' | 'dark'
   hasBarAbove?: boolean
+  onCopyCallBack?: ClipboardButtonProps['onCopyCallback']
   options?: CodeBlockOptions
 }
 
@@ -40,6 +40,7 @@ function CodeBlock({
   language,
   theme = 'dark',
   hasBarAbove = false,
+  onCopyCallBack,
   options = {
     showChrome: false,
     highlight: false,
@@ -119,7 +120,7 @@ function CodeBlock({
             <div className={s.copyButtonBackground}>
               <ClipboardButton
                 getText={getText}
-                onCopyCallback={onCopyCallback}
+                onCopyCallback={onCopyCallBack}
               />
             </div>
           </div>

--- a/packages/code-block/index.tsx
+++ b/packages/code-block/index.tsx
@@ -2,7 +2,9 @@ import { useRef } from 'react'
 import type { ReactElement } from 'react'
 import classNames from 'classnames'
 import processSnippet from './utils/process-snippet'
-import ClipboardButton from './partials/clipboard-button'
+import ClipboardButton, {
+  ClipboardButtonProps,
+} from './partials/clipboard-button'
 import SnippetBar from './partials/snippet-bar'
 import themeDark from './theme-dark.module.css'
 import themeLight from './theme-light.module.css'
@@ -20,6 +22,7 @@ export interface CodeBlockOptions {
   showWindowBar?: boolean
   filename?: string
   heading?: string
+  onCopyCallBack?: ClipboardButtonProps['onCopyCallback']
 }
 
 export interface CodeBlockProps {
@@ -114,7 +117,10 @@ function CodeBlock({
         {hasFloatingCopyButton ? (
           <div className={s.copyButtonContainer}>
             <div className={s.copyButtonBackground}>
-              <ClipboardButton getText={getText} />
+              <ClipboardButton
+                getText={getText}
+                onCopyCallback={onCopyCallback}
+              />
             </div>
           </div>
         ) : null}

--- a/packages/code-block/partials/clipboard-button/index.tsx
+++ b/packages/code-block/partials/clipboard-button/index.tsx
@@ -7,12 +7,17 @@ import svgCopySuccess from './svg/copy-success.svg?include'
 import s from './style.module.css'
 import analytics, { heapAttributes } from '../../analytics'
 
-interface ClipboardButtonProps {
+export interface ClipboardButtonProps {
   className?: string
   getText: () => Promise<[unknown, null] | [null, string]>
+  onCopyCallback?: (copySuccess: boolean | null) => void
 }
 
-function ClipboardButton({ className, getText }: ClipboardButtonProps) {
+function ClipboardButton({
+  className,
+  getText,
+  onCopyCallback,
+}: ClipboardButtonProps) {
   // copiedState can be null (initial), true (success), or false (failure)
   const [copiedState, setCopiedState] = useState<boolean | null>(null)
   // we reset copiedState to its initial value using a timeout
@@ -45,6 +50,10 @@ function ClipboardButton({ className, getText }: ClipboardButtonProps) {
   // reset to the default appearance so that it's clear
   // the "Copy" button can be used again
   useEffect(() => {
+    // If an onCopyCallback was provided, call it
+    if (typeof onCopyCallback == 'function') {
+      onCopyCallback(copiedState)
+    }
     // Clear any pending timeouts, which can occur if the
     // button is quickly clicked multiple times
     window.clearTimeout(resetTimeout)
@@ -58,7 +67,7 @@ function ClipboardButton({ className, getText }: ClipboardButtonProps) {
     }
     // Clean up if the component unmounts with a pending timeout
     return () => clearTimeout(resetTimeout)
-  }, [copiedState])
+  }, [copiedState, onCopyCallback])
 
   return (
     <button

--- a/packages/code-block/partials/clipboard-button/index.tsx
+++ b/packages/code-block/partials/clipboard-button/index.tsx
@@ -10,7 +10,7 @@ import analytics, { heapAttributes } from '../../analytics'
 export interface ClipboardButtonProps {
   className?: string
   getText: () => Promise<[unknown, null] | [null, string]>
-  onCopyCallback?: (copySuccess: boolean | null) => void
+  onCopyCallback?: (copiedState: boolean | null) => void
 }
 
 function ClipboardButton({

--- a/packages/code-block/props.js
+++ b/packages/code-block/props.js
@@ -27,6 +27,11 @@ module.exports = {
     description:
       'Intended for automatic use in CodeTabs, not meant as a consumer-facing prop. Set to `true` to remove border rounding from the top of the CodeBlock.',
   },
+  onCopyCallback: {
+    type: 'function',
+    description:
+      'Optional callback that is called when copy success state changes. Copy success state is `null` initially. When code is successfully copied using the "Copy" button, it changes to `true`. If there is an error when copying code, it changes to `false`. After a timeout set within the `clipboard-button` partial, the copy success state reverts to `null`.',
+  },
   options: {
     type: 'object',
     description:
@@ -51,11 +56,6 @@ module.exports = {
         type: 'boolean',
         description:
           'Set to `true` to show the copy-to-clipboard prompt and functionality.',
-      },
-      onCopyCallback: {
-        type: 'function',
-        description:
-          'Optional callback that is called when copy success state changes. Copy success state is `null` initially. When code is successfully copied using the "Copy" button, it changes to `true`. If there is an error when copying code, it changes to `false`. After a timeout set within the `clipboard-button` partial, the copy success state reverts to `null`.',
       },
     },
   },

--- a/packages/code-block/props.js
+++ b/packages/code-block/props.js
@@ -52,6 +52,11 @@ module.exports = {
         description:
           'Set to `true` to show the copy-to-clipboard prompt and functionality.',
       },
+      onCopyCallback: {
+        type: 'function',
+        description:
+          'Optional callback that is called when copy success state changes. Copy success state is `null` initially. When code is successfully copied using the "Copy" button, it changes to `true`. If there is an error when copying code, it changes to `false`. After a timeout set within the `clipboard-button` partial, the copy success state reverts to `null`.',
+      },
     },
   },
 }


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1201903760348480/1202114097062999/f)
🔍 [Preview Link](https://react-components-git-zscode-block-on-copy-hashicorp.vercel.app/components/codeblock)

---

This PR implements an `onCopyCallback` prop for `code-block`. This callback is called after `code-block`'s Copy button is clicked.

Note that this callback is _not_ called as a direct result of the `onClick` on the button - instead, we wait until we can confirm whether the copying of text was successful.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
