### PR TITLE
feat: add support for generic links for PersonCard

### DIFF
--- a/.changeset/beige-walls-doubt.md
+++ b/.changeset/beige-walls-doubt.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-card': minor
+---
+
+Add support for generic links for PersonCard

--- a/package-lock.json
+++ b/package-lock.json
@@ -38602,7 +38602,7 @@
     },
     "packages/consent-manager": {
       "name": "@hashicorp/react-consent-manager",
-      "version": "8.2.1",
+      "version": "8.2.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/flight-icons": "^2.5.0",

--- a/packages/card/person-card/index.test.js
+++ b/packages/card/person-card/index.test.js
@@ -46,6 +46,7 @@ describe('<PersonCard />', () => {
       github: 'https://github.com',
       twitter: 'https://twitter.com',
       linkedin: 'https://linkedin.com',
+      link: 'https://example.com',
     }
 
     render(
@@ -59,5 +60,11 @@ describe('<PersonCard />', () => {
     Object.keys(links).forEach((platform) => {
       screen.getByTestId(`wpl-personcard-${platform}-icon`)
     })
+  })
+
+  it('should not render a thumbnail icon when link is on hashicorp.com', () => {
+    render(<PersonCard {...defaultProps} link="https://hashicorp.com" />)
+
+    expect(screen.queryByTestId('wpl-personcard-link-icon')).toBeNull()
   })
 })

--- a/packages/card/person-card/index.tsx
+++ b/packages/card/person-card/index.tsx
@@ -8,6 +8,7 @@ import * as CardPrimitives from '../primitives'
 import { IconGithub16 } from '@hashicorp/flight-icons/svg-react/github-16'
 import { IconTwitter16 } from '@hashicorp/flight-icons/svg-react/twitter-16'
 import { IconLinkedin16 } from '@hashicorp/flight-icons/svg-react/linkedin-16'
+import { IconLink16 } from '@hashicorp/flight-icons/svg-react/link-16'
 import s from './style.module.css'
 
 export interface PersonCardProps {
@@ -20,8 +21,12 @@ export interface PersonCardProps {
   productBadges?: ProductBadgesProps['badges']
 }
 
-function Icon({ url }) {
-  let icon
+function Icon({ url }: { url: string }) {
+  if (url.includes('hashicorp.com')) {
+    return null
+  }
+
+  let icon = <IconLink16 data-testid={'wpl-personcard-link-icon'} />
   if (url.includes('twitter')) {
     icon = <IconTwitter16 data-testid={'wpl-personcard-twitter-icon'} />
   }
@@ -32,7 +37,7 @@ function Icon({ url }) {
     icon = <IconLinkedin16 data-testid={'wpl-personcard-linkedin-icon'} />
   }
 
-  return icon ? <div className={s.thumbnailIcon}>{icon}</div> : null
+  return <div className={s.thumbnailIcon}>{icon}</div>
 }
 
 export function PersonCard({


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR adds support for generic links for `PersonCard`, allowing HashiCorp Ambassadors to link to their personal websites.

<img width="219" alt="image" src="https://user-images.githubusercontent.com/88163/217361239-3839ae06-a58f-43b2-aae3-4e2d6727ca6f.png">

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
