### PR TITLE
feat(docs-page): strip tfe version from pathparams

### DIFF
--- a/.changeset/tall-spoons-greet.md
+++ b/.changeset/tall-spoons-greet.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-page': minor
+---
+
+This updates `docs-page` remote content loader to handle TFE versions in path params.

--- a/packages/docs-page/util/index.ts
+++ b/packages/docs-page/util/index.ts
@@ -1,5 +1,5 @@
-const REGEX =
-  /^v([0-9]+)\.([0-9]+)\.(x|[0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/i
+const REGEX = /^v[0-9]+\.[0-9]+\.(x|[0-9]+)$/i
+const TFE_REGEX = /^v[0-9]{6}-[0-9]+$/i
 
 /**
  * Given an array of strings, returns a tuple of
@@ -11,7 +11,7 @@ const REGEX =
 export const stripVersionFromPathParams = (
   pathParams: string[] = []
 ): [string, string[]] => {
-  const index = pathParams.findIndex((e) => REGEX.test(e))
+  const index = pathParams.findIndex((e) => REGEX.test(e) || TFE_REGEX.test(e))
   let version = 'latest'
   let params = [...pathParams]
 

--- a/packages/docs-page/util/util.test.ts
+++ b/packages/docs-page/util/util.test.ts
@@ -14,6 +14,27 @@ describe('stripVersionFromPathParams', () => {
     }
   })
 
+  it('should strip a regular version string', () => {
+    const [version, params] = stripVersionFromPathParams([
+      'cli',
+      'v1.2.x',
+      'commands',
+      'graph',
+    ])
+    expect(version).toEqual('v1.2.x')
+    expect(params).toEqual(['cli', 'commands', 'graph'])
+  })
+
+  it('should strip a TFE version string', () => {
+    const [version, params] = stripVersionFromPathParams([
+      'enterprise',
+      'v202206-1',
+      'support',
+    ])
+    expect(version).toEqual('v202206-1')
+    expect(params).toEqual(['enterprise', 'support'])
+  })
+
   it('should return v-prefixed version and stripped path parms', () => {
     const [version, params] = stripVersionFromPathParams(['v0.5.x', 'destroy'])
     expect(version).toEqual('v0.5.x')


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This fixes a bug where a frontend URL was being converted to an incorrect content API url
- /enterprise/v202206-1/support
- https://content.hashicorp.com/api/content/ptfe-releases/doc/v2022.6.1/enterprise/v202206-1/support

```console
[GET] /enterprise/v202206-1/support
10:36:18:02
2022-06-30T14:36:18.253Z	e224ee77-631b-4fc5-a2ce-f47460eec718	ERROR	Failed to generate static props: ContentApiError: Failed to fetch: https://content.hashicorp.com/api/content/ptfe-releases/doc/v2022.6.1/enterprise/v202206-1/support
    at fetchDocument (/var/task/.next/server/chunks/935.js:12159:15)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Promise.all (index 0)
    at async RemoteContentLoader.loadStaticProps (/var/task/.next/server/chunks/935.js:12767:41)
    at async getStaticProps (/var/task/.next/server/chunks/935.js:12849:31)
    at async getStaticProps (/var/task/.next/server/pages/enterprise/[[...page]].js:84:17)
    at async Object.renderToHTML (/var/task/node_modules/next/dist/server/render.js:470:20)
    at async doRender (/var/task/node_modules/next/dist/server/base-server.js:867:38)
    at async cacheEntry.responseCache.get.isManualRevalidate.isManualRevalidate (/var/task/node_modules/next/dist/server/base-server.js:966:28)
    at async /var/task/node_modules/next/dist/server/response-cache.js:72:36 {
  status: 404
```

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
