### PR TITLE
fix(code-block): fix language-undefined in MDX CodeTabs

### DIFF
--- a/.changeset/itchy-flowers-whisper.md
+++ b/.changeset/itchy-flowers-whisper.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-code-block': patch
+---
+
+Fixes issue where code-tabs in MDX would render blocks with a language-undefined className, even if the className was in fact defined.

--- a/package-lock.json
+++ b/package-lock.json
@@ -35335,7 +35335,7 @@
     },
     "packages/actions": {
       "name": "@hashicorp/react-actions",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
@@ -36078,10 +36078,10 @@
     },
     "packages/intro": {
       "name": "@hashicorp/react-intro",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@hashicorp/react-actions": "^0.3.0",
+        "@hashicorp/react-actions": "^0.4.0",
         "classnames": "^2.3.1"
       },
       "peerDependencies": {
@@ -36473,12 +36473,12 @@
     },
     "packages/next-steps": {
       "name": "@hashicorp/react-next-steps",
-      "version": "0.1.1",
+      "version": "0.3.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
-        "@hashicorp/react-actions": "^0.3.0",
-        "@hashicorp/react-intro": "^0.4.0",
+        "@hashicorp/react-actions": "^0.4.0",
+        "@hashicorp/react-intro": "^0.5.0",
         "classnames": "^2.3.1"
       },
       "peerDependencies": {
@@ -40190,7 +40190,7 @@
     "@hashicorp/react-intro": {
       "version": "file:packages/intro",
       "requires": {
-        "@hashicorp/react-actions": "^0.3.0",
+        "@hashicorp/react-actions": "^0.4.0",
         "classnames": "^2.3.1"
       }
     },
@@ -40445,8 +40445,8 @@
       "version": "file:packages/next-steps",
       "requires": {
         "@hashicorp/platform-product-meta": "^0.1.0",
-        "@hashicorp/react-actions": "^0.3.0",
-        "@hashicorp/react-intro": "^0.4.0",
+        "@hashicorp/react-actions": "^0.4.0",
+        "@hashicorp/react-intro": "^0.5.0",
         "classnames": "^2.3.1"
       }
     },

--- a/packages/code-block/partials/code-tabs/index.tsx
+++ b/packages/code-block/partials/code-tabs/index.tsx
@@ -152,10 +152,6 @@ function CodeTabs({
         {validChildren.map((tabChild, idx) => {
           const isActive = idx == activeTabIdx
           const clonedChild = React.cloneElement(tabChild, {
-            // Note: wipes any custom classNames on the tabChild.
-            // This is intentional, for example, it removes
-            // any margin set in MDX custom components
-            className: s.tabChild,
             hasBarAbove: true, // removes margin, and top border rounding, for better UI fit
             theme, // ensures theme of child code blocks in JSX matches tabs theme
           })


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1202097197789424/1203204105610771/f)
🔍 [Preview Link](https://react-components-git-zsfix-code-tabs-language-hashicorp.vercel.app)

---

Fixes a bug where `shell-session` snippets within `CodeTabs` would copy correctly via the `Copy` button, but would still include the `$` character when selected and copied by clicking and dragging.

## Details

Removes a `className` attribute that passed a non-existent className, which also dropped any incoming classNames. This was originally intended to prevent the possibility of custom styling via MDX, but has the side-effect of dropping the `language-<language>` class. That language class was unused for the most part (highlighting happens on the server!), but has become important for full functionality since #736 shipped.

This approach has been proven out in https://github.com/hashicorp/dev-portal/pull/1268. Screenshots below are from that PR, demonstrating that with this fix, we go from the issue-causing `language-undefined` to `language-shell-session`.

### Before

![before](https://user-images.githubusercontent.com/4624598/196829407-0f5273f9-0f4a-4f01-b869-6928ada50451.png)

### After

![after](https://user-images.githubusercontent.com/4624598/196829399-0405f7fe-4618-4c81-a5f4-bc0a150433d6.png)


### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
