### PR TITLE
feat(consent manager): Add function to check if preferences are loaded

### DIFF
--- a/packages/consent-manager/util/cookies.js
+++ b/packages/consent-manager/util/cookies.js
@@ -50,3 +50,12 @@ export function savePreferences(prefs, version) {
     domain,
   })
 }
+
+export function preferencesSavedAndLoaded() {
+  const preferences = loadPreferences()
+  if (preferences && preferences.length > 0) {
+    return true
+  }
+
+  return false
+}

--- a/packages/consent-manager/util/cookies.js
+++ b/packages/consent-manager/util/cookies.js
@@ -43,12 +43,13 @@ export function getDomain() {
 
 export function loadPreferences() {
   const cookiesJSON = cookies.getJSON(COOKIE_KEY)
-  if (
-    cookiesJSON &&
-    Object.keys(
-      typeof cookiesJSON === 'string' ? JSON.parse(cookiesJSON) : cookiesJSON
-    ).length > 0
-  ) {
+  if (cookiesJSON) {
+    // if (
+    //   cookiesJSON &&
+    //   Object.keys(
+    //     typeof cookiesJSON === 'string' ? JSON.parse(cookiesJSON) : cookiesJSON
+    //   ).length > 0
+    // ) {
     preferencesLoaded = true
   } else if (preferencesLoaded) {
     preferencesLoaded = false

--- a/packages/consent-manager/util/cookies.js
+++ b/packages/consent-manager/util/cookies.js
@@ -11,7 +11,7 @@ import cookies from 'js-cookie'
 export const COOKIE_KEY = 'hashi-consent-preferences'
 export const COOKIE_EXPIRES = 183
 
-var preferencesLoaded
+var preferencesLoaded = false
 
 export function getDomain() {
   const host = window.location.hostname
@@ -45,8 +45,6 @@ export function loadPreferences() {
   const cookiesJSON = cookies.getJSON(COOKIE_KEY)
   if (cookiesJSON) {
     preferencesLoaded = true
-  } else if (preferencesLoaded) {
-    preferencesLoaded = false
   }
 
   return cookiesJSON
@@ -61,4 +59,4 @@ export function savePreferences(prefs, version) {
   preferencesLoaded = true
 }
 
-export const preferencesSavedAndLoaded = () => !!preferencesLoaded
+export const preferencesSavedAndLoaded = () => preferencesLoaded

--- a/packages/consent-manager/util/cookies.js
+++ b/packages/consent-manager/util/cookies.js
@@ -42,14 +42,19 @@ export function getDomain() {
 }
 
 export function loadPreferences() {
-  const cookiesObj = cookies.getJSON(COOKIE_KEY)
-  if (cookiesObj && Object.keys(JSON.parse(cookiesObj)).length > 0) {
+  const cookiesJSON = cookies.getJSON(COOKIE_KEY)
+  if (
+    cookiesJSON &&
+    Object.keys(
+      typeof cookiesJSON === 'string' ? JSON.parse(cookiesJSON) : cookiesJSON
+    ).length > 0
+  ) {
     preferencesLoaded = true
   } else if (preferencesLoaded) {
     preferencesLoaded = false
   }
 
-  return cookiesObj
+  return cookiesJSON
 }
 
 export function savePreferences(prefs, version) {

--- a/packages/consent-manager/util/cookies.js
+++ b/packages/consent-manager/util/cookies.js
@@ -53,10 +53,12 @@ export const loadPreferences = () => {
 
 export function savePreferences(prefs, version) {
   const domain = getDomain()
-  cookies.set(COOKIE_KEY, Object.assign(prefs, { version: version }), {
+  const prefsWithVersion = Object.assign(prefs, { version: version })
+  cookies.set(COOKIE_KEY, prefsWithVersion, {
     expires: COOKIE_EXPIRES,
     domain,
   })
+  preferences = prefsWithVersion
   preferencesLoaded = true
 }
 

--- a/packages/consent-manager/util/cookies.js
+++ b/packages/consent-manager/util/cookies.js
@@ -43,9 +43,12 @@ export function getDomain() {
 
 export function loadPreferences() {
   const cookiesObj = cookies.getJSON(COOKIE_KEY)
-  if (cookiesObj && Object.keys(cookiesObj).length > 0) {
+  if (cookiesObj && Object.keys(JSON.parse(cookiesObj)).length > 0) {
     preferencesLoaded = true
+  } else if (preferencesLoaded) {
+    preferencesLoaded = false
   }
+
   return cookiesObj
 }
 

--- a/packages/consent-manager/util/cookies.js
+++ b/packages/consent-manager/util/cookies.js
@@ -44,12 +44,6 @@ export function getDomain() {
 export function loadPreferences() {
   const cookiesJSON = cookies.getJSON(COOKIE_KEY)
   if (cookiesJSON) {
-    // if (
-    //   cookiesJSON &&
-    //   Object.keys(
-    //     typeof cookiesJSON === 'string' ? JSON.parse(cookiesJSON) : cookiesJSON
-    //   ).length > 0
-    // ) {
     preferencesLoaded = true
   } else if (preferencesLoaded) {
     preferencesLoaded = false
@@ -64,6 +58,7 @@ export function savePreferences(prefs, version) {
     expires: COOKIE_EXPIRES,
     domain,
   })
+  preferencesLoaded = true
 }
 
 export const preferencesSavedAndLoaded = () => !!preferencesLoaded

--- a/packages/consent-manager/util/cookies.js
+++ b/packages/consent-manager/util/cookies.js
@@ -11,6 +11,8 @@ import cookies from 'js-cookie'
 export const COOKIE_KEY = 'hashi-consent-preferences'
 export const COOKIE_EXPIRES = 183
 
+var preferencesLoaded
+
 export function getDomain() {
   const host = window.location.hostname
   const parts = host.split('.')
@@ -40,7 +42,11 @@ export function getDomain() {
 }
 
 export function loadPreferences() {
-  return cookies.getJSON(COOKIE_KEY)
+  const cookiesObj = cookies.getJSON(COOKIE_KEY)
+  if (cookiesObj && Object.keys(cookiesObj).length > 0) {
+    preferencesLoaded = true
+  }
+  return cookiesObj
 }
 
 export function savePreferences(prefs, version) {
@@ -51,11 +57,4 @@ export function savePreferences(prefs, version) {
   })
 }
 
-export function preferencesSavedAndLoaded() {
-  const preferences = loadPreferences()
-  if (preferences && preferences.length > 0) {
-    return true
-  }
-
-  return false
-}
+export const preferencesSavedAndLoaded = () => !!preferencesLoaded

--- a/packages/consent-manager/util/cookies.js
+++ b/packages/consent-manager/util/cookies.js
@@ -11,7 +11,8 @@ import cookies from 'js-cookie'
 export const COOKIE_KEY = 'hashi-consent-preferences'
 export const COOKIE_EXPIRES = 183
 
-var preferencesLoaded = false
+let preferences = undefined
+let preferencesLoaded = false
 
 export function getDomain() {
   const host = window.location.hostname
@@ -41,13 +42,13 @@ export function getDomain() {
   return result
 }
 
-export function loadPreferences() {
-  const cookiesJSON = cookies.getJSON(COOKIE_KEY)
-  if (cookiesJSON) {
+export const loadPreferences = () => {
+  if (!preferences) {
+    preferences = cookies.getJSON(COOKIE_KEY)
     preferencesLoaded = true
   }
 
-  return cookiesJSON
+  return preferences
 }
 
 export function savePreferences(prefs, version) {

--- a/packages/consent-manager/util/cookies.test.js
+++ b/packages/consent-manager/util/cookies.test.js
@@ -56,7 +56,7 @@ it('should save preferences', () => {
   cookies.set = originalCookiesSet
 })
 
-it('should return false if cookies are not loaded', () => {
+it('should not show preferences loaded if cookies are not loaded', () => {
   const originalCookiesGetJSON = cookies.getJSON
   cookiesJS.loadPreferences()
 
@@ -66,7 +66,7 @@ it('should return false if cookies are not loaded', () => {
   cookies.set = originalCookiesGetJSON
 })
 
-it('should return true if cookies are loaded', () => {
+it('should show preferences loaded if cookies are loaded', () => {
   const preferences = JSON.stringify({ loadAll: true, version: 1 })
   const originalCookiesGetJSON = cookies.getJSON
 

--- a/packages/consent-manager/util/cookies.test.js
+++ b/packages/consent-manager/util/cookies.test.js
@@ -55,3 +55,19 @@ it('should save preferences', () => {
 
   cookies.set = originalCookiesSet
 })
+
+it('should return false if cookies are not loaded', () => {
+  expect(cookiesJS.preferencesSavedAndLoaded()).toBe(false)
+})
+
+it('should return true if cookies are loaded', () => {
+  const preferences = JSON.stringify({ loadAll: true, version: 1 })
+  const originalCookiesGetJSON = cookies.getJSON
+
+  // mocks
+  cookies.getJSON = jest.fn().mockImplementationOnce(() => preferences)
+  expect(cookiesJS.preferencesSavedAndLoaded()).toBe(true)
+
+  // restore mocks
+  cookies.getJSON = originalCookiesGetJSON
+})

--- a/packages/consent-manager/util/cookies.test.js
+++ b/packages/consent-manager/util/cookies.test.js
@@ -57,11 +57,7 @@ it('should save preferences', () => {
 })
 
 it('should return false if cookies are not loaded', () => {
-  const preferences = JSON.stringify({})
   const originalCookiesGetJSON = cookies.getJSON
-
-  // mocks
-  cookies.getJSON = jest.fn().mockImplementationOnce(() => preferences)
   cookiesJS.loadPreferences()
 
   const preferencesLoaded = cookiesJS.preferencesSavedAndLoaded()

--- a/packages/consent-manager/util/cookies.test.js
+++ b/packages/consent-manager/util/cookies.test.js
@@ -57,7 +57,17 @@ it('should save preferences', () => {
 })
 
 it('should return false if cookies are not loaded', () => {
-  expect(cookiesJS.preferencesSavedAndLoaded()).toBe(false)
+  const preferences = JSON.stringify({})
+  const originalCookiesGetJSON = cookies.getJSON
+
+  // mocks
+  cookies.getJSON = jest.fn().mockImplementationOnce(() => preferences)
+  cookiesJS.loadPreferences()
+
+  const preferencesLoaded = cookiesJS.preferencesSavedAndLoaded()
+  expect(preferencesLoaded).toBe(false)
+
+  cookies.set = originalCookiesGetJSON
 })
 
 it('should return true if cookies are loaded', () => {
@@ -66,8 +76,10 @@ it('should return true if cookies are loaded', () => {
 
   // mocks
   cookies.getJSON = jest.fn().mockImplementationOnce(() => preferences)
-  expect(cookiesJS.preferencesSavedAndLoaded()).toBe(true)
+  cookiesJS.loadPreferences()
 
-  // restore mocks
-  cookies.getJSON = originalCookiesGetJSON
+  const preferencesLoaded = cookiesJS.preferencesSavedAndLoaded()
+  expect(preferencesLoaded).toBe(true)
+
+  cookies.set = originalCookiesGetJSON
 })

--- a/packages/consent-manager/util/cookies.test.js
+++ b/packages/consent-manager/util/cookies.test.js
@@ -1,6 +1,24 @@
 import cookies from 'js-cookie'
 import * as cookiesJS from './cookies.js'
 
+it('should not show preferences loaded before cookies are saved', () => {
+  expect(cookiesJS.preferencesSavedAndLoaded()).toBe(false)
+})
+
+it('should show preferences loaded if cookies are loaded', () => {
+  const preferences = JSON.stringify({ loadAll: true, version: 1 })
+  const originalCookiesGetJSON = cookies.getJSON
+
+  // mocks
+  cookies.getJSON = jest.fn().mockImplementationOnce(() => preferences)
+  cookiesJS.loadPreferences()
+
+  const preferencesLoaded = cookiesJS.preferencesSavedAndLoaded()
+  expect(preferencesLoaded).toBe(true)
+
+  cookies.set = originalCookiesGetJSON
+})
+
 it('should get the domain', () => {
   const originalLocation = global.window.location
   const originalCookiesGet = cookies.get
@@ -54,28 +72,4 @@ it('should save preferences', () => {
   expect(JSON.stringify(lastArgs)).toBe(JSON.stringify(args))
 
   cookies.set = originalCookiesSet
-})
-
-it('should not show preferences loaded if cookies are not loaded', () => {
-  const originalCookiesGetJSON = cookies.getJSON
-  cookiesJS.loadPreferences()
-
-  const preferencesLoaded = cookiesJS.preferencesSavedAndLoaded()
-  expect(preferencesLoaded).toBe(false)
-
-  cookies.set = originalCookiesGetJSON
-})
-
-it('should show preferences loaded if cookies are loaded', () => {
-  const preferences = JSON.stringify({ loadAll: true, version: 1 })
-  const originalCookiesGetJSON = cookies.getJSON
-
-  // mocks
-  cookies.getJSON = jest.fn().mockImplementationOnce(() => preferences)
-  cookiesJS.loadPreferences()
-
-  const preferencesLoaded = cookiesJS.preferencesSavedAndLoaded()
-  expect(preferencesLoaded).toBe(true)
-
-  cookies.set = originalCookiesGetJSON
 })


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1202097197789424/1203274026595792/f)
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Exports a const that lets us know if preferences have been loaded by reading a global variable set within `loadPreferences()`. The motivation here is to use this in order to prevent re-runs of `saveAndLoadAnalytics()` in our web properties. See [this draft PR for example](https://github.com/hashicorp/dev-portal/pull/1317/files#diff-b359798aa474d6e3d6c2a75fe11ed4d0bb12fed48592453f433524ed0be5ab5dR52). In this example, we want to run `saveAndLoadAnalytics()` only after sign in. So here we'd replace `if (!loadPreferences())` to `if (!preferencesSavedAndLoaded())`. It is essentially the same check but it provides the data without having to re-read the cookie, optimizing performance.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
