### PR TITLE
feat: introduce notification types

### DIFF
--- a/.changeset/stale-bulldogs-design.md
+++ b/.changeset/stale-bulldogs-design.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-notification': minor
+---
+
+Adjust role based on notification type

--- a/package-lock.json
+++ b/package-lock.json
@@ -35705,7 +35705,7 @@
     },
     "packages/consent-manager": {
       "name": "@hashicorp/react-consent-manager",
-      "version": "7.3.0",
+      "version": "7.4.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/react-button": "^6.2.0",
@@ -35748,7 +35748,7 @@
     },
     "packages/docs-page": {
       "name": "@hashicorp/react-docs-page",
-      "version": "17.1.2",
+      "version": "17.2.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-docs-mdx": "^0.1.4",
@@ -36174,7 +36174,7 @@
     },
     "packages/notification": {
       "name": "@hashicorp/react-notification",
-      "version": "0.2.0",
+      "version": "0.3.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/flight-icons": "^2.0.2",

--- a/packages/notification/components/notification-with-resource/index.tsx
+++ b/packages/notification/components/notification-with-resource/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import type {
-  NotificationTypes,
+  NotificationResources,
   NotificationWithResourceProps,
 } from '../../types'
 import Notification from '../notification'
@@ -10,7 +10,7 @@ import { IconGuide16 } from '@hashicorp/flight-icons/svg-react/guide-16'
 import s from '../style.module.css'
 
 const TYPE_MAP: {
-  [key in NotificationTypes]: {
+  [key in NotificationResources]: {
     name: string
     icon: React.ReactNode
   }

--- a/packages/notification/components/notifications/index.tsx
+++ b/packages/notification/components/notifications/index.tsx
@@ -28,6 +28,12 @@ export const Notifications = ({
     >
       <AnimatePresence initial={false}>
         {notifications.map((n) => {
+          /**
+           * Define the role attribute based on toast type.
+           * toast.dialog() should be used in the case that
+           * the notification contians interactive content.
+           */
+          const role = n.type === 'toast' ? 'alert' : 'alertDialog'
           return (
             <m.div
               key={n.id}
@@ -39,7 +45,7 @@ export const Notifications = ({
                 scale: reducedMotion ? 1 : 0.75,
                 transition: { duration: 0.2 },
               }}
-              role="status"
+              role={role}
               aria-live="polite"
             >
               {renderNotification(n.message, n)}

--- a/packages/notification/core/notification.ts
+++ b/packages/notification/core/notification.ts
@@ -2,6 +2,7 @@ import {
   Renderable,
   Notification,
   NotificationOptions,
+  NotificationAsType,
   ValueOrFunction,
 } from '../types'
 import { genId } from './utils'
@@ -14,23 +15,30 @@ type NotificationHandler = (
   options?: NotificationOptions
 ) => string
 
-const createNotification = (message: Message, options): Notification => ({
+const createNotification = (
+  message: Message,
+  type: NotificationAsType = 'toast',
+  options
+): Notification => ({
   createdAt: Date.now(),
   visible: true,
+  type,
   message,
   pauseDuration: 0,
   ...options,
   id: options?.id || `notification-${genId()}`,
 })
 
-const createHandler = (): NotificationHandler => (message, options) => {
-  const notification = createNotification(message, options)
-  dispatch({ type: ActionType.UPSERT_NOTIFICATION, notification })
-  return notification.id
-}
+const createHandler =
+  (type?: NotificationAsType): NotificationHandler =>
+  (message, options) => {
+    const notification = createNotification(message, type, options)
+    dispatch({ type: ActionType.UPSERT_NOTIFICATION, notification })
+    return notification.id
+  }
 
 const notification = (message: Message, options?: NotificationOptions) => {
-  createHandler()(message, options)
+  createHandler('toast')(message, options)
 }
 
 notification.dismiss = (notificationId?: string) => {
@@ -42,5 +50,8 @@ notification.dismiss = (notificationId?: string) => {
 
 notification.remove = (notificationId?: string) =>
   dispatch({ type: ActionType.REMOVE_NOTIFICATION, notificationId })
+
+notification.toast = createHandler('toast')
+notification.dialog = createHandler('dialog')
 
 export { notification }

--- a/packages/notification/core/notification.ts
+++ b/packages/notification/core/notification.ts
@@ -2,7 +2,7 @@ import {
   Renderable,
   Notification,
   NotificationOptions,
-  NotificationAsType,
+  NotificationType,
   ValueOrFunction,
 } from '../types'
 import { genId } from './utils'
@@ -17,7 +17,7 @@ type NotificationHandler = (
 
 const createNotification = (
   message: Message,
-  type: NotificationAsType = 'toast',
+  type: NotificationType = 'toast',
   options
 ): Notification => ({
   createdAt: Date.now(),
@@ -30,7 +30,7 @@ const createNotification = (
 })
 
 const createHandler =
-  (type?: NotificationAsType): NotificationHandler =>
+  (type?: NotificationType): NotificationHandler =>
   (message, options) => {
     const notification = createNotification(message, type, options)
     dispatch({ type: ActionType.UPSERT_NOTIFICATION, notification })

--- a/packages/notification/types.ts
+++ b/packages/notification/types.ts
@@ -4,7 +4,7 @@ export type Renderable = JSX.Element | string | null
 
 export type ValueFunction<TValue, TArg> = (arg: TArg) => TValue
 export type ValueOrFunction<TValue, TArg> = TValue | ValueFunction<TValue, TArg>
-export type NotificationAsType = 'toast' | 'dialog'
+export type NotificationType = 'toast' | 'dialog'
 
 export interface NotificationsProps {
   /**
@@ -22,7 +22,7 @@ export interface NotificationsProps {
 }
 
 export interface Notification {
-  type: NotificationAsType
+  type: NotificationType
   createdAt: number
   id: string
   message: ValueOrFunction<Renderable, Notification>
@@ -42,7 +42,7 @@ export type NotificationLanguages =
   | 'pt'
   | 'es'
 export type NotificationProducts = Exclude<Products, 'hashicorp'>
-export type NotificationTypes = 'podcast' | 'webinar' | 'whitepaper'
+export type NotificationResources = 'podcast' | 'webinar' | 'whitepaper'
 
 export interface NotificationProps {
   /**
@@ -84,7 +84,7 @@ export interface NotificationWithResourceProps extends NotificationProps {
   /**
    * Renders resource type name and icon.
    */
-  type: NotificationTypes
+  type: NotificationResources
 }
 
 export interface NotificationWithThumbnailProps extends NotificationProps {

--- a/packages/notification/types.ts
+++ b/packages/notification/types.ts
@@ -4,6 +4,7 @@ export type Renderable = JSX.Element | string | null
 
 export type ValueFunction<TValue, TArg> = (arg: TArg) => TValue
 export type ValueOrFunction<TValue, TArg> = TValue | ValueFunction<TValue, TArg>
+export type NotificationAsType = 'toast' | 'dialog'
 
 export interface NotificationsProps {
   /**
@@ -21,6 +22,7 @@ export interface NotificationsProps {
 }
 
 export interface Notification {
+  type: NotificationAsType
   createdAt: number
   id: string
   message: ValueOrFunction<Renderable, Notification>


### PR DESCRIPTION
<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Based on whether or not the notification contains interactive content, render the notification with `role="alert"` for toasts and `role="alerDialog"` for dialogs.

This is based off the work HDS team has done with their [toast implementations](https://design-system-components-hashicorp.vercel.app/components/toast).

And confirmation from HDS team https://hashicorp.slack.com/archives/C7KTUHNUS/p1657818549189699?thread_ts=1657652997.846709&cid=C7KTUHNUS

### Usage

```tsx
notification() // defaults to toast type
notification.toast() // type = toast with role = alert
notification.dialog() // type = dialog with role = alertDialog
```

https://user-images.githubusercontent.com/825855/179763363-611d8b2c-0f60-4864-b44e-f0dff14a8951.mp4

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
