### PR TITLE
feat: add support for mailto links in PersonCard

### DIFF
--- a/.changeset/late-rats-complain.md
+++ b/.changeset/late-rats-complain.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-card': minor
+---
+
+Add support for email links in PersonCard

--- a/package-lock.json
+++ b/package-lock.json
@@ -38785,7 +38785,7 @@
     },
     "packages/alert": {
       "name": "@hashicorp/react-alert",
-      "version": "6.1.0",
+      "version": "6.1.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
@@ -38798,7 +38798,7 @@
     },
     "packages/alert-banner": {
       "name": "@hashicorp/react-alert-banner",
-      "version": "7.0.4",
+      "version": "7.0.5",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
@@ -38855,7 +38855,7 @@
     },
     "packages/button": {
       "name": "@hashicorp/react-button",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
@@ -38878,11 +38878,11 @@
     },
     "packages/call-to-action": {
       "name": "@hashicorp/react-call-to-action",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
-        "@hashicorp/react-button": "^6.0.4"
+        "@hashicorp/react-button": "^6.3.1"
       },
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",
@@ -39201,12 +39201,12 @@
     },
     "packages/docs-page": {
       "name": "@hashicorp/react-docs-page",
-      "version": "17.7.1",
+      "version": "17.7.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-docs-mdx": "^0.2.0",
         "@hashicorp/platform-product-meta": "^0.1.0",
-        "@hashicorp/react-alert": "^6.0.2",
+        "@hashicorp/react-alert": "^6.1.1",
         "@hashicorp/react-content": "^8.2.3",
         "@hashicorp/react-docs-sidenav": "^9.0.0",
         "@hashicorp/react-head": "^3.1.2",
@@ -39563,7 +39563,7 @@
     },
     "packages/form-fields": {
       "name": "@hashicorp/react-form-fields",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@hashicorp/flight-icons": "^2.5.0",
         "@reach/auto-id": "^0.18.0",
@@ -39641,7 +39641,7 @@
     },
     "packages/image": {
       "name": "@hashicorp/react-image",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "MPL-2.0",
       "dependencies": {
         "object-assign": "^4.1.1",
@@ -39713,11 +39713,11 @@
     },
     "packages/logo-grid": {
       "name": "@hashicorp/react-logo-grid",
-      "version": "5.0.3",
+      "version": "5.0.5",
       "license": "MPL-2.0",
       "dependencies": {
-        "@hashicorp/react-button": "^6.0.4",
-        "@hashicorp/react-image": "^4.0.4",
+        "@hashicorp/react-button": "^6.3.1",
+        "@hashicorp/react-image": "^4.1.1",
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@reach/popover": "^0.16.2",
         "@reach/portal": "^0.16.2",
@@ -40272,7 +40272,7 @@
     },
     "packages/section-header": {
       "name": "@hashicorp/react-section-header",
-      "version": "5.0.4",
+      "version": "5.0.5",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/js-utils": "^1.0.10"

--- a/packages/card/person-card/index.test.js
+++ b/packages/card/person-card/index.test.js
@@ -47,6 +47,7 @@ describe('<PersonCard />', () => {
       twitter: 'https://twitter.com',
       linkedin: 'https://linkedin.com',
       link: 'https://example.com',
+      mail: 'mailto:name@example.com',
     }
 
     render(

--- a/packages/card/person-card/index.tsx
+++ b/packages/card/person-card/index.tsx
@@ -3,12 +3,14 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import { memo, type ReactNode } from 'react'
 import type { CardProps, ProductBadgesProps, ThumbnailProps } from '../types'
 import * as CardPrimitives from '../primitives'
 import { IconGithub16 } from '@hashicorp/flight-icons/svg-react/github-16'
 import { IconTwitter16 } from '@hashicorp/flight-icons/svg-react/twitter-16'
 import { IconLinkedin16 } from '@hashicorp/flight-icons/svg-react/linkedin-16'
 import { IconLink16 } from '@hashicorp/flight-icons/svg-react/link-16'
+import { IconMail16 } from '@hashicorp/flight-icons/svg-react/mail-16'
 import s from './style.module.css'
 
 export interface PersonCardProps {
@@ -21,24 +23,40 @@ export interface PersonCardProps {
   productBadges?: ProductBadgesProps['badges']
 }
 
-function Icon({ url }: { url: string }) {
-  if (url.includes('hashicorp.com')) {
+// Map of hostnames to icons.
+/* eslint-disable react/jsx-key */
+const iconMap = new Map<string, ReactNode>([
+  // null signals that we don't want to render any icon
+  ['hashicorp.com', null],
+  [
+    'twitter.com',
+    <IconTwitter16 data-testid={'wpl-personcard-twitter-icon'} />,
+  ],
+  ['github.com', <IconGithub16 data-testid={'wpl-personcard-github-icon'} />],
+  [
+    'linkedin.com',
+    <IconLinkedin16 data-testid={'wpl-personcard-linkedin-icon'} />,
+  ],
+  ['mailto:', <IconMail16 data-testid={'wpl-personcard-mail-icon'} />],
+])
+/* eslint-enable react/jsx-key */
+
+const Icon = memo(function Icon({ url }: { url: string }) {
+  const { protocol, host } = new URL(url)
+  const icon = iconMap.get(protocol === 'mailto:' ? 'mailto:' : host)
+
+  // If the icon value is null, don't render an icon
+  if (icon === null) {
     return null
   }
 
-  let icon = <IconLink16 data-testid={'wpl-personcard-link-icon'} />
-  if (url.includes('twitter')) {
-    icon = <IconTwitter16 data-testid={'wpl-personcard-twitter-icon'} />
-  }
-  if (url.includes('github')) {
-    icon = <IconGithub16 data-testid={'wpl-personcard-github-icon'} />
-  }
-  if (url.includes('linkedin')) {
-    icon = <IconLinkedin16 data-testid={'wpl-personcard-linkedin-icon'} />
-  }
-
-  return <div className={s.thumbnailIcon}>{icon}</div>
-}
+  // Render the icon or the default icon if the icon value is undefined
+  return (
+    <div className={s.thumbnailIcon}>
+      {icon ?? <IconLink16 data-testid={'wpl-personcard-link-icon'} />}
+    </div>
+  )
+})
 
 export function PersonCard({
   appearance,


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR adds support for `mailto:` links to `PersonCard`. Additionally, it refactors the `Icon` component to rely on a `Map` and `memo` instead of several `if` statements.

<img width="479" alt="image" src="https://user-images.githubusercontent.com/88163/228645557-f2d5df8e-b6ed-4e3c-99bf-cc2959912cd5.png">

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
