### PR TITLE
feat(Quote): add text size option

### DIFF
--- a/.changeset/angry-suns-melt.md
+++ b/.changeset/angry-suns-melt.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-quote': patch
+---
+
+add text size option

--- a/packages/quote/docs.mdx
+++ b/packages/quote/docs.mdx
@@ -3,7 +3,7 @@ componentName: 'Quote'
 ---
 
 <LiveComponent>
-{`<div style={{ padding: 24, background: 'white' }}>
+  {`<div style={{ padding: 24, background: 'white' }}>
   <Quote
     text="Amet, nisl massa id egestas tincidunt urna tortor id bibendum. Mauris elit nunc fermentum elit mi varius suspendisse ut dictum. Nec a, massa vitae, viverra ultricies."
     avatar="https://www.datocms-assets.com/2885/1560891392-cropped0000armon.jpg"

--- a/packages/quote/index.tsx
+++ b/packages/quote/index.tsx
@@ -1,18 +1,36 @@
+import * as React from 'react'
 import classNames from 'classnames'
 import AuthorByline from '@hashicorp/react-author-byline'
 import type { QuoteProps } from './types'
 import s from './style.module.css'
 
+const gaps: {
+  [K in NonNullable<QuoteProps['textSize']>]: `${number}px`
+} = {
+  4: '32px',
+  5: '24px',
+}
+
 export default function Quote({
+  textSize = 4,
   text,
   avatar,
   name,
   role,
   appearance = 'light',
 }: QuoteProps) {
+  const textSizeClassName = `g-type-display-${textSize}`
   return (
-    <figure className={classNames(s.quote, s[appearance])} data-testid="quote">
-      <blockquote className={s.text}>
+    <figure
+      className={classNames(s.quote, s[appearance])}
+      style={
+        {
+          '--gap': gaps[textSize],
+        } as React.CSSProperties
+      }
+      data-testid="quote"
+    >
+      <blockquote className={classNames(s.text, textSizeClassName)}>
         <p>{text}</p>
       </blockquote>
       <figcaption className={s.caption}>

--- a/packages/quote/props.js
+++ b/packages/quote/props.js
@@ -1,6 +1,12 @@
 module.exports = {
+  textSize: {
+    type: 'number',
+    description: 'The display size the text should render as.',
+    options: [4, 5],
+  },
   text: {
     type: 'string',
+    required: true,
     description: 'The text displayed as the quote',
   },
   avatar: {

--- a/packages/quote/style.module.css
+++ b/packages/quote/style.module.css
@@ -1,7 +1,10 @@
 .quote {
   --color: var(--wpl-neutral-700);
+  --gap: 32px;
 
   margin: 0;
+  display: grid;
+  gap: var(--gap);
 
   &.dark {
     --color: var(--wpl-neutral-0);
@@ -25,8 +28,4 @@
       content: '”';
     }
   }
-}
-
-.caption {
-  margin-top: 32px;
 }

--- a/packages/quote/types.ts
+++ b/packages/quote/types.ts
@@ -2,6 +2,10 @@ import type { AuthorBylineProps } from '@hashicorp/react-author-byline/types'
 
 export interface QuoteProps extends AuthorBylineProps {
   /**
+   * The display size the text should render as.
+   */
+  textSize?: 4 | 5
+  /**
    * The text displayed as the quote
    */
   text: string


### PR DESCRIPTION
🔍 [Preview Link](https://react-components-git-acquote-text-size-hashicorp.vercel.app/components/quote)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Adds option to control the text sizing.

Following similar prop naming convention as Intro `headingSize` options.

Used on new early careers landing page https://github.com/hashicorp/hashicorp-www-next/pull/3309

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
