### PR TITLE
fix: return error on skipped records

### DIFF
--- a/.changeset/chilly-plums-share.md
+++ b/.changeset/chilly-plums-share.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-marketo-form': patch
+---
+
+Return errors on skipped records

--- a/.changeset/chilly-plums-share.md
+++ b/.changeset/chilly-plums-share.md
@@ -2,4 +2,5 @@
 '@hashicorp/react-marketo-form': patch
 ---
 
-Return errors on skipped records
+- `MarketoForm` will now treat skipped records as errors, and correctly invoke any `onSubmitError` handlers.
+- Added a new `onSubmitStart` handler that's called as soon as the submission process begins.

--- a/packages/marketo-form/form/index.tsx
+++ b/packages/marketo-form/form/index.tsx
@@ -66,6 +66,11 @@ interface Props {
   resetOnSubmission?: boolean
 
   /**
+   * Callback called when form has started submission process.
+   */
+  onSubmitStart?: () => void
+
+  /**
    * Callback called when form has been successfully submitted.
    */
   onSubmitSuccess?: () => void
@@ -113,6 +118,7 @@ const Form = ({
   submitTitle,
   className,
   resetOnSubmission,
+  onSubmitStart,
   onSubmitSuccess,
   onSubmitError,
   validateFields,
@@ -208,6 +214,9 @@ const Form = ({
   }, [hasBeenRendered])
 
   const onSubmit = async (data: Record<string, unknown>) => {
+    if (onSubmitStart) {
+      onSubmitStart()
+    }
     const leadFormFields = convertToRESTFields(data)
 
     segmentIdentify(leadFormFields)

--- a/packages/marketo-form/form/index.tsx
+++ b/packages/marketo-form/form/index.tsx
@@ -8,11 +8,13 @@ import {
   groupFields,
   calculateDefaultValues,
   segmentIdentify,
+  includesSkippedRecords,
 } from '../utils'
 import type {
   MarketoForm,
   MarketoFormGroups,
   MarketoFormComponents,
+  MarketoSubmissionResponse,
 } from '../types'
 
 interface Props {
@@ -227,8 +229,12 @@ const Form = ({
         formId,
       }),
     })
-    const marketoResponse = (await res.json()) as { success: boolean }
-    if (res.status === 200 && marketoResponse.success) {
+    const marketoResponse = (await res.json()) as MarketoSubmissionResponse
+    if (
+      res.status === 200 &&
+      marketoResponse.success &&
+      !includesSkippedRecords(marketoResponse)
+    ) {
       if (onSubmitSuccess) {
         onSubmitSuccess()
       }

--- a/packages/marketo-form/index.test.js
+++ b/packages/marketo-form/index.test.js
@@ -20,7 +20,7 @@ describe('MarketoForm', () => {
     nock('http://local.test')
       .persist()
       .post('/api/marketo/submit')
-      .reply(200, { success: true })
+      .reply(200, { success: true, result: [] })
 
     delete window.location
     window.location = {

--- a/packages/marketo-form/server/api-routes.ts
+++ b/packages/marketo-form/server/api-routes.ts
@@ -1,4 +1,5 @@
 import * as client from './client'
+import { includesSkippedRecords } from '../utils'
 import type { SubmissionFilter, MarketoSubmissionResponse } from '../types'
 import type { MarketoFieldsResponse } from './client'
 import type { NextApiRequest, NextApiResponse } from 'next'
@@ -77,11 +78,6 @@ function isE2ETest(req: NextApiRequest): boolean {
   }
 
   return false
-}
-
-// Returns true if any of the results have a status of skipped
-function includesSkippedRecords(res: MarketoSubmissionResponse): boolean {
-  return res.result.some((r) => r.status === 'skipped')
 }
 
 async function submitForm(

--- a/packages/marketo-form/utils.test.js
+++ b/packages/marketo-form/utils.test.js
@@ -1,4 +1,9 @@
-import { calculateDefaultValues, formattedLabel, groupFields } from './utils'
+import {
+  calculateDefaultValues,
+  formattedLabel,
+  groupFields,
+  includesSkippedRecords,
+} from './utils'
 import { UTM_FORM_PROPS, VISIBILITY_RULE_FORM_PROPS } from './fixtures'
 
 describe('formattedLabel', () => {
@@ -64,5 +69,40 @@ describe('calculateDefaultValues', () => {
       utm_medium__c: '',
       form_page_url__c: 'http',
     })
+  })
+})
+
+describe('includesSkippedRecords', () => {
+  it('returns true when containing skipped records', () => {
+    const response = {
+      requestId: 'f8a8#185cc1e96b9',
+      result: [
+        {
+          status: 'skipped',
+          reasons: [
+            {
+              code: '1003',
+              message:
+                "Invalid value for field 'email' and value 'dylan.staley@hashicorp.co.k'",
+            },
+          ],
+        },
+      ],
+      success: true,
+    }
+    expect(includesSkippedRecords(response)).toBe(true)
+  })
+
+  it('returns false when not containing skipped records', () => {
+    const response = {
+      requestId: 'f8a8#185cc1e96b9',
+      result: [
+        {
+          status: 'created',
+        },
+      ],
+      success: true,
+    }
+    expect(includesSkippedRecords(response)).toBe(false)
   })
 })

--- a/packages/marketo-form/utils.ts
+++ b/packages/marketo-form/utils.ts
@@ -1,5 +1,5 @@
 import { isAnalyticsMethodAvailable } from '@hashicorp/platform-analytics'
-import { MarketoFormField } from './types'
+import { MarketoFormField, MarketoSubmissionResponse } from './types'
 import { useFormState } from 'react-hook-form'
 
 // Marketo stores field names in two versions, SOAP and REST. Some API
@@ -230,4 +230,11 @@ export function segmentIdentify(leadFormFields: Record<string, unknown>) {
   } catch (err) {
     console.error(err)
   }
+}
+
+// Returns true if any of the results have a status of skipped
+export function includesSkippedRecords(
+  res: MarketoSubmissionResponse
+): boolean {
+  return res.result.some((r) => r.status === 'skipped')
 }


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR treats skipped records as errors. Basically, this prevents calling the onSuccess handler if any of the records of the response are skipped.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
