### PR TITLE
feat: update GraphQL fragment to fetch image dimensions

### DIFF
--- a/.changeset/blue-trees-talk.md
+++ b/.changeset/blue-trees-talk.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-image': minor
+---
+
+Update GraphQL fragment to fetch image dimensions

--- a/package-lock.json
+++ b/package-lock.json
@@ -38393,7 +38393,7 @@
     },
     "packages/card": {
       "name": "@hashicorp/react-card",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/react-expandable-arrow": "^0.1.0",
@@ -38602,7 +38602,7 @@
     },
     "packages/consent-manager": {
       "name": "@hashicorp/react-consent-manager",
-      "version": "8.2.2",
+      "version": "9.0.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/flight-icons": "^2.5.0",
@@ -39095,7 +39095,7 @@
     },
     "packages/marketo-form": {
       "name": "@hashicorp/react-marketo-form",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-analytics": "^0.10.0",

--- a/packages/image/fragment.graphql
+++ b/packages/image/fragment.graphql
@@ -1,5 +1,7 @@
-fragment imageFields on FileField {
+fragment imageFields on FileFieldInterface {
   url
   alt
   format
+  width
+  height
 }


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR updates the GraphQL fragment for `react-image` to fetch image dimensions, making it suitable for use in instances where we're passing the fragment's data to `next/image`.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
