### PR TITLE
fix(EnterpriseAlert): render span when inline

### DIFF
--- a/.changeset/chilly-bikes-scream.md
+++ b/.changeset/chilly-bikes-scream.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-enterprise-alert': patch
+---
+
+Fix EnterpriseAlert so that it does not potentially generate invalid markup when used inline

--- a/packages/enterprise-alert/index.tsx
+++ b/packages/enterprise-alert/index.tsx
@@ -23,8 +23,12 @@ function EnterpriseAlert({
   className,
 }: EnterpriseAlertProps) {
   const { name, slug, themeClass } = useProductMeta(product)
+
+  // This ensures we aren't producing invalid HTML when rendering inline alerts within MDX. When used inline, we might end up nesting a div inside of a p. This is invalid as p cannot contain block-level elements (ref: https://www.w3.org/TR/html401/struct/text.html#h-9.3.1).
+  const Element = inline ? 'span' : 'div'
+
   return (
-    <div
+    <Element
       className={classNames(s.root, themeClass, className, {
         [s.themed]: themeClass,
         [s.inline]: inline,
@@ -50,7 +54,7 @@ function EnterpriseAlert({
           )}
         </p>
       )}
-    </div>
+    </Element>
   )
 }
 


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

When used inline, `EnterpriseAlert` currently renders a `div` as its root element. This is problematic when used in MDX specifically, as it will most likely be a child of a `p`. Per the spec, `p` elements cannot contain block-level elements and so the HTML is invalid. This results in React hydration errors.

I've updated `EnterpriseAlert` to render `span` as its root element if the `inline` prop is passed to fix this.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
