### PR TITLE
feat: remove @reach/auto-id

### DIFF
--- a/.changeset/good-icons-argue.md
+++ b/.changeset/good-icons-argue.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-form-fields': minor
+---
+
+Replace @reach/auto-id with React.useId

--- a/.changeset/tasty-parrots-battle.md
+++ b/.changeset/tasty-parrots-battle.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-docs-page': minor
+---
+
+Update TypeScript types to be compatible with React v18

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^13.5.0",
-        "@types/react": "^17.0.38",
+        "@types/react": "^18.0.37",
         "dotenv": "^14.3.0",
         "eslint": "^7.32.0",
         "identity-obj-proxy": "^3.0.0",
@@ -9193,8 +9193,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "17.0.38",
-      "license": "MIT",
+      "version": "18.0.37",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.37.tgz",
+      "integrity": "sha512-4yaZZtkRN3ZIQD3KSEwkfcik8s0SWV+82dlJot1AbGYHCzJkWP3ENBY6wYeDRmKZ6HkrgoGAmR2HqdwYGp6OEw==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -38906,7 +38907,7 @@
     },
     "packages/card": {
       "name": "@hashicorp/react-card",
-      "version": "0.10.2",
+      "version": "0.11.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/react-expandable-arrow": "^0.1.0",
@@ -39201,7 +39202,7 @@
     },
     "packages/docs-page": {
       "name": "@hashicorp/react-docs-page",
-      "version": "17.7.2",
+      "version": "17.8.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-docs-mdx": "^0.2.0",
@@ -39566,7 +39567,6 @@
       "version": "0.1.2",
       "dependencies": {
         "@hashicorp/flight-icons": "^2.5.0",
-        "@reach/auto-id": "^0.18.0",
         "clsx": "^1.2.1"
       }
     },
@@ -39976,17 +39976,15 @@
       "name": "@hashicorp/react-motion-config",
       "version": "0.2.0",
       "license": "MPL-2.0",
