### PR TITLE
Fix TypeScript types for react-hook-form compatibility

### DIFF
--- a/.changeset/green-cats-attack.md
+++ b/.changeset/green-cats-attack.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-textarea-input': minor
+---
+
+Fix TS type for field.ref property

--- a/.changeset/green-cats-attack.md
+++ b/.changeset/green-cats-attack.md
@@ -2,4 +2,4 @@
 '@hashicorp/react-textarea-input': minor
 ---
 
-Fix TS type for field.ref property
+Fix TypeScript types for `field.ref` and `form.errors` properties

--- a/packages/textarea-input/index.tsx
+++ b/packages/textarea-input/index.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 import { useId } from '@reach/auto-id'
-import type { RefObject, ChangeEventHandler, FocusEventHandler } from 'react'
+import type { ChangeEventHandler, FocusEventHandler } from 'react'
 import s from './style.module.css'
 
 interface Props {
@@ -9,7 +9,7 @@ interface Props {
     name: string
     onChange: ChangeEventHandler<HTMLTextAreaElement>
     onBlur?: FocusEventHandler<HTMLTextAreaElement>
-    ref?: RefObject<HTMLTextAreaElement>
+    ref?: (instance: HTMLTextAreaElement) => void
   }
   form: { touched: Record<string, boolean>; errors: Record<string, string> }
   label?: string

--- a/packages/textarea-input/index.tsx
+++ b/packages/textarea-input/index.tsx
@@ -11,7 +11,10 @@ interface Props {
     onBlur?: FocusEventHandler<HTMLTextAreaElement>
     ref?: (instance: HTMLTextAreaElement) => void
   }
-  form: { touched: Record<string, boolean>; errors: Record<string, string> }
+  form: {
+    touched: Record<string, boolean>
+    errors: Record<string, string | null | undefined>
+  }
   label?: string
   placeholder?: string
   theme?: { background: 'light' | 'dark' | 'brand' }


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Fixes the TypeScript types for the `field.ref` and `form.errors` properties to be compatible with react-hook-form.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
