### PR TITLE
fix(notifications) timing bug with memoryState and listener

### DIFF
--- a/.changeset/stupid-days-remain.md
+++ b/.changeset/stupid-days-remain.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-notification': patch
+---
+
+Fixes bug where notification is called on load but does not show a notification.

--- a/packages/notification/core/store.ts
+++ b/packages/notification/core/store.ts
@@ -167,7 +167,9 @@ export const dispatch = (action: Action) => {
 }
 
 export const useStore = () => {
-  const [state, setState] = React.useState<State>(memoryState)
+  // Using a functional state initializer here ensures that memoryState can update in between when this useState
+  // is called and when the listener is added in the below useEffect
+  const [state, setState] = React.useState<State>(() => memoryState)
   React.useEffect(() => {
     listeners.push(setState)
     return () => {


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Fixed a tricky timing bug with the initial state in `useStore` and `memoryState`. Basically, `memoryState` can update in between when `useState` is called in `useStore` and when the store listener is added in the `useEffect`. Changing `useState` to use a lazy initializer fixes this by deferring the initial reading of `memoryState` until it's needed.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
