### PR TITLE
fix: update ts type to allow theme="gray"

### DIFF
--- a/.changeset/fuzzy-bugs-learn.md
+++ b/.changeset/fuzzy-bugs-learn.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-call-to-action': patch
+---
+
+Update TypeScript type to allow theme="gray"

--- a/packages/call-to-action/index.tsx
+++ b/packages/call-to-action/index.tsx
@@ -29,7 +29,7 @@ interface CallToActionProps {
   }[]
   variant?: 'centered' | 'compact' | 'compactGrid' | 'links'
   product?: Products
-  theme?: 'light' | 'dark' | 'brand'
+  theme?: 'light' | 'gray' | 'dark' | 'brand'
   className?: string
 }
 

--- a/packages/call-to-action/index.tsx
+++ b/packages/call-to-action/index.tsx
@@ -89,7 +89,7 @@ function CallToAction({
                     theme={{
                       variant: buttonVariant,
                       brand: product,
-                      background: theme,
+                      background: theme === 'gray' ? 'light' : theme,
                     }}
                     title={link.text}
                     url={link.url}


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR updates the `theme` prop for `CallToAction` to accept `gray` in line with usage [here](https://github.com/hashicorp/hashicorp-www-next/blob/main/pages/community/office-hours/index.jsx#L56).

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
