### PR TITLE
fix(code-block): code tabs dropdown alignment

### DIFF
--- a/.changeset/nine-items-end.md
+++ b/.changeset/nine-items-end.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-code-block': patch
+---
+
+Fixes alignment of code-tabs dropdown when no heading is present

--- a/packages/code-block/partials/code-tabs/partials/tabs-as-dropdown/index.js
+++ b/packages/code-block/partials/code-tabs/partials/tabs-as-dropdown/index.js
@@ -26,7 +26,12 @@ function TabsAsDropdown({
           {activeLabel}
           <InlineSvg className={s.dropdownIcon} src={svgChevronDown} />
         </ListboxButton>
-        <ListboxPopover className={s.listboxPopover} portal={false}>
+        <ListboxPopover
+          className={classNames(s.listboxPopover, {
+            [s.hasHeading]: hasHeading,
+          })}
+          portal={false}
+        >
           <ListboxList className={s.listboxList}>
             {tabLabels.map((tabLabel, idx) => {
               return (

--- a/packages/code-block/partials/code-tabs/partials/tabs-as-dropdown/style.module.css
+++ b/packages/code-block/partials/code-tabs/partials/tabs-as-dropdown/style.module.css
@@ -52,7 +52,7 @@ to be present.
   display: block;
   position: absolute;
   z-index: 1;
-  right: 0;
+  left: 0;
   min-width: min-content;
   border: 1px solid var(--background-tabs);
   border-top: none;
@@ -66,6 +66,11 @@ to be present.
 
   &[hidden] {
     display: none;
+  }
+
+  &.hasHeading {
+    left: auto;
+    right: 0;
   }
 }
 


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1202114367927919/1202439831418533/f)
🔍 [Preview Link](https://react-components-git-zstweak-code-block-dropdown-alignment-hashicorp.vercel.app)

🏷️ Downstream pre-release test: https://github.com/hashicorp/dev-portal/pull/615

---

This PR fixes alignment of code-tabs dropdown when no heading is present.

Easiest way to review new styles & behaviour is likely downstream in this `dev-portal` PR, which uses a pre-release from this PR:
- https://github.com/hashicorp/dev-portal/pull/615

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