-      "dependencies": {
-        "framer-motion": "^6.3.11"
-      },
       "peerDependencies": {
-        "framer-motion": ">=6.3.11",
+        "framer-motion": "^6.3.11",
         "react": ">=16.x"
       }
     },
     "packages/motion-config/node_modules/framer-motion": {
       "version": "6.3.11",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "framesync": "6.0.1",
         "hey-listen": "^1.0.8",
@@ -40004,7 +40002,8 @@
     },
     "packages/motion-config/node_modules/tslib": {
       "version": "2.4.0",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "packages/next-steps": {
       "name": "@hashicorp/react-next-steps",
@@ -40180,10 +40179,10 @@
     },
     "packages/related-content": {
       "name": "@hashicorp/react-related-content",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MPL-2.0",
       "dependencies": {
-        "@hashicorp/react-card": "^0.10.0",
+        "@hashicorp/react-card": "^0.11.0",
         "@hashicorp/react-standalone-link": "^0.4.0",
         "classnames": "^2.3.1"
       },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^13.5.0",
-    "@types/react": "^17.0.38",
+    "@types/react": "^18.0.37",
     "dotenv": "^14.3.0",
     "eslint": "^7.32.0",
     "identity-obj-proxy": "^3.0.0",

--- a/packages/docs-page/components.ts
+++ b/packages/docs-page/components.ts
@@ -5,12 +5,11 @@
 
 import defaultMdxComponents from '@hashicorp/platform-docs-mdx'
 import { MDXProviderComponentsProp } from '@mdx-js/react'
-import { ReactElement } from 'react'
 
 export default function generateComponents(
   productName: string,
   additionalComponents: MDXProviderComponentsProp = {}
-): Record<string, (p: any) => ReactElement> {
+) {
   return defaultMdxComponents({
     product: productName,
     additionalComponents,

--- a/packages/docs-page/index.tsx
+++ b/packages/docs-page/index.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { useEffect, FunctionComponent, ReactElement } from 'react'
+import { useEffect, ReactElement, type ReactNode } from 'react'
 import classNames from 'classnames'
 import { useRouter } from 'next/router'
 import Head from 'next/head'
@@ -32,6 +32,7 @@ import type { VersionSelectItem } from './server/loaders/remote-content'
 
 interface DocsPageInnerProps {
   canonicalUrl: string | null
+  children: ReactNode
   description: string
   navData: NavData
   currentPath: string
@@ -48,7 +49,7 @@ interface DocsPageInnerProps {
   projectName?: string
 }
 
-export const DocsPageInner: FunctionComponent<DocsPageInnerProps> = ({
+export const DocsPageInner = ({
   canonicalUrl,
   children,
   description,
@@ -64,7 +65,7 @@ export const DocsPageInner: FunctionComponent<DocsPageInnerProps> = ({
   algoliaConfig,
   optInBanner,
   projectName,
-}) => {
+}: DocsPageInnerProps) => {
   const isMobile = useIsMobile()
   const { asPath } = useRouter()
   const versionInPath = getVersionFromPath(asPath)

--- a/packages/form-fields/package.json
+++ b/packages/form-fields/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.2",
   "dependencies": {
     "@hashicorp/flight-icons": "^2.5.0",
-    "@reach/auto-id": "^0.18.0",
     "clsx": "^1.2.1"
   }
 }

--- a/packages/form-fields/partials/choice-group/index.tsx
+++ b/packages/form-fields/partials/choice-group/index.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { useId } from '@reach/auto-id'
+import { useId } from 'react'
 import Radio from '../../radio'
 import Checkbox from '../../checkbox'
 import Label from '../label'

--- a/packages/form-fields/partials/radio-checkbox/index.tsx
+++ b/packages/form-fields/partials/radio-checkbox/index.tsx
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import React, { ReactNode, ComponentProps } from 'react'
-import { useId } from '@reach/auto-id'
+import React, { ReactNode, ComponentProps, useId } from 'react'
 import s from './style.module.css'
 import clsx from 'clsx'
 

--- a/packages/form-fields/select/index.tsx
+++ b/packages/form-fields/select/index.tsx
@@ -4,7 +4,7 @@
  */
 
 import classNames from 'classnames'
-import { useId } from '@reach/auto-id'
+import { useId } from 'react'
 import s from './style.module.css'
 import type { HTMLProps } from 'react'
 import Label from '../partials/label'

--- a/packages/form-fields/text/index.tsx
+++ b/packages/form-fields/text/index.tsx
@@ -4,7 +4,7 @@
  */
 
 import classNames from 'classnames'
-import { useId } from '@reach/auto-id'
+import { useId } from 'react'
 import s from './style.module.css'
 import type { HTMLProps } from 'react'
 import Label from '../partials/label'

--- a/packages/form-fields/textarea/index.tsx
+++ b/packages/form-fields/textarea/index.tsx
@@ -4,7 +4,7 @@
  */
 
 import clsx from 'clsx'
-import { useId } from '@reach/auto-id'
+import { useId } from 'react'
 import s from './style.module.css'
 import { HTMLProps } from 'react'
 import Label from '../partials/label'

--- a/swingset-extensions/playground/index.tsx
+++ b/swingset-extensions/playground/index.tsx
@@ -7,10 +7,10 @@ import {
   useRef,
   useState,
   Children,
-  FC,
   ElementType,
   ReactElement,
   useEffect,
+  type ReactNode,
 } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 import classNames from 'classnames'
@@ -50,6 +50,7 @@ interface PlaygroundProps {
    * WARNING: only one Playground per page can have its state persisted to the URL
    */
   persistStateToUrl?: boolean
+  children: ReactNode
 }
 
 /**
@@ -197,12 +198,12 @@ const PlaygroundInner = ({ layout, persistStateToUrl }) => {
   )
 }
 
-const Playground: FC<PlaygroundProps> = ({
+const Playground = ({
   children,
   title,
   layout,
   persistStateToUrl,
-}) => {
+}: PlaygroundProps) => {
   const [codeChild, styleChild] = Children.toArray(children)
 
   const initialCode =


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR removes `@reach/auto-id` in favor of React.useId in `react-form-fields`. The remaining packages using `@reach/auto-id` are no longer being maintained.

As a part of this PR, `@types/react` was updated to v18, and `react-docs-page` was adjusted to account for the breaking changes (namely the deprecation of the `FunctionalComponent` utility type).

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
