### PR TITLE
fix(Card): thumbnail sizing

### DIFF
--- a/.changeset/gold-avocados-raise.md
+++ b/.changeset/gold-avocados-raise.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-card': patch
+---
+
+fix issue with thumbnail image sizing

--- a/packages/card/primitives.tsx
+++ b/packages/card/primitives.tsx
@@ -52,14 +52,7 @@ function Thumbnail({ src, alt }: ThumbnailProps) {
   return (
     <div className={s.thumbnail} data-testid="wpl-card-thumbnail">
       <div className={s.image}>
-        <Image
-          src={src}
-          alt={alt}
-          width={800}
-          height={450}
-          layout="responsive"
-          objectFit="cover"
-        />
+        <Image src={src} alt={alt} width={800} height={450} />
       </div>
     </div>
   )

--- a/packages/card/style.module.css
+++ b/packages/card/style.module.css
@@ -76,9 +76,14 @@
 
 .thumbnail {
   border-bottom: 1px solid var(--border-color);
+}
 
-  & .image {
-    display: grid;
+.image {
+  display: grid;
+  aspect-ratio: 16 / 9;
+
+  & img {
+    object-fit: cover;
   }
 }
 

--- a/packages/card/style.module.css
+++ b/packages/card/style.module.css
@@ -76,14 +76,17 @@
 
 .thumbnail {
   border-bottom: 1px solid var(--border-color);
-}
 
-.image {
-  display: grid;
-  aspect-ratio: 16 / 9;
+  & .image {
+    display: grid;
+    aspect-ratio: 16 / 9;
 
-  & img {
-    object-fit: cover;
+    & img {
+      object-fit: cover;
+      object-position: center;
+      width: 100%;
+      height: 100%;
+    }
   }
 }
 

--- a/packages/card/style.module.css
+++ b/packages/card/style.module.css
@@ -78,6 +78,7 @@
   border-bottom: 1px solid var(--border-color);
 
   & .image {
+    position: relative;
     display: grid;
     aspect-ratio: 16 / 9;
 


### PR DESCRIPTION
🔍 [Preview Link](https://react-components-git-acfix-card-thumbnail-sizing-hashicorp.vercel.app/components/card)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Fixes issue with card thumbnail sizing due to Next13 image updates.

**Before**

<img width="1058" alt="image" src="https://user-images.githubusercontent.com/825855/221270308-30037e5c-9462-4dc6-90da-2194bb60d67a.png">


**After**

<img width="927" alt="image" src="https://user-images.githubusercontent.com/825855/221270368-c5d7f990-5801-4944-aacd-0a39d59e0803.png">

Preview the fix: https://github.com/hashicorp/hashicorp-www-next/pull/3427

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
