### PR TITLE
fix(react-head): only check if image prop is absolute if it exists

### DIFF
--- a/.changeset/lazy-pets-run.md
+++ b/.changeset/lazy-pets-run.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-head': patch
+---
+
+Only validate the `image` prop if it's passed as the correct type.

--- a/packages/head/index.test.js
+++ b/packages/head/index.test.js
@@ -112,6 +112,12 @@ describe('<Head />', () => {
     global.console.error.mockRestore()
   })
 
+  it('should not throw an error if image is not a string', () => {
+    expect(() => {
+      renderHead(<Head image={null} />)
+    }).not.toThrowError()
+  })
+
   it('should render and display <link rel="preload"> tags', () => {
     const { container } = renderHead(
       <Head preload={[{ href: '/style.css', as: 'stylesheet' }]} />

--- a/packages/head/index.tsx
+++ b/packages/head/index.tsx
@@ -12,7 +12,7 @@ export default function HashiHead(props: HashiHeadProps): React.ReactElement {
    * It must be an absolute URL in order to work as expected as og:image.
    * Reference: https://ogp.me/#url
    */
-  if (typeof props.image !== 'undefined' && !isAbsoluteUrl(props.image)) {
+  if (typeof props.image === 'string' && !isAbsoluteUrl(props.image)) {
     const errorMessage = `Error: HashiHead "props.image" must be an absolute URL. Non-absolute URL detected: "${props.image}". Please provide a fully qualified absolute URL or "props.image".`
     if (IS_DEV) {
       throw new Error(errorMessage)


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Update the absolute URL check on the `image` prop to only happen if the `image` prop is a string. This ensures the head component can still retain its fallback behavior in cases where we're specifying a default image higher up in the component tree.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
