### PR TITLE
feat(docs-page): local version faking

### DIFF
--- a/.changeset/nine-squids-teach.md
+++ b/.changeset/nine-squids-teach.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-page': minor
+---
+
+Support version faking when using FS loader

--- a/packages/docs-page/server/loaders/file-system.test.ts
+++ b/packages/docs-page/server/loaders/file-system.test.ts
@@ -49,7 +49,9 @@ describe('FileSystemLoader', () => {
         "githubFileUrl": "https://github.com/hashicorp/waypoint/blob/main/website/packages/docs-page/server/__fixtures__/index.mdx",
         "mdxSource": Object {
           "compiledSource": Any<String>,
-          "scope": Object {},
+          "scope": Object {
+            "version": "latest",
+          },
         },
         "navData": Any<Array>,
         "versions": Array [],
@@ -84,7 +86,9 @@ describe('FileSystemLoader', () => {
         "githubFileUrl": "https://hashicorp.com/packages/docs-page/server/__fixtures__/index.mdx",
         "mdxSource": Object {
           "compiledSource": Any<String>,
-          "scope": Object {},
+          "scope": Object {
+            "version": "latest",
+          },
         },
         "navData": Any<Array>,
         "versions": Array [],

--- a/packages/docs-page/server/loaders/file-system.ts
+++ b/packages/docs-page/server/loaders/file-system.ts
@@ -48,7 +48,6 @@ export default class FileSystemLoader implements DataLoader {
   loadStaticProps = async ({
     params,
   }: GetStaticPropsContext): Promise<$TSFixMe> => {
-    console.log('YALCYBOI')
     let remarkPlugins: $TSFixMe[] = []
 
     // given: v0.5.x (latest), v0.4.x, v0.3.x

--- a/packages/docs-page/server/loaders/remote-content.test.ts
+++ b/packages/docs-page/server/loaders/remote-content.test.ts
@@ -152,7 +152,9 @@ describe('RemoteContentLoader', () => {
         "githubFileUrl": "https://github.com/hashicorp/waypoint/blob/main/website/content/commands/index.mdx",
         "mdxSource": Object {
           "compiledSource": Any<String>,
-          "scope": Object {},
+          "scope": Object {
+            "version": "latest",
+          },
         },
         "navData": Any<Array>,
         "versions": Array [

--- a/packages/docs-page/server/loaders/remote-content.ts
+++ b/packages/docs-page/server/loaders/remote-content.ts
@@ -152,17 +152,17 @@ export default class RemoteContentLoader implements DataLoader {
       remarkPlugins = this.opts.remarkPlugins!
     }
 
-    const mdxRenderer = (mdx) =>
-      renderPageMdx(mdx, {
-        remarkPlugins,
-        rehypePlugins: this.opts.rehypePlugins,
-        scope: this.opts.scope,
-      })
-
     // given: v0.5.x (latest), v0.4.x, v0.3.x
     const [versionFromPath, paramsNoVersion] = stripVersionFromPathParams(
       params![this.opts.paramId!] as string[]
     )
+
+    const mdxRenderer = (mdx) =>
+      renderPageMdx(mdx, {
+        remarkPlugins,
+        rehypePlugins: this.opts.rehypePlugins,
+        scope: { version: versionFromPath, ...this.opts.scope },
+      })
 
     const versionMetadataList: VersionMetadataItem[] =
       await cachedFetchVersionMetadataList(this.opts.product)


### PR DESCRIPTION
# Description

This enables local version-faking when using the `FS` content loader.

You can force a "version" into state by inserting a version like `v1.1.x` or `v202207-1` after the subpath in the URL.