### PR TITLE
feat: update ts type to accept ReactNode

### DIFF
--- a/.changeset/late-seahorses-approve.md
+++ b/.changeset/late-seahorses-approve.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-call-to-action': minor
+---
+
+Update TypeScript type to accept ReactNode

--- a/package-lock.json
+++ b/package-lock.json
@@ -38798,7 +38798,7 @@
     },
     "packages/alert-banner": {
       "name": "@hashicorp/react-alert-banner",
-      "version": "7.0.3",
+      "version": "7.0.4",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
@@ -38906,7 +38906,7 @@
     },
     "packages/card": {
       "name": "@hashicorp/react-card",
-      "version": "0.10.0",
+      "version": "0.10.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/react-expandable-arrow": "^0.1.0",
@@ -40026,7 +40026,7 @@
     },
     "packages/notification": {
       "name": "@hashicorp/react-notification",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/flight-icons": "^2.0.2",
@@ -40058,7 +40058,7 @@
     },
     "packages/placeholder": {
       "name": "@hashicorp/react-placeholder",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MPL-2.0",
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",

--- a/packages/call-to-action/index.tsx
+++ b/packages/call-to-action/index.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import type { ReactNode } from 'react'
 import Button from '@hashicorp/react-button'
 import type { Products } from '@hashicorp/platform-product-meta'
 import classNames from 'classnames'
@@ -20,7 +21,7 @@ const stylesDict = {
 
 interface CallToActionProps {
   heading?: string
-  content?: string
+  content?: ReactNode
   links?: {
     type?: 'inbound' | 'outbound' | 'anchor' | 'download'
     text: string


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR updates the type of `content` for `CallToAction` to accept a `ReactNode` to accommodate usage such as [this](https://github.com/hashicorp/hashicorp-www-next/blob/main/pages/sentinel/index.jsx#L145-L149). (note: `ReactNode` is a union containing `string`, so we don't need to manually specify that it accepts strings.)

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
