### PR TITLE
Rename event to error page loaded

### DIFF
--- a/.changeset/nervous-gorillas-hear.md
+++ b/.changeset/nervous-gorillas-hear.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-error-view': patch
+---
+
+Adjust error analytics event to have a consistent name

--- a/packages/error-view/__tests__/use-error-page-analytics.test.tsx
+++ b/packages/error-view/__tests__/use-error-page-analytics.test.tsx
@@ -16,9 +16,8 @@ describe('useErrorPageAnalytics', () => {
     // Render and assert
     render(<HookTestComponent statusCode={404} />)
     await waitFor(() => expect(window.analytics.track).toHaveBeenCalledTimes(1))
-    expect(window.analytics.track).toBeCalledWith(window.location.href, {
-      category: '404 Response',
-      label: 'No Referrer',
+    expect(window.analytics.track).toBeCalledWith('Error Page Loaded', {
+      http_status_code: 404,
     })
     // Cleanup
     window.analytics = forMockRestore

--- a/packages/error-view/use-error-page-analytics.ts
+++ b/packages/error-view/use-error-page-analytics.ts
@@ -21,9 +21,8 @@ export default function useErrorPageAnalytics(
       typeof window?.document?.referrer === 'string' &&
       typeof window?.location?.href === 'string'
     )
-      window.analytics.track(window.location.href, {
-        category: `${statusCode} Response`,
-        label: window.document.referrer || 'No Referrer',
+      window.analytics.track('Error Page Loaded', {
+        http_status_code: statusCode,
       })
   }, [statusCode])
 }


### PR DESCRIPTION
## Description

Update our error page analytics event to be consistently named.

This will make Analysis against this event easier, as the way that the event is currently structured produces a new table in our analysis systems, which makes broad error analysis nearly impossible to do.

We're only sending along the error code itself, as Segment will automatically send two context values which will be useful for error analysis: `context_page_url` (the URL where the error happened) and `context_page_referrer` (the URL before the error happened, which will be useful for sniffing out the source of 404s).

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
