### PR TITLE
fix(docs-page): use correct boolean to determine versionedDocsOffset

### DIFF
--- a/.changeset/polite-shrimps-refuse.md
+++ b/.changeset/polite-shrimps-refuse.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-page': patch
+---
+
+Fix condition for applying the margin top to align search with the version select

--- a/packages/docs-page/index.tsx
+++ b/packages/docs-page/index.tsx
@@ -154,8 +154,7 @@ export const DocsPageInner: FunctionComponent<DocsPageInnerProps> = ({
           id="inner"
           role="main"
           className={classNames(s.inner, s.tempJumpToSectionParent, {
-            [s.versionedDocsOffset]:
-              process.env.ENABLE_VERSIONED_DOCS === 'true',
+            [s.versionedDocsOffset]: showVersionSelect,
           })}
         >
           <CodeTabsProvider>


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Adjusts conditional to apply `s.versionedDocsOffset` to use `showVersionSelect` instead of the env var. This will line up the version select element with the search element visually.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
