### PR TITLE
fix: keep dirty values when resetting form

### DIFF
--- a/.changeset/fast-peas-repeat.md
+++ b/.changeset/fast-peas-repeat.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-marketo-form': patch
+---
+
+Keep dirty values when resetting form

--- a/packages/marketo-form/form/index.tsx
+++ b/packages/marketo-form/form/index.tsx
@@ -180,9 +180,14 @@ const Form = ({
   // resolved _after_ the initial render for SSG pages.
   useEffect(() => {
     if (hasBeenRendered.current) {
-      methods.reset(calculateDefaultValues(marketoForm.result, initialValues), {
-        keepValues: true,
-        keepDirtyValues: true,
+      const newValues = calculateDefaultValues(
+        marketoForm.result,
+        initialValues
+      )
+      Object.entries(newValues).forEach(([fieldId, value]) => {
+        if (!methods.getValues(fieldId)) {
+          methods.setValue(fieldId, value)
+        }
       })
     }
   }, [hasBeenRendered, methods, marketoForm, initialValues])

--- a/packages/marketo-form/form/index.tsx
+++ b/packages/marketo-form/form/index.tsx
@@ -182,6 +182,7 @@ const Form = ({
     if (hasBeenRendered.current) {
       methods.reset(calculateDefaultValues(marketoForm.result, initialValues), {
         keepValues: true,
+        keepDirtyValues: true,
       })
     }
   }, [hasBeenRendered, methods, marketoForm, initialValues])


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This is a follow up to https://github.com/hashicorp/react-components/pull/743 that restores `keepDirtyValues` to ensure that values that are set via `initialValues` are retained alongside values that are set via `setValue`.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
