### PR TITLE
fix(consent-manager): check preferences before setting global var

### DIFF
--- a/.changeset/proud-walls-flow.md
+++ b/.changeset/proud-walls-flow.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/react-consent-manager": patch
+---
+
+fix: check preferences before setting global var

--- a/packages/consent-manager/util/cookies.js
+++ b/packages/consent-manager/util/cookies.js
@@ -45,7 +45,9 @@ export function getDomain() {
 export const loadPreferences = () => {
   if (!preferences) {
     preferences = cookies.getJSON(COOKIE_KEY)
-    preferencesLoaded = true
+    if (preferences) {
+      preferencesLoaded = true
+    }
   }
 
   return preferences


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Add a check before setting `preferencesLoaded` global variable. We were previously setting `preferencesLoaded` to true before the cookies were actually set. This affected our check following dev portal sign ins

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
