### PR TITLE
Render `react-player` only if the `window` exists

### DIFF
--- a/.changeset/red-jokes-allow.md
+++ b/.changeset/red-jokes-allow.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-inline-video': minor
+---
+
+Add lazy loading to prevent hydration errors

--- a/packages/inline-video/index.tsx
+++ b/packages/inline-video/index.tsx
@@ -1,8 +1,8 @@
 import classNames from 'classnames'
 import WistiaPlayer from 'react-player/wistia'
+import Player from 'react-player'
 import type { InlineVideoProps } from './types'
 import s from './style.module.css'
-import dynamic from 'next/dynamic'
 
 export default function InlineVideo(props: InlineVideoProps) {
   const {
@@ -13,7 +13,6 @@ export default function InlineVideo(props: InlineVideoProps) {
     solution,
   } = props
 
-  const ReactPlayer = dynamic(() => import('react-player/lazy'), { ssr: false })
   const playerProps = {
     controls: true,
     url,
@@ -42,7 +41,7 @@ export default function InlineVideo(props: InlineVideoProps) {
               }}
             />
           ) : (
-            <ReactPlayer {...playerProps} />
+            <Player {...playerProps} />
           )}
         </div>
       </div>

--- a/packages/inline-video/index.tsx
+++ b/packages/inline-video/index.tsx
@@ -1,8 +1,8 @@
 import classNames from 'classnames'
 import WistiaPlayer from 'react-player/wistia'
-import Player from 'react-player'
 import type { InlineVideoProps } from './types'
 import s from './style.module.css'
+import dynamic from 'next/dynamic'
 
 export default function InlineVideo(props: InlineVideoProps) {
   const {
@@ -13,6 +13,7 @@ export default function InlineVideo(props: InlineVideoProps) {
     solution,
   } = props
 
+  const ReactPlayer = dynamic(() => import('react-player/lazy'), { ssr: false })
   const playerProps = {
     controls: true,
     url,
@@ -41,7 +42,7 @@ export default function InlineVideo(props: InlineVideoProps) {
               }}
             />
           ) : (
-            <Player {...playerProps} />
+            <ReactPlayer {...playerProps} />
           )}
         </div>
       </div>

--- a/packages/inline-video/index.tsx
+++ b/packages/inline-video/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import classNames from 'classnames'
 import WistiaPlayer from 'react-player/wistia'
 import Player from 'react-player'
@@ -20,6 +21,14 @@ export default function InlineVideo(props: InlineVideoProps) {
     height: '100%',
   }
 
+  const [hasWindow, setHasWindow] = useState(false)
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setHasWindow(true)
+    }
+  }, [])
+
   return (
     <div
       className={classNames(
@@ -31,18 +40,22 @@ export default function InlineVideo(props: InlineVideoProps) {
     >
       <div className={classNames(s.videoContainer, solution && s[solution])}>
         <div className={s.video}>
-          {url.includes('wistia') ? (
-            <WistiaPlayer
-              {...playerProps}
-              config={{
-                options: {
-                  controlsVisibleOnLoad: false,
-                },
-              }}
-            />
-          ) : (
-            <Player {...playerProps} />
-          )}
+          {hasWindow ? (
+            <>
+              {url.includes('wistia') ? (
+                <WistiaPlayer
+                  {...playerProps}
+                  config={{
+                    options: {
+                      controlsVisibleOnLoad: false,
+                    },
+                  }}
+                />
+              ) : (
+                <Player {...playerProps} />
+              )}
+            </>
+          ) : null}
         </div>
       </div>
 


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Unless `react-player` is loaded on the client-side using dynamic/no-ssr or `useEffect`, React will panic with a hydration error (see [this issue](https://github.com/cookpete/react-player/issues/1474)). 

This PR updates the `InlineVideo` component to conditionally render the player if the `window` not `undefined`.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
