### PR TITLE
Use `useErrorPageAnalytics` hook on 404 page

### DIFF
--- a/.changeset/stupid-lions-grab.md
+++ b/.changeset/stupid-lions-grab.md
@@ -2,4 +2,4 @@
 '@hashicorp/react-error-view': minor
 ---
 
-Uses the useErrorPageAnalytics hook
+Replaces track event name with static value.

--- a/.changeset/stupid-lions-grab.md
+++ b/.changeset/stupid-lions-grab.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-error-view': minor
+---
+
+Uses the useErrorPageAnalytics hook

--- a/packages/error-view/__tests__/use-404-redirects.test.tsx
+++ b/packages/error-view/__tests__/use-404-redirects.test.tsx
@@ -58,8 +58,7 @@ describe('use404Redirects', () => {
       expect(useRouterMethods.replace).toHaveBeenCalledWith('/new-destination')
     )
     expect(window.analytics.track).toHaveBeenCalledTimes(1)
-    expect(window.analytics.track).toBeCalledWith('http://local.test/testing', {
-      category: 'Client-side Redirect',
+    expect(window.analytics.track).toBeCalledWith('Client-side Redirect', {
       label: 'http://local.test/new-destination',
     })
   })

--- a/packages/error-view/use-404-redirects.ts
+++ b/packages/error-view/use-404-redirects.ts
@@ -28,8 +28,7 @@ export default function use404Redirects(): void {
             typeof window?.analytics?.track === 'function' &&
             typeof window?.location?.href === 'string'
           ) {
-            window.analytics.track(window.location.href, {
-              category: 'Client-side Redirect',
+            window.analytics.track('Client-side Redirect', {
               label: href,
             })
           }


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1202791227659279/1202865459293217/f)

---

## Description
It was recently discovered that, across our various web properties, we make the following call:

`window.analytics.track(window.location.href, { ... } )`

The first parameter of the `track` method is used downstream in our various data warehouses to create a new table. Since we're using `window.location.href`, we're creating a table for _every_ URL that 404s. This is not ideal for analytics.

## Solution
This PR leverages the new `useErrorPageAnalytics` hook (see [this PR](https://github.com/hashicorp/web-platform-packages/pull/86)) for pushing 404-related data to Segment. This PR replaces the `window.analytics.track` call on the 404 page with said hook.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
