### PR TITLE
fix: require emails to have domains

### DIFF
--- a/.changeset/rotten-bats-pretend.md
+++ b/.changeset/rotten-bats-pretend.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-marketo-form': patch
+---
+
+Require emails to have domains

--- a/package-lock.json
+++ b/package-lock.json
@@ -38602,7 +38602,7 @@
     },
     "packages/consent-manager": {
       "name": "@hashicorp/react-consent-manager",
-      "version": "8.2.1",
+      "version": "8.2.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/flight-icons": "^2.5.0",
@@ -38852,7 +38852,7 @@
     },
     "packages/enterprise-alert": {
       "name": "@hashicorp/react-enterprise-alert",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
@@ -39095,7 +39095,7 @@
     },
     "packages/marketo-form": {
       "name": "@hashicorp/react-marketo-form",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-analytics": "^0.10.0",
@@ -39274,7 +39274,7 @@
     },
     "packages/next-steps": {
       "name": "@hashicorp/react-next-steps",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
@@ -39347,7 +39347,7 @@
     },
     "packages/pricing-tiers": {
       "name": "@hashicorp/react-pricing-tiers",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/react-button": "^6.3.0",

--- a/packages/marketo-form/form/index.tsx
+++ b/packages/marketo-form/form/index.tsx
@@ -110,8 +110,9 @@ const defaultFieldGroupings = {
 
 function isValidEmail(value: string): boolean {
   // Source: https://html.spec.whatwg.org/multipage/input.html#email-state-(type=email)
+  // Slightly modified to require domains instead of bare TLDs
   /* eslint-disable-next-line no-useless-escape */
-  return /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/i.test(
+  return /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/i.test(
     value
   )
 }


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Technically emails in the form of `label@domain` are valid, but Marketo doesn't accept these emails. This PR adjusts our validation regex to require a domain+tld combination to reduce the instances where we submit an invalid form.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
