### PR TITLE
Chore: Bump `mktg-logos` to v1.3.2

### DIFF
--- a/.changeset/orange-impalas-act.md
+++ b/.changeset/orange-impalas-act.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-subnav': minor
+---
+
+Bumping mktg-logos deps

--- a/package-lock.json
+++ b/package-lock.json
@@ -1902,8 +1902,9 @@
       "license": "MPL-2.0"
     },
     "node_modules/@hashicorp/mktg-logos": {
-      "version": "1.2.0",
-      "license": "MPL-2.0"
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/mktg-logos/-/mktg-logos-1.3.2.tgz",
+      "integrity": "sha512-lXsA+EgCukTQ7rbS0GW7CrGUbUoRiHREDzK57/HF/SvehGJu8l+zhyCODIBhjOC0FtG/Dek1A9jmtBNHsVng6A=="
     },
     "node_modules/@hashicorp/next-optimized-images": {
       "version": "0.2.0",
@@ -4974,6 +4975,24 @@
         "@octokit/openapi-types": "^9.4.0"
       }
     },
+    "node_modules/@reach/descendants": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.16.1.tgz",
+      "integrity": "sha512-3WZgRnD9O4EORKE31rrduJDiPFNMOjUkATx0zl192ZxMq3qITe4tUj70pS5IbJl/+v9zk78JwyQLvA1pL7XAPA==",
+      "dependencies": {
+        "@reach/utils": "0.16.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@reach/descendants/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
     "node_modules/@reach/listbox": {
       "version": "0.17.0",
       "license": "MIT",
@@ -5101,24 +5120,6 @@
     "node_modules/@reach/machine/node_modules/tslib": {
       "version": "2.4.0",
       "license": "0BSD"
-    },
-    "node_modules/@reach/descendants": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.16.1.tgz",
-      "integrity": "sha512-3WZgRnD9O4EORKE31rrduJDiPFNMOjUkATx0zl192ZxMq3qITe4tUj70pS5IbJl/+v9zk78JwyQLvA1pL7XAPA==",
-      "dependencies": {
-        "@reach/utils": "0.16.0",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/@reach/descendants/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@reach/observe-rect": {
       "version": "1.2.0",
@@ -35367,7 +35368,7 @@
     },
     "packages/alert-banner": {
       "name": "@hashicorp/react-alert-banner",
-      "version": "7.0.2",
+      "version": "7.0.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
@@ -36139,7 +36140,7 @@
     },
     "packages/marketo-form": {
       "name": "@hashicorp/react-marketo-form",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/react-button": "^6.2.0",
@@ -38393,7 +38394,9 @@
       "version": "4.2.0"
     },
     "@hashicorp/mktg-logos": {
-      "version": "1.2.0"
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/mktg-logos/-/mktg-logos-1.3.2.tgz",
+      "integrity": "sha512-lXsA+EgCukTQ7rbS0GW7CrGUbUoRiHREDzK57/HF/SvehGJu8l+zhyCODIBhjOC0FtG/Dek1A9jmtBNHsVng6A=="
     },
     "@hashicorp/next-optimized-images": {
       "version": "0.2.0",
@@ -40148,7 +40151,7 @@
         "@vercel/fetch": "^6.2.0",
         "clsx": "^1.1.1",
         "js-cookie": "^3.0.1",
-        "moize": "*",
+        "moize": "^6.1.3",
         "react-hook-form": "^7.33.0"
       },
       "dependencies": {
@@ -41576,6 +41579,22 @@
         "@octokit/openapi-types": "^9.4.0"
       }
     },
+    "@reach/descendants": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.16.1.tgz",
+      "integrity": "sha512-3WZgRnD9O4EORKE31rrduJDiPFNMOjUkATx0zl192ZxMq3qITe4tUj70pS5IbJl/+v9zk78JwyQLvA1pL7XAPA==",
+      "requires": {
+        "@reach/utils": "0.16.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
     "@reach/listbox": {
       "version": "0.17.0",
       "requires": {
@@ -41658,22 +41677,6 @@
         },
         "tslib": {
           "version": "2.4.0"
-        }
-      }
-    },
-    "@reach/descendants": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.16.1.tgz",
-      "integrity": "sha512-3WZgRnD9O4EORKE31rrduJDiPFNMOjUkATx0zl192ZxMq3qITe4tUj70pS5IbJl/+v9zk78JwyQLvA1pL7XAPA==",
-      "requires": {
-        "@reach/utils": "0.16.0",
-        "tslib": "^2.3.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       "dependencies": {
         "@hashicorp/flight-icons": "^2.5.0",
         "@hashicorp/mktg-global-styles": "^4.2.0",
-        "@hashicorp/mktg-logos": "^1.2.0",
+        "@hashicorp/mktg-logos": "^1.3.2",
         "@hashicorp/sentinel-embedded": "^0.0.14",
         "classnames": "^2.3.1",
         "formik": "^2.2.9",
@@ -35552,7 +35552,7 @@
     },
     "packages/code-block": {
       "name": "@hashicorp/react-code-block",
-      "version": "6.1.0",
+      "version": "6.1.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/react-inline-svg": "^6.0.3",
@@ -35916,7 +35916,7 @@
     },
     "packages/docs-sidenav": {
       "name": "@hashicorp/react-docs-sidenav",
-      "version": "9.0.1",
+      "version": "9.0.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
@@ -36068,7 +36068,7 @@
     },
     "packages/intro": {
       "name": "@hashicorp/react-intro",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/react-actions": "^0.3.0",
@@ -36723,7 +36723,8 @@
       }
     },
     "packages/standalone-link": {
-      "version": "0.1.0",
+      "name": "@hashicorp/react-standalone-link",
+      "version": "0.1.1",
       "license": "MPL-2.0",
       "dependencies": {
         "classnames": "^2.3.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -36752,7 +36752,7 @@
       "version": "9.4.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@hashicorp/mktg-logos": "^1.2.0",
+        "@hashicorp/mktg-logos": "^1.3.2",
         "@hashicorp/platform-product-meta": "^0.1.0",
         "@hashicorp/react-button": "^6.0.4",
         "@hashicorp/react-inline-svg": "^6.0.3",
@@ -40523,7 +40523,7 @@
     "@hashicorp/react-subnav": {
       "version": "file:packages/subnav",
       "requires": {
-        "@hashicorp/mktg-logos": "^1.2.0",
+        "@hashicorp/mktg-logos": "^1.3.2",
         "@hashicorp/platform-product-meta": "^0.1.0",
         "@hashicorp/react-button": "^6.0.4",
         "@hashicorp/react-inline-svg": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@hashicorp/flight-icons": "^2.5.0",
     "@hashicorp/mktg-global-styles": "^4.2.0",
-    "@hashicorp/mktg-logos": "^1.2.0",
+    "@hashicorp/mktg-logos": "^1.3.2",
     "@hashicorp/sentinel-embedded": "^0.0.14",
     "classnames": "^2.3.1",
     "formik": "^2.2.9",

--- a/packages/subnav/package.json
+++ b/packages/subnav/package.json
@@ -7,7 +7,7 @@
     "Zach Shilton"
   ],
   "dependencies": {
-    "@hashicorp/mktg-logos": "^1.2.0",
+    "@hashicorp/mktg-logos": "^1.3.2",
     "@hashicorp/platform-product-meta": "^0.1.0",
     "@hashicorp/react-button": "^6.0.4",
     "@hashicorp/react-inline-svg": "^6.0.3",


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1202791227659279/1203093711604797/f)
🔍 [Preview Link](https://react-components-git-nels-choresbump-mktg-logos-hashicorp.vercel.app/components/subnav)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description
It was recently discovered that the old Vault logo is currently being used in the `Subnav` component. This PR updates packages so as to use the new logos (logo change [here](https://github.com/hashicorp/mktg-logos/pull/9)).

## Validation Steps
- Navigate to the [`Subnav` in Preview](https://react-components-git-nels-choresbump-mktg-logos-hashicorp.vercel.app/components/subnav)
- Set `text` in the `titleLink` prop to `HashiCorp Vault`
- Verify that the correct logo is displayed:
<img width="531" alt="Screen Shot 2022-10-04 at 9 31 16 AM" src="https://user-images.githubusercontent.com/39201593/193874697-6efd7f79-3a52-4e6c-8318-c0d0bae1a8da.png">


### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
