### PR TITLE
fix: specifically import React types

### DIFF
--- a/.changeset/popular-gorillas-compare.md
+++ b/.changeset/popular-gorillas-compare.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-head': patch
+---
+
+Specifically import React types

--- a/packages/head/index.tsx
+++ b/packages/head/index.tsx
@@ -1,12 +1,13 @@
 import Head from 'next/head'
 import isAbsoluteUrl from './helpers/is-absolute-url'
 import { renderMetaTags } from './seo'
+import type { ReactNode, ReactElement } from 'react'
 
 export { renderMetaTags }
 
 const IS_DEV = process.env.NODE_ENV !== 'production'
 
-export default function HashiHead(props: HashiHeadProps): React.ReactElement {
+export default function HashiHead(props: HashiHeadProps): ReactElement {
   /**
    * Throw an error if props.image is a relative URL.
    * It must be an absolute URL in order to work as expected as og:image.
@@ -111,7 +112,7 @@ const whenString = (value, returnValue) =>
 
 interface HashiHeadProps {
   canonicalUrl?: string
-  children?: React.ReactNode
+  children?: ReactNode
   description?: string
   icon?: {
     [key: string]: unknown


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR updates `react-head` to specifically import the types from `react` that it needs rather than relying on a global `React` type being present.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
