### PR TITLE
fix(tabs): activeIdx of nested tabs

### DIFF
--- a/.changeset/blue-ladybugs-scream.md
+++ b/.changeset/blue-ladybugs-scream.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-tabs': patch
+---
+
+Fix case where the activeTabIdx of a nested Tabs instance is not reset when tabs content changes

--- a/packages/tabs/index.tsx
+++ b/packages/tabs/index.tsx
@@ -69,6 +69,12 @@ function Tabs({
   }
 
   useEffect(() => {
+    if (activeTabIdx >= children.length) {
+      setActiveTabIdx(defaultTabIdx || 0)
+    }
+  }, [children])
+
+  useEffect(() => {
     const hasGroups = children.filter((tab) => tab.props.group).length > 0
     if (
       process.env.NODE_ENV !== 'production' &&
@@ -89,6 +95,8 @@ function Tabs({
     return null
   }
 
+  const activeTab = children[activeTabIdx] ?? children[defaultTabIdx || 0]
+
   return (
     <section className={classNames(className, themeStyle[theme])}>
       <TabTriggers
@@ -103,7 +111,7 @@ function Tabs({
         setActiveTab={setActiveTab}
         theme={theme}
       />
-      <div className={s.content}>{children[activeTabIdx].props.children}</div>
+      <div className={s.content}>{activeTab.props.children}</div>
     </section>
   )
 }


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Fixes a scenario where a Tabs instance which has a nested Tabs instance in multiple children with a different number of tabs throws an error when switching between top-level tabs.

Repro:
* Navigate to https://learn.hashicorp.com/tutorials/boundary/hcp-getting-started-install?in=boundary/hcp-getting-started
* Select "Linux"
* Select the last tab
* Select "Windows"
* See the error page

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
