### PR TITLE
feat: Add `<ProductBadge />` support to `<Card />` component

### DIFF
--- a/.changeset/forty-tips-matter.md
+++ b/.changeset/forty-tips-matter.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-card': minor
+---
+
+Add ProductBadge support to Card

--- a/package-lock.json
+++ b/package-lock.json
@@ -35482,6 +35482,7 @@
       "version": "0.2.0",
       "license": "MPL-2.0",
       "dependencies": {
+        "@hashicorp/react-product-badge": "^0.1.1",
         "classnames": "^2.3.1"
       },
       "peerDependencies": {
@@ -39731,6 +39732,7 @@
     "@hashicorp/react-card": {
       "version": "file:packages/card",
       "requires": {
+        "@hashicorp/react-product-badge": "*",
         "classnames": "^2.3.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@hashicorp/flight-icons": "^2.5.0",
         "@hashicorp/mktg-global-styles": "^4.2.0",
         "@hashicorp/mktg-logos": "^1.3.2",
-        "@hashicorp/react-product-badge": "^0.1.1",
         "@hashicorp/sentinel-embedded": "^0.0.14",
         "classnames": "^2.3.1",
         "formik": "^2.2.9",
@@ -35483,6 +35482,7 @@
       "version": "0.2.0",
       "license": "MPL-2.0",
       "dependencies": {
+        "@hashicorp/react-product-badge": "^0.1.1",
         "classnames": "^2.3.1"
       },
       "peerDependencies": {
@@ -39732,6 +39732,7 @@
     "@hashicorp/react-card": {
       "version": "file:packages/card",
       "requires": {
+        "@hashicorp/react-product-badge": "*",
         "classnames": "^2.3.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -35482,7 +35482,6 @@
       "version": "0.2.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@hashicorp/react-product-badge": "^0.1.1",
         "classnames": "^2.3.1"
       },
       "peerDependencies": {
@@ -39732,7 +39731,6 @@
     "@hashicorp/react-card": {
       "version": "file:packages/card",
       "requires": {
-        "@hashicorp/react-product-badge": "^0.1.1",
         "classnames": "^2.3.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@hashicorp/flight-icons": "^2.5.0",
         "@hashicorp/mktg-global-styles": "^4.2.0",
         "@hashicorp/mktg-logos": "^1.3.2",
+        "@hashicorp/react-product-badge": "^0.1.1",
         "@hashicorp/sentinel-embedded": "^0.0.14",
         "classnames": "^2.3.1",
         "formik": "^2.2.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39732,7 +39732,7 @@
     "@hashicorp/react-card": {
       "version": "file:packages/card",
       "requires": {
-        "@hashicorp/react-product-badge": "*",
+        "@hashicorp/react-product-badge": "^0.1.1",
         "classnames": "^2.3.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "@hashicorp/flight-icons": "^2.5.0",
     "@hashicorp/mktg-global-styles": "^4.2.0",
     "@hashicorp/mktg-logos": "^1.3.2",
+    "@hashicorp/react-product-badge": "^0.1.1",
     "@hashicorp/sentinel-embedded": "^0.0.14",
     "classnames": "^2.3.1",
     "formik": "^2.2.9",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "@hashicorp/flight-icons": "^2.5.0",
     "@hashicorp/mktg-global-styles": "^4.2.0",
     "@hashicorp/mktg-logos": "^1.3.2",
-    "@hashicorp/react-product-badge": "^0.1.1",
     "@hashicorp/sentinel-embedded": "^0.0.14",
     "classnames": "^2.3.1",
     "formik": "^2.2.9",

--- a/packages/card/docs.mdx
+++ b/packages/card/docs.mdx
@@ -222,47 +222,43 @@ A component used to promote and link to marketing pages, always using a descript
       'USE CASE'
     ]}
     heading="Display 5 - 4 lines with character limit of 130. Leo mauris fermentum pharetra blandit tellus euismod…"
-    productBadges={
-      {badges: [
-        {productName: 'waypoint'},
-        {productName: 'consul'},
-      ]}} 
-    description="Body small - 4 lines with character limit of 170. Leo mauris fermentum pharetra blandit tellus euismod pharetra. Duis egestas volutpat dolor…"
-  />
-  <Card
-    link="https://hashicorp.com"
-    thumbnail={{
-      src: "https://www.datocms-assets.com/19447/1648680074-screenshot-2022-03-31-at-00-40-47.png",
-      alt: "HashiConf Europe 2022 Recap"
-    }}
-    meta={[
-      'USE CASE'
-    ]}
-    heading="Display 5 - 4 lines with character limit of 130. Leo mauris fermentum pharetra blandit tellus euismod…"
-    productBadges={
-      {badges: [
-        {productName: 'terraform'},
-        {productName: 'consul'},
-      ]}} 
-    description="Body small - 4 lines with character limit of 170. Leo mauris fermentum pharetra blandit tellus euismod pharetra. Duis egestas volutpat dolor…"
-  />
-  <Card
-    link="https://hashicorp.com"
-    thumbnail={{
-      src: "https://www.datocms-assets.com/19447/1648680074-screenshot-2022-03-31-at-00-40-47.png",
-      alt: "HashiConf Europe 2022 Recap"
-    }}
-    meta={[
-      'USE CASE'
-    ]}
-    heading="Display 5 - 4 lines with character limit of 130. Leo mauris fermentum pharetra blandit tellus euismod…"
-    productBadges={
-      {badges: [
-        {productName: 'nomad'},
-        {productName: 'vault'},
-        {productName: 'terraform'},
+    productBadges={[
+        'waypoint',
+        'consul',
       ]}
-    }
+    description="Body small - 4 lines with character limit of 170. Leo mauris fermentum pharetra blandit tellus euismod pharetra. Duis egestas volutpat dolor…"
+  />
+  <Card
+    link="https://hashicorp.com"
+    thumbnail={{
+      src: "https://www.datocms-assets.com/19447/1648680074-screenshot-2022-03-31-at-00-40-47.png",
+      alt: "HashiConf Europe 2022 Recap"
+    }}
+    meta={[
+      'USE CASE'
+    ]}
+    heading="Display 5 - 4 lines with character limit of 130. Leo mauris fermentum pharetra blandit tellus euismod…"
+    productBadges={[
+        'terraform',
+        'consul',
+      ]}
+    description="Body small - 4 lines with character limit of 170. Leo mauris fermentum pharetra blandit tellus euismod pharetra. Duis egestas volutpat dolor…"
+  />
+  <Card
+    link="https://hashicorp.com"
+    thumbnail={{
+      src: "https://www.datocms-assets.com/19447/1648680074-screenshot-2022-03-31-at-00-40-47.png",
+      alt: "HashiConf Europe 2022 Recap"
+    }}
+    meta={[
+      'USE CASE'
+    ]}
+    heading="Display 5 - 4 lines with character limit of 130. Leo mauris fermentum pharetra blandit tellus euismod…"
+    productBadges={[
+      'nomad',
+      'vault',
+      'terraform'
+    ]}
     description="Body small - 4 lines with character limit of 170. Leo mauris fermentum pharetra blandit tellus euismod pharetra. Duis egestas volutpat dolor…"
   />
 </div>

--- a/packages/card/docs.mdx
+++ b/packages/card/docs.mdx
@@ -222,10 +222,11 @@ A component used to promote and link to marketing pages, always using a descript
       'USE CASE'
     ]}
     heading="Display 5 - 4 lines with character limit of 130. Leo mauris fermentum pharetra blandit tellus euismod…"
-    productBadges={[
-      {productName: 'waypoint'},
-      {productName: 'consul'},
-    ]}
+    productBadges={
+      {badges: [
+        {productName: 'waypoint'},
+        {productName: 'consul'},
+      ]}} 
     description="Body small - 4 lines with character limit of 170. Leo mauris fermentum pharetra blandit tellus euismod pharetra. Duis egestas volutpat dolor…"
   />
   <Card
@@ -238,10 +239,11 @@ A component used to promote and link to marketing pages, always using a descript
       'USE CASE'
     ]}
     heading="Display 5 - 4 lines with character limit of 130. Leo mauris fermentum pharetra blandit tellus euismod…"
-    productBadges={[
-      {productName: 'terraform'},
-      {productName: 'consul'},
-    ]}
+    productBadges={
+      {badges: [
+        {productName: 'terraform'},
+        {productName: 'consul'},
+      ]}} 
     description="Body small - 4 lines with character limit of 170. Leo mauris fermentum pharetra blandit tellus euismod pharetra. Duis egestas volutpat dolor…"
   />
   <Card
@@ -254,11 +256,13 @@ A component used to promote and link to marketing pages, always using a descript
       'USE CASE'
     ]}
     heading="Display 5 - 4 lines with character limit of 130. Leo mauris fermentum pharetra blandit tellus euismod…"
-    productBadges={[
-      {productName: 'nomad'},
-      {productName: 'vault'},
-      {productName: 'terraform'},
-    ]}
+    productBadges={
+      {badges: [
+        {productName: 'nomad'},
+        {productName: 'vault'},
+        {productName: 'terraform'},
+      ]}
+    }
     description="Body small - 4 lines with character limit of 170. Leo mauris fermentum pharetra blandit tellus euismod pharetra. Duis egestas volutpat dolor…"
   />
 </div>

--- a/packages/card/docs.mdx
+++ b/packages/card/docs.mdx
@@ -200,6 +200,69 @@ A component used to promote and link to marketing pages, always using a descript
   </Card>
 </div>
 
+<h3 className="g-type-label" style={{ color: 'var(--gray-3)' }}>
+  Use Case Cards with Product Badges
+</h3>
+
+<div
+  style={{
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr 1fr',
+    gap: '32px',
+    marginBottom: '32px',
+  }}
+>
+  <Card
+    link="https://hashicorp.com"
+    thumbnail={{
+      src: "https://www.datocms-assets.com/19447/1648680074-screenshot-2022-03-31-at-00-40-47.png",
+      alt: "HashiConf Europe 2022 Recap"
+    }}
+    meta={[
+      'USE CASE'
+    ]}
+    heading="Display 5 - 4 lines with character limit of 130. Leo mauris fermentum pharetra blandit tellus euismod…"
+    productBadges={[
+      {productName: 'waypoint'},
+      {productName: 'consul'},
+    ]}
+    description="Body small - 4 lines with character limit of 170. Leo mauris fermentum pharetra blandit tellus euismod pharetra. Duis egestas volutpat dolor…"
+  />
+  <Card
+    link="https://hashicorp.com"
+    thumbnail={{
+      src: "https://www.datocms-assets.com/19447/1648680074-screenshot-2022-03-31-at-00-40-47.png",
+      alt: "HashiConf Europe 2022 Recap"
+    }}
+    meta={[
+      'USE CASE'
+    ]}
+    heading="Display 5 - 4 lines with character limit of 130. Leo mauris fermentum pharetra blandit tellus euismod…"
+    productBadges={[
+      {productName: 'terraform'},
+      {productName: 'consul'},
+    ]}
+    description="Body small - 4 lines with character limit of 170. Leo mauris fermentum pharetra blandit tellus euismod pharetra. Duis egestas volutpat dolor…"
+  />
+  <Card
+    link="https://hashicorp.com"
+    thumbnail={{
+      src: "https://www.datocms-assets.com/19447/1648680074-screenshot-2022-03-31-at-00-40-47.png",
+      alt: "HashiConf Europe 2022 Recap"
+    }}
+    meta={[
+      'USE CASE'
+    ]}
+    heading="Display 5 - 4 lines with character limit of 130. Leo mauris fermentum pharetra blandit tellus euismod…"
+    productBadges={[
+      {productName: 'nomad'},
+      {productName: 'vault'},
+      {productName: 'terraform'},
+    ]}
+    description="Body small - 4 lines with character limit of 170. Leo mauris fermentum pharetra blandit tellus euismod pharetra. Duis egestas volutpat dolor…"
+  />
+</div>
+
 ## Base Props
 
 <PropsTable props={componentProps.baseProps} />

--- a/packages/card/index.tsx
+++ b/packages/card/index.tsx
@@ -37,6 +37,7 @@ function Card(props: CardProps) {
           <Content>
             {meta && meta.length > 0 ? <Meta items={meta} /> : null}
             <Heading>{heading}</Heading>
+            {description ? <Description>{description}</Description> : null}
             {productBadges &&
             productBadges?.badges &&
             productBadges?.badges?.length > 0 ? (
@@ -45,7 +46,6 @@ function Card(props: CardProps) {
                 appearance={appearance}
               />
             ) : null}
-            {description ? <Description>{description}</Description> : null}
           </Content>
         </>
       )}

--- a/packages/card/index.tsx
+++ b/packages/card/index.tsx
@@ -13,7 +13,6 @@ import type {
   DescriptionProps,
 } from './types'
 import s from './style.module.css'
-import React from 'react'
 
 function Card(props: CardProps) {
   const {
@@ -118,14 +117,13 @@ function ProductBadges({ badges, appearance = 'light' }: ProductBadgesProps) {
     <div className={s.productBadges}>
       {badges.map((badge, stableIdx) => {
         return (
-          // eslint-disable-next-line react/no-array-index-key
-          <React.Fragment key={stableIdx}>
-            <ProductBadge
-              appearance={appearance}
-              productName={badge.productName}
-              hasDot={true}
-            />
-          </React.Fragment>
+          <ProductBadge
+            // eslint-disable-next-line react/no-array-index-key
+            key={stableIdx}
+            appearance={appearance}
+            productName={badge.productName}
+            hasDot={true}
+          />
         )
       })}
     </div>

--- a/packages/card/index.tsx
+++ b/packages/card/index.tsx
@@ -37,9 +37,11 @@ function Card(props: CardProps) {
           <Content>
             {meta && meta.length > 0 ? <Meta items={meta} /> : null}
             <Heading>{heading}</Heading>
-            {productBadges && ProductBadges.length > 0 ? (
+            {productBadges &&
+            productBadges?.badges &&
+            productBadges?.badges?.length > 0 ? (
               <ProductBadges
-                productBadges={productBadges}
+                badges={productBadges.badges}
                 appearance={appearance}
               />
             ) : null}
@@ -111,13 +113,10 @@ function Heading({ as: Component = 'h2', children }: HeadingProps) {
   )
 }
 
-function ProductBadges({
-  productBadges,
-  appearance = 'light',
-}: ProductBadgesProps) {
+function ProductBadges({ badges, appearance = 'light' }: ProductBadgesProps) {
   return (
     <div className={s.productBadges}>
-      {productBadges.map((badge, stableIdx) => {
+      {badges.map((badge, stableIdx) => {
         return (
           // eslint-disable-next-line react/no-array-index-key
           <React.Fragment key={stableIdx}>

--- a/packages/card/index.tsx
+++ b/packages/card/index.tsx
@@ -25,7 +25,6 @@ function Card(props: CardProps) {
     link,
     children,
   } = props
-
   return (
     <div className={classNames(s.card, s[appearance])} data-testid="wpl-card">
       {children ? (
@@ -37,13 +36,8 @@ function Card(props: CardProps) {
             {meta && meta.length > 0 ? <Meta items={meta} /> : null}
             <Heading>{heading}</Heading>
             {description ? <Description>{description}</Description> : null}
-            {productBadges &&
-            productBadges?.badges &&
-            productBadges?.badges?.length > 0 ? (
-              <ProductBadges
-                badges={productBadges.badges}
-                appearance={appearance}
-              />
+            {productBadges && productBadges?.length > 0 ? (
+              <ProductBadges badges={productBadges} appearance={appearance} />
             ) : null}
           </Content>
         </>
@@ -121,7 +115,7 @@ function ProductBadges({ badges, appearance = 'light' }: ProductBadgesProps) {
             // eslint-disable-next-line react/no-array-index-key
             key={stableIdx}
             appearance={appearance}
-            productName={badge.productName}
+            productName={badge}
             hasDot={true}
           />
         )

--- a/packages/card/index.tsx
+++ b/packages/card/index.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames'
 import Image from 'next/image'
 import Link from 'next/link'
+import ProductBadge from '@hashicorp/react-product-badge'
 import { IconArrowRight24 } from '@hashicorp/flight-icons/svg-react/arrow-right-24'
 import type {
   CardProps,
@@ -8,9 +9,11 @@ import type {
   MetaProps,
   ContentProps,
   HeadingProps,
+  ProductBadgesProps,
   DescriptionProps,
 } from './types'
 import s from './style.module.css'
+import React from 'react'
 
 function Card(props: CardProps) {
   const {
@@ -18,6 +21,7 @@ function Card(props: CardProps) {
     meta,
     thumbnail,
     heading,
+    productBadges,
     description,
     link,
     children,
@@ -33,6 +37,12 @@ function Card(props: CardProps) {
           <Content>
             {meta && meta.length > 0 ? <Meta items={meta} /> : null}
             <Heading>{heading}</Heading>
+            {productBadges && ProductBadges.length > 0 ? (
+              <ProductBadges
+                productBadges={productBadges}
+                appearance={appearance}
+              />
+            ) : null}
             {description ? <Description>{description}</Description> : null}
           </Content>
         </>
@@ -101,6 +111,28 @@ function Heading({ as: Component = 'h2', children }: HeadingProps) {
   )
 }
 
+function ProductBadges({
+  productBadges,
+  appearance = 'light',
+}: ProductBadgesProps) {
+  return (
+    <div className={s.productBadges}>
+      {productBadges.map((badge, stableIdx) => {
+        return (
+          // eslint-disable-next-line react/no-array-index-key
+          <React.Fragment key={stableIdx}>
+            <ProductBadge
+              appearance={appearance}
+              productName={badge.productName}
+              hasDot={true}
+            />
+          </React.Fragment>
+        )
+      })}
+    </div>
+  )
+}
+
 function Description({ children }: DescriptionProps) {
   return (
     <p className={s.description} data-testid="wpl-card-description">
@@ -113,6 +145,7 @@ Card.Thumbnail = Thumbnail
 Card.Meta = Meta
 Card.Content = Content
 Card.Heading = Heading
+Card.ProductBadges = ProductBadges
 Card.Description = Description
 
 export default Card

--- a/packages/card/index.tsx
+++ b/packages/card/index.tsx
@@ -145,7 +145,6 @@ Card.Thumbnail = Thumbnail
 Card.Meta = Meta
 Card.Content = Content
 Card.Heading = Heading
-Card.ProductBadges = ProductBadges
 Card.Description = Description
 
 export default Card

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -5,11 +5,12 @@
   "author": "HashiCorp",
   "license": "MPL-2.0",
   "dependencies": {
+    "@hashicorp/react-product-badge": "^0.1.1",
     "classnames": "^2.3.1"
   },
   "peerDependencies": {
-    "@hashicorp/mktg-global-styles": ">=3.x",
     "@hashicorp/flight-icons": ">=2.x",
+    "@hashicorp/mktg-global-styles": ">=3.x",
     "react": ">=16.x"
   },
   "repository": {

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -5,6 +5,7 @@
   "author": "HashiCorp",
   "license": "MPL-2.0",
   "dependencies": {
+    "@hashicorp/react-product-badge": "^0.1.1",
     "classnames": "^2.3.1"
   },
   "peerDependencies": {

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -5,7 +5,6 @@
   "author": "HashiCorp",
   "license": "MPL-2.0",
   "dependencies": {
-    "@hashicorp/react-product-badge": "^0.1.1",
     "classnames": "^2.3.1"
   },
   "peerDependencies": {

--- a/packages/card/props.js
+++ b/packages/card/props.js
@@ -40,6 +40,23 @@ const baseProps = {
     type: 'string',
     required: false,
   },
+  productBadges: {
+    type: 'object',
+    description: `A list of ProductBadges.`,
+    properties: {
+      appearance: {
+        description:
+          'Styles the ProductBadges with either a light or dark theme.',
+        type: 'string',
+        required: false,
+        options: ['light', 'dark'],
+      },
+      badges: {
+        type: 'array',
+        description: `A list of ProductBadges. See props for the ProductBadges component <a href="https://react-components.vercel.app/components/productbadges">here</a>`,
+      },
+    },
+  },
   description: {
     description: "Text describing the card's destination.",
     type: 'string',

--- a/packages/card/style.module.css
+++ b/packages/card/style.module.css
@@ -93,6 +93,12 @@
   color: var(--secondary-text-color);
 }
 
+.productBadges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .cta {
   display: flex;
   align-items: center;

--- a/packages/card/types.ts
+++ b/packages/card/types.ts
@@ -10,7 +10,7 @@ interface BaseCardProps {
 
 interface CardWithChildren extends BaseCardProps {
   meta?: never
-  productBadges?: ProductBadgesProps
+  productBadges?: never
   description?: never
   thumbnail?: never
   children: React.ReactNode
@@ -20,7 +20,7 @@ interface CardWithProps extends BaseCardProps {
   children?: never
   thumbnail?: ThumbnailProps
   meta?: MetaProps['items']
-  productBadges?: any
+  productBadges?: ProductBadgesProps
   description?: DescriptionProps['children']
 }
 
@@ -42,7 +42,7 @@ export interface HeadingProps {
 }
 
 export interface ProductBadgesProps {
-  productBadges: Array<ProductBadgeProps>
+  badges: Array<ProductBadgeProps>
   appearance?: 'light' | 'dark'
 }
 

--- a/packages/card/types.ts
+++ b/packages/card/types.ts
@@ -1,5 +1,5 @@
 import { ImageProps } from 'next/image'
-import type { Products } from '@hashicorp/platform-product-meta'
+import type { ProductBadgeProps } from '@hashicorp/react-product-badge/types'
 import React from 'react'
 
 interface BaseCardProps {
@@ -20,7 +20,7 @@ interface CardWithProps extends BaseCardProps {
   children?: never
   thumbnail?: ThumbnailProps
   meta?: MetaProps['items']
-  productBadges?: Array<Products>
+  productBadges?: Array<ProductBadgeProps['productName']>
   description?: DescriptionProps['children']
 }
 
@@ -42,7 +42,7 @@ export interface HeadingProps {
 }
 
 export interface ProductBadgesProps {
-  badges: Array<Products>
+  badges: Array<ProductBadgeProps['productName']>
   appearance?: 'light' | 'dark'
 }
 

--- a/packages/card/types.ts
+++ b/packages/card/types.ts
@@ -1,4 +1,5 @@
 import { ImageProps } from 'next/image'
+import { ProductBadgeProps } from '@hashicorp/react-product-badge/types'
 import React from 'react'
 
 interface BaseCardProps {
@@ -9,6 +10,7 @@ interface BaseCardProps {
 
 interface CardWithChildren extends BaseCardProps {
   meta?: never
+  productBadges?: ProductBadgesProps
   description?: never
   thumbnail?: never
   children: React.ReactNode
@@ -18,6 +20,7 @@ interface CardWithProps extends BaseCardProps {
   children?: never
   thumbnail?: ThumbnailProps
   meta?: MetaProps['items']
+  productBadges?: any
   description?: DescriptionProps['children']
 }
 
@@ -36,6 +39,11 @@ export interface ContentProps {
 export interface HeadingProps {
   as?: 'h2' | 'h3' | 'h4'
   children: string
+}
+
+export interface ProductBadgesProps {
+  productBadges: Array<ProductBadgeProps>
+  appearance?: 'light' | 'dark'
 }
 
 export interface DescriptionProps {

--- a/packages/card/types.ts
+++ b/packages/card/types.ts
@@ -1,5 +1,5 @@
 import { ImageProps } from 'next/image'
-import { ProductBadgeProps } from '@hashicorp/react-product-badge/types'
+import type { Products } from '@hashicorp/platform-product-meta'
 import React from 'react'
 
 interface BaseCardProps {
@@ -20,7 +20,7 @@ interface CardWithProps extends BaseCardProps {
   children?: never
   thumbnail?: ThumbnailProps
   meta?: MetaProps['items']
-  productBadges?: ProductBadgesProps
+  productBadges?: Array<Products>
   description?: DescriptionProps['children']
 }
 
@@ -42,7 +42,7 @@ export interface HeadingProps {
 }
 
 export interface ProductBadgesProps {
-  badges: Array<ProductBadgeProps>
+  badges: Array<Products>
   appearance?: 'light' | 'dark'
 }
 


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1202802428287999/1203049731246701/f)
🔍 [Preview Link](https://react-components-git-nels-cardadd-product-badg-3c55a7-hashicorp.vercel.app/components/card)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR enables `<ProductBadge />` support to the `<Card />` component. Couple of call-outs:
- The spec for the `Card` component displays the `hasDot` variant of `ProductBadge`. Given that and a preference to be a bit restrictive, we force that variant in the code.
- Similarly, the code does not allow `ProductBadge` to be a composable child.

## Validation Steps
- Navigate to the [preview link](https://react-components-git-nels-cardadd-product-badg-3c55a7-hashicorp.vercel.app/components/card)
- Add the following prop to any of the cards in the Code Editor:
`productBadges={{badges: [{ productName: 'waypoint'}]}}`
- Verify that the Product Badges render properly
- Review the Use Case Cards in the Examples section

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
