### PR TITLE
fix(placeholder): Shine height on Safari/iOS

### DIFF
--- a/.changeset/stale-plants-divide.md
+++ b/.changeset/stale-plants-divide.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-placeholder': patch
+---
+
+Fixes shine animation height not filling its containing box

--- a/package-lock.json
+++ b/package-lock.json
@@ -39133,7 +39133,7 @@
     },
     "packages/consent-manager": {
       "name": "@hashicorp/react-consent-manager",
-      "version": "9.0.0",
+      "version": "9.0.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/flight-icons": "^2.5.0",
@@ -40058,7 +40058,7 @@
     },
     "packages/placeholder": {
       "name": "@hashicorp/react-placeholder",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MPL-2.0",
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",

--- a/packages/placeholder/style.module.css
+++ b/packages/placeholder/style.module.css
@@ -17,7 +17,7 @@
     rgba(211, 211, 211, 0) 100%
   );
   background-position: -300% 0;
-  background-size: 75%;
+  background-size: 75% 100%;
   animation: loading 2s infinite;
 }
 


### PR DESCRIPTION
🔍 [Preview Link](https://react-components-git-nqplaceholder-fix-shine-height-hashicorp.vercel.app/components/placeholder)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR fixes an issue with `.box` `background-size` causing the "shine" animation not to fill the box height on Safari/iOS.

Context: `.box` had no explicit height value set for its `background-size` property, and values default to auto if not set. However, in Safari/iOS, the `auto` for the height value is not the height of the container, but (from observation) the value set for width. This behavior seems to have caused the "shine" to only reach `75%` of the box's height in Safari/iOS. Setting the height value to an explicit `100%` mitigates the issue.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
