### PR TITLE
feat(docs-page): pass `projectName` to version-alert

### DIFF
--- a/.changeset/twenty-ads-sort.md
+++ b/.changeset/twenty-ads-sort.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-page': minor
+---
+
+Pass `projectName` to internal `VersionAlert`

--- a/packages/docs-page/components/version-alert/version-alert.test.tsx
+++ b/packages/docs-page/components/version-alert/version-alert.test.tsx
@@ -10,9 +10,9 @@ const useRouterMock = mocked(useRouter)
 jest.mock('next/router')
 
 describe('<VersionAlert />', () => {
-  const routerMock = ({
+  const routerMock = {
     asPath: '/docs',
-  } as unknown) as Router
+  } as unknown as Router
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -24,16 +24,34 @@ describe('<VersionAlert />', () => {
     expect(container.hasChildNodes()).toBe(false)
   })
 
-  it('should be shown when viewing an older version', () => {
-    useRouterMock.mockImplementation(() => {
-      return ({
-        asPath: '/docs/v0.5.1',
-      } as unknown) as Router
-    })
+  it.each([
+    [
+      /* Product      */ 'Waypoint',
+      /* Path         */ '/docs/v0.5.x',
+      /* Text content */ "You're looking at documentation for Waypoint v0.5.x. Click here to view the latest content.",
+    ],
+    [
+      'CDK for Terraform',
+      '/cdktf/v0.10.x',
+      "You're looking at documentation for CDK for Terraform v0.10.x. Click here to view the latest content.",
+    ],
+    [
+      'Terraform Enterprise',
+      '/enterprise/v202207-1',
+      "You're looking at documentation for Terraform Enterprise v202207-1. Click here to view the latest content.",
+    ],
+  ])(
+    'given product: %p, and path: %p as arguments, should render an alert: %p',
+    (product, path, textContent) => {
+      useRouterMock.mockImplementation(() => {
+        return {
+          asPath: path,
+        } as unknown as Router
+      })
 
-    const { getByText } = render(<VersionAlert product={'waypoint'} />)
+      const { getByTestId } = render(<VersionAlert product={product} />)
 
-    expect(getByText('waypoint', { exact: false })).toBeInTheDocument()
-    expect(getByText('v0.5.1', { exact: false })).toBeInTheDocument()
-  })
+      expect(getByTestId('text')).toHaveTextContent(textContent)
+    }
+  )
 })

--- a/packages/docs-page/index.tsx
+++ b/packages/docs-page/index.tsx
@@ -98,7 +98,7 @@ export const DocsPageInner: FunctionComponent<DocsPageInnerProps> = ({
 
   const versionAlert =
     !versionIsLatest && showVersionSelect ? (
-      <VersionAlert product={name} />
+      <VersionAlert product={projectName || name} />
     ) : null
 
   return (
@@ -189,6 +189,9 @@ export interface DocsPageProps {
     versions: VersionSelectItem[]
   }
   optInBanner?: ReactElement
+  /**
+   * This will override the `product.name` that is passed to the version-alert.
+   */
   projectName?: string
 }
 


### PR DESCRIPTION
## Description

This updates `docs-page` to pass the `projectName` prop to the `VersionAlert` component.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
