### PR TITLE
feat(docs-page): add optInBanner prop to docs-page

### DIFF
--- a/.changeset/polite-pears-wash.md
+++ b/.changeset/polite-pears-wash.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-page': minor
+---
+
+Adds optInBanner prop to render an optInBanner in the content area

--- a/packages/docs-page/index.tsx
+++ b/packages/docs-page/index.tsx
@@ -39,6 +39,7 @@ interface DocsPageInnerProps {
   showVersionSelect: boolean
   versions: VersionSelectItem[]
   algoliaConfig?: AlgoliaConfigObject
+  optInBanner?: ReactElement
 }
 
 export const DocsPageInner: FunctionComponent<DocsPageInnerProps> = ({
@@ -55,6 +56,7 @@ export const DocsPageInner: FunctionComponent<DocsPageInnerProps> = ({
   showVersionSelect,
   versions,
   algoliaConfig,
+  optInBanner,
 }) => {
   const isMobile = useIsMobile()
   const { asPath } = useRouter()
@@ -139,6 +141,7 @@ export const DocsPageInner: FunctionComponent<DocsPageInnerProps> = ({
               product={slug}
               content={
                 <>
+                  {optInBanner ? optInBanner : null}
                   {isMobile ? null : search}
                   {children}
                 </>
@@ -179,6 +182,7 @@ export interface DocsPageProps {
     githubFileUrl: string
     versions: VersionSelectItem[]
   }
+  optInBanner?: ReactElement
 }
 
 export default function DocsPage({
@@ -196,6 +200,7 @@ export default function DocsPage({
     githubFileUrl,
     versions,
   },
+  optInBanner,
 }: DocsPageProps): ReactElement {
   const router = useRouter()
 
@@ -223,6 +228,7 @@ export default function DocsPage({
       baseRoute={baseRoute}
       versions={versions}
       algoliaConfig={algoliaConfig}
+      optInBanner={optInBanner}
     >
       {content}
     </DocsPageInner>


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Adds an `optInBanner` prop to docs page so we can render an opt-in banner for dev portal. Intentionally made the prop specific as we'll eventually be pulling this code into dev-portal and or deprecating it, so it doesn't make sense to try and make this a "generic" feature.

Related dev-portal PR: https://github.com/hashicorp/dev-portal/pull/470

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
