### PR TITLE
fix(docs-sidenav): fix bug in mobile menu toggling

### DIFF
--- a/.changeset/yellow-jars-lie.md
+++ b/.changeset/yellow-jars-lie.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-sidenav': patch
+---
+
+Fix mobile menu toggling by validating that the click was in the menu toggle before closing in our "auto close on click outisde" logic

--- a/packages/docs-sidenav/index.tsx
+++ b/packages/docs-sidenav/index.tsx
@@ -68,6 +68,7 @@ export default function DocsSidenav({
   // a transition ends and the menu is not open, we set isMenuFullyHidden
   // which translates into a visibility: hidden CSS property
   const menuRef = useRef<HTMLUListElement | null>(null)
+  const menuToggleRef = useRef<HTMLButtonElement | null>(null)
   const handleMenuTransitionEnd = useCallback(() => {
     setIsMenuFullyHidden(!isMobileOpen)
   }, [isMobileOpen, setIsMenuFullyHidden])
@@ -77,7 +78,9 @@ export default function DocsSidenav({
   const handleDocumentClick = useCallback(
     (event) => {
       if (!isMobileOpen) return
-      const isClickOutside = !menuRef.current?.contains(event.target)
+      const isClickOutside =
+        !menuRef.current?.contains(event.target) &&
+        !menuToggleRef.current?.contains(event.target)
       if (isClickOutside) setIsMobileOpen(false)
     },
     [isMobileOpen]
@@ -117,6 +120,7 @@ export default function DocsSidenav({
           <button
             className={`${s.mobileMenuToggle} g-type-body-small-strong`}
             onClick={() => setIsMobileOpen(!isMobileOpen)}
+            ref={menuToggleRef}
           >
             <span>
               <InlineSvg src={svgMenuIcon} /> Documentation Menu


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Updated the `onClickOutside` handler to also validate that the click event was not from the menu toggle button. I'm not sure why this started happening, potentially a React internal update that came with React 18.

Fixes the mobile menu not opening: https://www.consul.io/docs

To validate locally in `dev-portal`:
* Copy the contents of `packages/docs-sidenav/index.tsx`
* In `dev-portal`:
* replace the contents of `node_modules/@hashicorp/react-docs-page/node_modules/@hashicorp/react-docs-sidenav/index.tsx` with what you coped from the previous step
* clear next's local cache: `rm -rf .next`
* run the app locally in a .io context: `npm run start:consul`
* validate that the mobile menu properly opens on small viewports

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
