### PR TITLE
fix: mark product as optional

### DIFF
--- a/.changeset/six-dingos-pay.md
+++ b/.changeset/six-dingos-pay.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-alert': patch
+---
+
+Mark product as optional

--- a/.changeset/thirty-pugs-listen.md
+++ b/.changeset/thirty-pugs-listen.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-page': patch
+---
+
+Remove ts-expect-error

--- a/packages/alert/index.tsx
+++ b/packages/alert/index.tsx
@@ -70,7 +70,7 @@ Alert.fragmentSpec = { fragment }
 export default Alert
 
 interface AlertProps {
-  product: Products
+  product?: Products
   url: string
   tag: string
   text: string

--- a/packages/docs-page/components/version-alert/index.tsx
+++ b/packages/docs-page/components/version-alert/index.tsx
@@ -23,7 +23,6 @@ export default function VersionAlert({ tag, text }: VersionAlertProps) {
 
   return (
     <div className={s.wrapper}>
-      {/* @ts-expect-error: explicitly not passing `product` */}
       <Alert
         url={removeVersionFromPath(router.asPath)}
         tag={tag}


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR marks the `product` prop of `Alert` as optional to match [this](https://github.com/hashicorp/hashicorp-www-next/blob/main/pages/community/index.jsx#L57-L62) usage. `useProductMeta` is allowed to be invoked with `undefined`, which will then use the `product` config from the nearest `ProductMetaProvider`.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
