### PR TITLE
fix(Intro): actions centering

### DIFF
--- a/.changeset/beige-zebras-think.md
+++ b/.changeset/beige-zebras-think.md
@@ -1,0 +1,6 @@
+---
+'@hashicorp/react-actions': patch
+'@hashicorp/react-intro': patch
+---
+
+add actions alignment option

--- a/packages/actions/index.tsx
+++ b/packages/actions/index.tsx
@@ -10,6 +10,7 @@ const hasStandaloneLink = (item) => item.type === 'standalone-link'
 export default function Actions({
   appearance = 'light',
   layout = 'inline',
+  alignment = 'left',
   theme = 'hashicorp',
   size = 'medium',
   ctas,
@@ -27,7 +28,12 @@ export default function Actions({
   }
   return (
     <div
-      className={classNames(s.actions, s[layout], mixed && s.mixed)}
+      className={classNames(
+        s.actions,
+        s[layout],
+        s[alignment],
+        mixed && s.mixed
+      )}
       data-testid="actions"
     >
       {ctas.map((cta, index) => {

--- a/packages/actions/props.js
+++ b/packages/actions/props.js
@@ -9,6 +9,11 @@ module.exports = {
     description: 'Display buttons inline or stacked by default.',
     options: ['inline', 'stacked'],
   },
+  alignment: {
+    type: 'string',
+    description: 'Align items when stacked.',
+    options: ['left', 'center'],
+  },
   theme: {
     type: 'string',
     description: 'Render primary variant button CTA with product color.',

--- a/packages/actions/style.module.css
+++ b/packages/actions/style.module.css
@@ -6,18 +6,17 @@
 
   &.stacked {
     flex-direction: column;
-  }
 
-  &.left {
-    align-items: flex-start;
-  }
+    &.left {
+      align-items: flex-start;
+    }
 
-  &.center {
-    align-items: center;
+    &.center {
+      align-items: center;
+    }
   }
 
   &.mixed {
     column-gap: 24px;
-    row-gap: 32px;
   }
 }

--- a/packages/actions/style.module.css
+++ b/packages/actions/style.module.css
@@ -18,5 +18,6 @@
 
   &.mixed {
     column-gap: 24px;
+    row-gap: 32px;
   }
 }

--- a/packages/actions/style.module.css
+++ b/packages/actions/style.module.css
@@ -5,11 +5,19 @@
   gap: 16px 18px;
 
   &.stacked {
-    align-items: flex-start;
     flex-direction: column;
+  }
+
+  &.left {
+    align-items: flex-start;
+  }
+
+  &.center {
+    align-items: center;
   }
 
   &.mixed {
     column-gap: 24px;
+    row-gap: 32px;
   }
 }

--- a/packages/actions/types.ts
+++ b/packages/actions/types.ts
@@ -33,6 +33,10 @@ export interface ActionsProps {
    */
   layout?: 'inline' | 'stacked'
   /**
+   * Display buttons inline or stacked by default.
+   */
+  alignment?: 'left' | 'center'
+  /**
    * Render primary button with product color.
    */
   theme?: Products

--- a/packages/intro/index.tsx
+++ b/packages/intro/index.tsx
@@ -35,6 +35,7 @@ export default function Intro({
           <Actions
             appearance={appearance}
             layout={actions.layout}
+            alignment={textAlignment}
             theme={actions.theme}
             size={actions.size}
             ctas={actions.ctas}

--- a/packages/intro/props.js
+++ b/packages/intro/props.js
@@ -41,7 +41,7 @@ module.exports = {
         description: 'Display buttons inline or stacked by default.',
         options: ['inline', 'stacked'],
       },
-      brand: {
+      theme: {
         type: 'string',
         description: 'Render primary variant button with product color.',
         options: [


### PR DESCRIPTION
🔍 [Preview Link](https://react-components-git-acintro-centering-hashicorp.vercel.app/components/actions?id=MTk3MjQ5MjI3Mw&values=IjxBY3Rpb25zXG4gIGxheW91dD1cInN0YWNrZWRcIlxuICBhbGlnbm1lbnQ9XCJjZW50ZXJcIlxuICBjdGFzPXtbXG4gICAge1xuICAgICAgdGl0bGU6ICdWaWV3IHR1dG9yaWFscycsXG4gICAgICBocmVmOiAnL3R1dG9yaWFscycsXG4gICAgfSxcbiAgICB7XG4gICAgICB0aXRsZTogJ1ZpZXcgZG9jdW1lbnRhdGlvbicsXG4gICAgICBocmVmOiAnL2RvY3MnLFxuICAgIH1cbiAgXX1cbi8%2BIg%3D%3D)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Stacked CTAs within intro were always left aligned. This PR enables centering actions when Intro is using `textAlignment="center"` and ctas stacked.

**Before:**

![CleanShot 2023-01-06 at 12 50 31@2x](https://user-images.githubusercontent.com/825855/211069863-cdc1454e-e06a-4747-b22a-ca203e73e141.png)

**After:**

![CleanShot 2023-01-06 at 12 52 34@2x](https://user-images.githubusercontent.com/825855/211070009-d6975c55-875f-43ec-8027-046b5b91ccc8.png)

Needed for building out CRO io home hero alt component: https://github.com/hashicorp/dev-portal/pull/1510


### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
