### PR TITLE
fix(code-block): only render HiddenCopyContent after hydration

### DIFF
--- a/.changeset/eighty-elephants-switch.md
+++ b/.changeset/eighty-elephants-switch.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-code-block': patch
+---
+
+Only render HiddenCopyContent on the client to avoid hydration mismatches and duplicative markup

--- a/packages/code-block/partials/hidden-copy-content/index.js
+++ b/packages/code-block/partials/hidden-copy-content/index.js
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react'
+import { forwardRef, useEffect, useState } from 'react'
 
 /**
  * This hidden element acts solely as a container
@@ -8,6 +8,19 @@ import { forwardRef } from 'react'
  * line numbers and so on in other parts of code-block.
  */
 function HiddenCopyContent({ code }, copyRef) {
+  const [isClient, setIsClient] = useState(false)
+
+  useEffect(() => {
+    setIsClient(true)
+  }, [])
+
+  /**
+   * We are avoiding SSR here as this component is only used for the copy-to-clipboard interaction, and so rendering
+   * the text content of the code introduces duplicate markup and some difficult-to-debug hydration mismatches.
+   * By the time someone interacts with the copy-to-clipboard functionality, this should be rendered.
+   */
+  if (!isClient) return null
+
   return (
     <pre ref={copyRef} style={{ display: 'none' }}>
       {typeof code === 'string' ? (


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Adjust `HiddenCopyContent` to only render after hydration as occurred. This helps avoid some tricky hydration issues, and also avoids duplicative markup being shipped from the server. As the element is only used by the copy-to-clipboard interaction, it's safe to defer rendering.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
