### PR TITLE
[code-block] Moving invocation of onCopyCallback

### DIFF
--- a/.changeset/clever-zebras-shout.md
+++ b/.changeset/clever-zebras-shout.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-code-block': patch
+---
+
+Moves the invocation of onCopyCallback to after the Copy button has been clicked.

--- a/.changeset/clever-zebras-shout.md
+++ b/.changeset/clever-zebras-shout.md
@@ -1,5 +1,0 @@
----
-'@hashicorp/react-code-block': patch
----
-
-Moves the invocation of onCopyCallback to after the Copy button has been clicked.

--- a/.changeset/wise-terms-heal.md
+++ b/.changeset/wise-terms-heal.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-code-block': major
+---
+
+Moves the invocation of `onCopyCallback` to after the copy button has been clicked, and only invokes the callback if `copiedState` is `true` or `false`.

--- a/packages/code-block/partials/clipboard-button/index.tsx
+++ b/packages/code-block/partials/clipboard-button/index.tsx
@@ -37,26 +37,36 @@ function ClipboardButton({
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const isCopied = copyToClipboard(text!)
 
-    // If an onCopyCallback was provided, call it
-    if (typeof onCopyCallback == 'function') {
-      onCopyCallback(copiedState)
-    }
-
     // If there's an internal failure copying text, exit early to handle the error
     if (!isCopied) {
       return handleError(`ClipboardButton failed. Text: ${text}.`)
     }
 
-    // Otherwise, things went well, track the event, set state, invoke callback
-    analytics.trackCopy()
-    setCopiedState(true)
+    // Otherwise, things went well
+    return handleSuccess()
   }
 
-  // Handle errors from copying-to-clipboard
+  // Handle errors from copying-to-clipboard and invoke callback
   function handleError(errorMessage) {
     // Enhancement - is there anywhere we can send this error for tracking?
     console.error(errorMessage)
     setCopiedState(false)
+
+    // If an onCopyCallback was provided, call it
+    if (typeof onCopyCallback == 'function') {
+      onCopyCallback(false)
+    }
+  }
+
+  // Track the event, set state, and invoke callback
+  function handleSuccess() {
+    analytics.trackCopy()
+    setCopiedState(true)
+
+    // If an onCopyCallback was provided, call it
+    if (typeof onCopyCallback == 'function') {
+      onCopyCallback(true)
+    }
   }
 
   // After displaying feedback on the success state,

--- a/packages/code-block/partials/clipboard-button/index.tsx
+++ b/packages/code-block/partials/clipboard-button/index.tsx
@@ -27,14 +27,25 @@ function ClipboardButton({
   async function onClick() {
     // Retrieve the text to copy, using the fn passed by the consumer
     const [getTextError, text] = await getText()
+
     // If text cannot be retrieved, exit early to handle the error
-    if (getTextError) return handleError(getTextError)
+    if (getTextError) {
+      return handleError(getTextError)
+    }
+
     // Otherwise, continue on...
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const isCopied = copyToClipboard(text!)
+
     // If there's an internal failure copying text, exit early to handle the error
-    if (!isCopied) return handleError(`ClipboardButton failed. Text: ${text}.`)
-    // Otherwise, things went well, track the event and set state
+    if (!isCopied) {
+      return handleError(`ClipboardButton failed. Text: ${text}.`)
+    }
+
+    // Otherwise, things went well, track the event, set state, invoke callback
+    if (typeof onCopyCallback == 'function') {
+      onCopyCallback(copiedState)
+    }
     analytics.trackCopy()
     setCopiedState(true)
   }
@@ -50,10 +61,6 @@ function ClipboardButton({
   // reset to the default appearance so that it's clear
   // the "Copy" button can be used again
   useEffect(() => {
-    // If an onCopyCallback was provided, call it
-    if (typeof onCopyCallback == 'function') {
-      onCopyCallback(copiedState)
-    }
     // Clear any pending timeouts, which can occur if the
     // button is quickly clicked multiple times
     window.clearTimeout(resetTimeout)
@@ -67,7 +74,7 @@ function ClipboardButton({
     }
     // Clean up if the component unmounts with a pending timeout
     return () => clearTimeout(resetTimeout)
-  }, [copiedState, onCopyCallback])
+  }, [copiedState])
 
   let buttonText = 'Copy'
   let buttonIcon = <IconDuplicate16 className={s.svg} />

--- a/packages/code-block/partials/clipboard-button/index.tsx
+++ b/packages/code-block/partials/clipboard-button/index.tsx
@@ -37,15 +37,17 @@ function ClipboardButton({
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const isCopied = copyToClipboard(text!)
 
+    // If an onCopyCallback was provided, call it
+    if (typeof onCopyCallback == 'function') {
+      onCopyCallback(copiedState)
+    }
+
     // If there's an internal failure copying text, exit early to handle the error
     if (!isCopied) {
       return handleError(`ClipboardButton failed. Text: ${text}.`)
     }
 
     // Otherwise, things went well, track the event, set state, invoke callback
-    if (typeof onCopyCallback == 'function') {
-      onCopyCallback(copiedState)
-    }
     analytics.trackCopy()
     setCopiedState(true)
   }


### PR DESCRIPTION
🔍 [Preview Link](https://react-components-git-ambadjust-on-copy-callback-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

The new `onCopyCallback` function in `CodeBlock` was being invoked on initial load. This PR moves the invocation of this callback to the `onClick` handler for the rendered `<button>` used for copying.

- I've also added some empty lines between blocks of the `onClick` handler and added curly braces to one-line if statements. Both of these sets of additional changes were made to improve the readability of this code.

## Test steps

A draft PR was created to test these changes in `dev-portal`. See [dev-portal#555](https://github.com/hashicorp/dev-portal/pull/555).

- [ ] Go to https://dev-portal-git-ambtest-on-copy-callback-hashicorp.vercel.app/waypoint/downloads
- [ ] No toast should appear on load
- [ ] Click the Copy button on the CodeBlock shown
- [ ] A green success toast should appear

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
