### PR TITLE
Add data attribute to `FieldWrapper` to enable field-level styling

### DIFF
--- a/.changeset/three-pots-kneel.md
+++ b/.changeset/three-pots-kneel.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-marketo-form': minor
+---
+
+Surface field ID on the FieldWrapper component

--- a/packages/marketo-form/form/index.tsx
+++ b/packages/marketo-form/form/index.tsx
@@ -13,7 +13,6 @@ import type {
   MarketoFormGroups,
   MarketoFormComponents,
 } from '../types'
-import { Theme } from 'packages/button/types'
 
 interface Props {
   /**
@@ -79,12 +78,6 @@ interface Props {
     values: Record<string, string | boolean>,
     errors: Record<string, { message: string }>
   ) => Promise<{ values: any; errors: Record<string, { message: string }> }>
-
-  /**
-   * Theming options for the Submit button.
-   * See {@link Theme} for more details.
-   */
-  theme?: Theme
 }
 
 const defaultFieldGroupings = {
@@ -113,7 +106,6 @@ const Form = ({
   onSubmitSuccess,
   onSubmitError,
   validateFields,
-  theme,
 }: Props) => {
   // Track if the form has been rendered at least once, so that we know if
   // react-hook-form has already cached values.
@@ -277,7 +269,6 @@ const Form = ({
               ? 'Submitting...'
               : submitTitle ?? 'Submit'
           }
-          theme={theme}
         />
       </form>
     </FormProvider>

--- a/packages/marketo-form/form/index.tsx
+++ b/packages/marketo-form/form/index.tsx
@@ -13,6 +13,7 @@ import type {
   MarketoFormGroups,
   MarketoFormComponents,
 } from '../types'
+import { Theme } from 'packages/button/types'
 
 interface Props {
   /**
@@ -78,6 +79,12 @@ interface Props {
     values: Record<string, string | boolean>,
     errors: Record<string, { message: string }>
   ) => Promise<{ values: any; errors: Record<string, { message: string }> }>
+
+  /**
+   * Theming options for the Submit button.
+   * See {@link Theme} for more details.
+   */
+  theme?: Theme
 }
 
 const defaultFieldGroupings = {
@@ -106,6 +113,7 @@ const Form = ({
   onSubmitSuccess,
   onSubmitError,
   validateFields,
+  theme,
 }: Props) => {
   // Track if the form has been rendered at least once, so that we know if
   // react-hook-form has already cached values.
@@ -269,6 +277,7 @@ const Form = ({
               ? 'Submitting...'
               : submitTitle ?? 'Submit'
           }
+          theme={theme}
         />
       </form>
     </FormProvider>

--- a/packages/marketo-form/partials/field-wrapper/index.tsx
+++ b/packages/marketo-form/partials/field-wrapper/index.tsx
@@ -5,15 +5,18 @@ import styles from './style.module.css'
 const FieldWrapper = ({
   size,
   children,
+  fieldId,
 }: {
   size?: 'lg'
   children: ReactNode
+  fieldId: string
 }) => {
   return (
     <div
       className={clsx('marketo-form-field-wrapper', styles.wrapper, {
         [styles.sizeLg]: size === 'lg',
       })}
+      data-field-id={fieldId}
     >
       {children}
     </div>

--- a/packages/marketo-form/partials/fields/checkbox-field/index.tsx
+++ b/packages/marketo-form/partials/fields/checkbox-field/index.tsx
@@ -10,7 +10,7 @@ const CheckboxField = ({ field }: { field: MarketoFormCheckboxField }) => {
   const checked = watch(field.id, false)
 
   return (
-    <FieldWrapper size="lg">
+    <FieldWrapper size="lg" fieldId={field.id}>
       <CheckboxInput
         label={formattedLabel(field)}
         field={{

--- a/packages/marketo-form/partials/fields/country-field/index.tsx
+++ b/packages/marketo-form/partials/fields/country-field/index.tsx
@@ -31,7 +31,7 @@ export default function CountryField({ field }: CountryFieldProps) {
   }
 
   return (
-    <FieldWrapper>
+    <FieldWrapper fieldId={field.id}>
       <Label fieldName={field.id} label={formattedLabel(field)} />
       <Combobox
         invalidInputValue={showError}

--- a/packages/marketo-form/partials/fields/email-field/index.tsx
+++ b/packages/marketo-form/partials/fields/email-field/index.tsx
@@ -9,7 +9,7 @@ const EmailField = ({ field }: { field: MarketoFormEmailField }) => {
   const { errors, touchedFields } = useFormState()
 
   return (
-    <FieldWrapper>
+    <FieldWrapper fieldId={field.id}>
       <TextInput
         label={formattedLabel(field)}
         field={{

--- a/packages/marketo-form/partials/fields/privacy-policy-field/index.tsx
+++ b/packages/marketo-form/partials/fields/privacy-policy-field/index.tsx
@@ -9,7 +9,7 @@ const PrivacyPolicyField = ({ field }: { field: MarketoFormCheckboxField }) => {
   const checked = watch(field.id, false)
 
   return (
-    <FieldWrapper size="lg">
+    <FieldWrapper size="lg" fieldId={field.id}>
       <CheckboxInput
         label={`I agree to HashiCorp’s
                    <a

--- a/packages/marketo-form/partials/fields/select-field/index.tsx
+++ b/packages/marketo-form/partials/fields/select-field/index.tsx
@@ -8,7 +8,7 @@ const SelectField = ({ field }: { field: MarketoFormSelectField }) => {
   const { register, setValue } = useFormContext()
 
   return (
-    <FieldWrapper>
+    <FieldWrapper fieldId={field.id}>
       <SelectInput
         {...register(field.id)}
         label={formattedLabel(field)}

--- a/packages/marketo-form/partials/fields/telephone-field/index.tsx
+++ b/packages/marketo-form/partials/fields/telephone-field/index.tsx
@@ -9,7 +9,7 @@ const TelephoneField = ({ field }: { field: MarketoFormTelephoneField }) => {
   const { errors, touchedFields } = useFormState()
 
   return (
-    <FieldWrapper>
+    <FieldWrapper fieldId={field.id}>
       <TextInput
         label={formattedLabel(field)}
         field={register(field.id)}

--- a/packages/marketo-form/partials/fields/text-field/index.tsx
+++ b/packages/marketo-form/partials/fields/text-field/index.tsx
@@ -9,7 +9,7 @@ const Index = ({ field }: { field: MarketoFormTextField }) => {
   const { errors, touchedFields } = useFormState()
 
   return (
-    <FieldWrapper>
+    <FieldWrapper fieldId={field.id}>
       <TextInput
         label={formattedLabel(field)}
         field={register(field.id)}

--- a/packages/marketo-form/partials/fields/textarea-field/index.tsx
+++ b/packages/marketo-form/partials/fields/textarea-field/index.tsx
@@ -12,7 +12,7 @@ const Index = ({ field }: { field: MarketoFormTextAreaField }) => {
   const { errors, touchedFields } = useFormState<Record<string, unknown>>()
 
   return (
-    <FieldWrapper>
+    <FieldWrapper fieldId={field.id}>
       <TextareaInput
         label={formattedLabel(field)}
         field={register(field.id)}


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description
This PR surfaces a field's ID in the `FieldWrapper` component in the form of a data attribute. There are cases where we need control of the order of the form's fields. Creating a data attribute for the field's ID gives us specific, readable selectors to use in CSS (versus general, DOM element selectors).

## Validation Steps
- Navigate to the [MarketoForm in the Preview](https://react-components-git-nels-marketo-formextend-t-fe5bc2-hashicorp.vercel.app/components/marketoform)
- Pick a field in the form and inspect the top-level `div`
- Verify that there is a `data-field-id` attribute with a value of a field ID.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
