### PR TITLE
feat(Subnav): pass ctalinks onclick through to cta buttons

### DIFF
--- a/.changeset/young-bags-dream.md
+++ b/.changeset/young-bags-dream.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-subnav': patch
+---
+
+pass onclick handler through ctalink

--- a/packages/subnav/partials/CtaLinks/index.js
+++ b/packages/subnav/partials/CtaLinks/index.js
@@ -42,6 +42,7 @@ function CtaLinks({ links, product, isInDropdown, hideGithubStars, theme }) {
             title={link.text}
             url={link.url}
             icon={isDownload ? iconDownload : isGithub ? iconGithub : undefined}
+            onClick={link.onClick}
             theme={{
               brand: product,
               variant: isLastButton ? 'primary' : 'secondary',

--- a/packages/subnav/props.js
+++ b/packages/subnav/props.js
@@ -39,6 +39,11 @@ module.exports = {
             description:
               'An optional theme object, which will be passed to the Button element for this link, and will override and default settings in the component.',
           },
+          onClick: {
+            type: 'function',
+            description:
+              'Optional function that will be called when the button is clicked.',
+          },
         },
       },
     ],


### PR DESCRIPTION
🔍 [Preview Link](https://react-components-git-acsubnav-ctalinks-onclick-hashicorp.vercel.app/components/subnav)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

Adds the ability to supply an `onClick` prop to subnav `ctaLinks` item.

View usage example https://github.com/hashicorp/dev-portal/pull/1718

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
