### PR TITLE
feat(Intro): allow ReactNodes within description

### DIFF
--- a/.changeset/ninety-dingos-guess.md
+++ b/.changeset/ninety-dingos-guess.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-intro': minor
+---
+
+Add ReactNode support to description

--- a/packages/intro/index.tsx
+++ b/packages/intro/index.tsx
@@ -3,8 +3,6 @@ import type { IntroProps } from './types'
 import Actions from '@hashicorp/react-actions'
 import s from './style.module.css'
 
-const containsHTML = (str: string) => /<[a-z][\s\S]*>/i.test(str)
-
 export default function Intro({
   appearance = 'light',
   textAlignment = 'left',
@@ -22,23 +20,6 @@ export default function Intro({
     s.description,
     descriptionSizeClassname
   )
-  let descriptionMarkup
-  if (typeof description === 'object') {
-    descriptionMarkup = (
-      <div className={descriptionClassName}>{description}</div>
-    )
-  } else if (typeof description === 'string' && containsHTML(description)) {
-    descriptionMarkup = (
-      <div
-        dangerouslySetInnerHTML={{
-          __html: description,
-        }}
-        className={descriptionClassName}
-      />
-    )
-  } else {
-    descriptionMarkup = <p className={descriptionClassName}>{description}</p>
-  }
   return (
     <div
       className={classNames(s.intro, s[appearance], s[textAlignment])}
@@ -48,7 +29,7 @@ export default function Intro({
       <HeadingElement className={classNames(s.heading, headingSizeClassname)}>
         {heading}
       </HeadingElement>
-      {descriptionMarkup}
+      <Description className={descriptionClassName}>{description}</Description>
       {actions && actions.ctas && actions.ctas.length > 0 ? (
         <div className={s.actions}>
           <Actions
@@ -62,4 +43,34 @@ export default function Intro({
       ) : null}
     </div>
   )
+}
+
+const containsHTML = (str: string) => /<[a-z][\s\S]*>/i.test(str)
+
+function Description({
+  className,
+  children,
+}: {
+  className: string
+  children: IntroProps['description']
+}) {
+  // ReactNode
+  if (typeof children === 'object') {
+    return <div className={className}>{children}</div>
+  }
+
+  // HTML String
+  if (typeof children === 'string' && containsHTML(children)) {
+    return (
+      <div
+        dangerouslySetInnerHTML={{
+          __html: children,
+        }}
+        className={className}
+      />
+    )
+  }
+
+  // String
+  return <p className={className}>{children}</p>
 }

--- a/packages/intro/index.tsx
+++ b/packages/intro/index.tsx
@@ -22,6 +22,23 @@ export default function Intro({
     s.description,
     descriptionSizeClassname
   )
+  let descriptionMarkup
+  if (typeof description === 'object') {
+    descriptionMarkup = (
+      <div className={descriptionClassName}>{description}</div>
+    )
+  } else if (typeof description === 'string' && containsHTML(description)) {
+    descriptionMarkup = (
+      <div
+        dangerouslySetInnerHTML={{
+          __html: description,
+        }}
+        className={descriptionClassName}
+      />
+    )
+  } else {
+    descriptionMarkup = <p className={descriptionClassName}>{description}</p>
+  }
   return (
     <div
       className={classNames(s.intro, s[appearance], s[textAlignment])}
@@ -31,16 +48,7 @@ export default function Intro({
       <HeadingElement className={classNames(s.heading, headingSizeClassname)}>
         {heading}
       </HeadingElement>
-      {containsHTML(description) ? (
-        <div
-          dangerouslySetInnerHTML={{
-            __html: description,
-          }}
-          className={descriptionClassName}
-        />
-      ) : (
-        <p className={descriptionClassName}>{description}</p>
-      )}
+      {descriptionMarkup}
       {actions && actions.ctas && actions.ctas.length > 0 ? (
         <div className={s.actions}>
           <Actions

--- a/packages/intro/props.js
+++ b/packages/intro/props.js
@@ -30,7 +30,7 @@ module.exports = {
   },
   description: {
     required: true,
-    type: 'string',
+    type: 'string|React.ReactNode',
     description: 'Text following the heading element.',
   },
   actions: {

--- a/packages/intro/types.ts
+++ b/packages/intro/types.ts
@@ -1,4 +1,5 @@
 import type { ActionsProps } from '@hashicorp/react-actions/types'
+import React from 'react'
 
 type WithOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 
@@ -30,7 +31,7 @@ export interface IntroProps {
   /**
    * Text following the heading element.
    */
-  description: string
+  description: string | React.ReactNode
   /**
    * Render CTAs following the description element.
    */


### PR DESCRIPTION
🔍 [Preview Link](https://react-components-git-acintro-description-type-hashicorp.vercel.app/components/intro)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Allows ReactNodes to be rendered within the description.

### Use case

On some recent work for the brand landing page, we made use of structured text field, which required the type update.

```tsx
<Intro
  appearance="dark"
  heading={whitepaper.heading}
  description={
    <StructuredText data={whitepaper.description.value} />
  }
  actions={{
    ctas: [
      {
        title: whitepaper.cta.text,
        href: whitepaper.cta.url,
      },
    ],
  }}
/>
```

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
