### PR TITLE
feat(docs-page) expose `mdxContentHook`

### DIFF
--- a/.changeset/swift-birds-hear.md
+++ b/.changeset/swift-birds-hear.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-page': minor
+---
+
+Expose `mdxContentHook` option on loader interfaces

--- a/packages/docs-page/server/loaders/file-system.ts
+++ b/packages/docs-page/server/loaders/file-system.ts
@@ -35,6 +35,8 @@ export default class FileSystemLoader implements DataLoader {
     if (!this.opts.scope) this.opts.scope = {}
     if (!this.opts.remarkPlugins) this.opts.remarkPlugins = []
     if (!this.opts.rehypePlugins) this.opts.rehypePlugins = []
+    if (!this.opts.mdxContentHook)
+      this.opts.mdxContentHook = (mdxContent) => mdxContent
   }
 
   loadStaticPaths = async (): Promise<$TSFixMe> => {
@@ -73,6 +75,7 @@ export default class FileSystemLoader implements DataLoader {
 
     const mdxRenderer = (mdx) =>
       renderPageMdx(mdx, {
+        mdxContentHook: this.opts.mdxContentHook,
         remarkPlugins,
         rehypePlugins: this.opts.rehypePlugins,
         scope: { version: versionFromPath, ...this.opts.scope },

--- a/packages/docs-page/server/loaders/remote-content.ts
+++ b/packages/docs-page/server/loaders/remote-content.ts
@@ -106,6 +106,8 @@ export default class RemoteContentLoader implements DataLoader {
     if (!this.opts.remarkPlugins) this.opts.remarkPlugins = []
     if (!this.opts.rehypePlugins) this.opts.rehypePlugins = []
     if (!this.opts.navDataPrefix) this.opts.navDataPrefix = this.opts.basePath
+    if (!this.opts.mdxContentHook)
+      this.opts.mdxContentHook = (mdxContent) => mdxContent
   }
 
   loadStaticPaths = async (): Promise<$TSFixMe> => {
@@ -159,6 +161,7 @@ export default class RemoteContentLoader implements DataLoader {
 
     const mdxRenderer = (mdx) =>
       renderPageMdx(mdx, {
+        mdxContentHook: this.opts.mdxContentHook,
         remarkPlugins,
         rehypePlugins: this.opts.rehypePlugins,
         scope: { version: versionFromPath, ...this.opts.scope },

--- a/packages/docs-page/server/loaders/types.ts
+++ b/packages/docs-page/server/loaders/types.ts
@@ -9,4 +9,5 @@ export interface DataLoader {
 export interface DataLoaderOpts {
   product: string
   paramId?: string
+  mdxContentHook?: (mdxContent: string) => string
 }


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This exposes the previously unused [mdxContentHook](https://github.com/hashicorp/react-components/blob/main/packages/docs-page/render-page-mdx.ts#L15) option on our loader interfaces.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
