### PR TITLE
fix(consent-manager): filter additional services in main component

### DIFF
--- a/.changeset/grumpy-islands-repair.md
+++ b/.changeset/grumpy-islands-repair.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/react-consent-manager": patch
+---
+
+fix: filter additional services in main component

--- a/packages/consent-manager/index.test.js
+++ b/packages/consent-manager/index.test.js
@@ -209,40 +209,6 @@ test('loads segment and additional services if loadAll is passed', async () => {
   )
 })
 
-test('loads segment and additional services if loadAll is passed', async () => {
-  await runWithMockedImport(
-    './util/cookies',
-    {
-      loadPreferences: () => {
-        return { loadAll: true, segment: { foo: 'bar' } }
-      },
-      savePreferences: () => {},
-    },
-    (MockedConsentManager) => {
-      render(
-        <MockedConsentManager {...defaultProps} forceShow={false} version={2} />
-      )
-      const html = document.body.innerHTML
-      // script was injected
-      expect(html).toMatch(
-        /<script type="text\/javascript" src="https:\/\/artemis.hashicorp.com\/script/
-      )
-      // all services loaded, as well as custom segment
-      expect(html).toMatch(
-        /analytics\.load\("iyi06c432UL7SB1r3fQReec4bNwFyzkW", {"integrations":{"All":true,"Segment\.io":true,"foo":"bar"}}\);/
-      )
-
-      // custom service loaded
-      expect(html).toMatch(
-        /src="http:\/\/www.an-optional-url-for-a-script-to-add-to-the-page\.com"/
-      )
-
-      // custom inline script
-      expect(html).toMatch(/window\.foo = "bar"/)
-    }
-  )
-})
-
 describe('handles custom events', () => {
   test('manage preferences callback', async () => {
     const fn = jest.fn()

--- a/packages/consent-manager/index.test.js
+++ b/packages/consent-manager/index.test.js
@@ -332,6 +332,7 @@ describe('handles conditionally loaded services in dialog', () => {
 
     expect(category).toBeInTheDocument()
     const showMoreButton = category.nextSibling.nextSibling
+    // Open category accordion item to make services visible
     fireEvent.click(showMoreButton)
     const shouldLoadService = await screen.findByText('Name of the new service')
     const shouldNotLoadService = screen.queryByText(

--- a/packages/consent-manager/index.test.js
+++ b/packages/consent-manager/index.test.js
@@ -57,6 +57,21 @@ const defaultProps = {
         },
       ],
     },
+    {
+      name: 'Name of the conditionally loaded service',
+      category: 'Example Category with conditionally loaded service',
+      description: 'A script with additional elements to be injected',
+      body: 'window.foo = "bar"',
+      url: 'https://source-of-conditionally-loaded-script.com',
+      async: true,
+      dataAttrs: [
+        {
+          name: 'test',
+          value: 'foobar',
+        },
+      ],
+      shouldLoad: () => false,
+    },
   ],
   categories: [
     {
@@ -183,6 +198,45 @@ test('loads segment and additional services if loadAll is passed', async () => {
         /src="http:\/\/www.an-optional-url-for-a-script-to-add-to-the-page\.com"/
       )
 
+      // conditionally loaded service not loaded
+      expect(html).not.toMatch(
+        /src="https:\/\/source-of-conditionally-loaded-script\.com"/
+      )
+
+      // custom inline script
+      expect(html).toMatch(/window\.foo = "bar"/)
+    }
+  )
+})
+
+test('loads segment and additional services if loadAll is passed', async () => {
+  await runWithMockedImport(
+    './util/cookies',
+    {
+      loadPreferences: () => {
+        return { loadAll: true, segment: { foo: 'bar' } }
+      },
+      savePreferences: () => {},
+    },
+    (MockedConsentManager) => {
+      render(
+        <MockedConsentManager {...defaultProps} forceShow={false} version={2} />
+      )
+      const html = document.body.innerHTML
+      // script was injected
+      expect(html).toMatch(
+        /<script type="text\/javascript" src="https:\/\/artemis.hashicorp.com\/script/
+      )
+      // all services loaded, as well as custom segment
+      expect(html).toMatch(
+        /analytics\.load\("iyi06c432UL7SB1r3fQReec4bNwFyzkW", {"integrations":{"All":true,"Segment\.io":true,"foo":"bar"}}\);/
+      )
+
+      // custom service loaded
+      expect(html).toMatch(
+        /src="http:\/\/www.an-optional-url-for-a-script-to-add-to-the-page\.com"/
+      )
+
       // custom inline script
       expect(html).toMatch(/window\.foo = "bar"/)
     }
@@ -230,6 +284,61 @@ describe('handles custom events', () => {
         expect(fn).toHaveBeenCalled()
       }
     )
+  })
+})
+
+describe('handles conditionally loaded services in dialog', () => {
+  test('additional services category is not in dialog when shouldLoad() is false in all category services', async () => {
+    const { default: ConsentManager, open } = require('./')
+    render(<ConsentManager {...defaultProps} />)
+    act(() => open())
+
+    const shownCategory = await screen.findByText('Example Category')
+    const hiddenCategory = screen.queryByText(
+      'Example Category with conditionally loaded service'
+    )
+    expect(shownCategory).toBeInTheDocument()
+    expect(hiddenCategory).not.toBeInTheDocument()
+  })
+
+  test('additional services category is in dialog when shouldLoad() is false in some category services but service is not in dialog', async () => {
+    const newService = {
+      name: 'Name of the new service',
+      category: 'Example Category with conditionally loaded service',
+      description: 'A script with additional elements to be injected',
+      body: 'window.foo = "bar"',
+      async: true,
+      dataAttrs: [
+        {
+          name: 'test',
+          value: 'foobar',
+        },
+      ],
+    }
+
+    const { default: ConsentManager, open } = require('./')
+    render(
+      <ConsentManager
+        {...{
+          ...defaultProps,
+          additionalServices: [...defaultProps.additionalServices, newService],
+        }}
+      />
+    )
+    act(() => open())
+    const category = await screen.findByText(
+      'Example Category with conditionally loaded service'
+    )
+
+    expect(category).toBeInTheDocument()
+    const showMoreButton = category.nextSibling.nextSibling
+    fireEvent.click(showMoreButton)
+    const shouldLoadService = await screen.findByText('Name of the new service')
+    const shouldNotLoadService = screen.queryByText(
+      'Name of the conditionally loaded service'
+    )
+    expect(shouldLoadService).toBeInTheDocument()
+    expect(shouldNotLoadService).not.toBeInTheDocument()
   })
 })
 

--- a/packages/consent-manager/index.tsx
+++ b/packages/consent-manager/index.tsx
@@ -115,6 +115,10 @@ export default function ConsentManager(props: ConsentManagerProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- We only want to run this check once
   }, [])
 
+  const filteredAdditionalServices = props.additionalServices?.filter(
+    (service) => service.shouldLoad === undefined || service.shouldLoad()
+  )
+
   return (
     <div className={classNames(s.root, props.className)}>
       {/*  Consent banner at the bottom */}
@@ -143,7 +147,7 @@ export default function ConsentManager(props: ConsentManagerProps) {
           version={props.version}
           segmentWriteKey={props.segmentWriteKey}
           segmentServices={props.segmentServices}
-          additionalServices={props.additionalServices}
+          additionalServices={filteredAdditionalServices}
           preferences={preferences}
           categories={props.categories}
           privacyPolicyLink={props.privacyPolicyLink}
@@ -157,7 +161,7 @@ export default function ConsentManager(props: ConsentManagerProps) {
       />
       <CustomScripts
         preferences={preferences}
-        services={props.additionalServices}
+        services={filteredAdditionalServices}
       />
     </div>
   )

--- a/packages/consent-manager/scripts/custom.tsx
+++ b/packages/consent-manager/scripts/custom.tsx
@@ -25,10 +25,6 @@ function CustomScript({ service }: CustomScriptProps) {
   const strategy =
     service.strategy ?? service.async ? 'afterInteractive' : 'beforeInteractive'
 
-  // if (service.shouldLoad !== undefined && !service.shouldLoad()) {
-  //   return null
-  // }
-
   return (
     <Script
       src={service.url}
@@ -59,13 +55,9 @@ export default function CustomScripts({
 
   return (
     <>
-      {servicesToInject
-        // .filter(
-        //   (service) => service.shouldLoad === undefined || service.shouldLoad()
-        // )
-        .map((service) => (
-          <CustomScript service={service} key={service.name} />
-        ))}
+      {servicesToInject.map((service) => (
+        <CustomScript service={service} key={service.name} />
+      ))}
     </>
   )
 }

--- a/packages/consent-manager/scripts/custom.tsx
+++ b/packages/consent-manager/scripts/custom.tsx
@@ -25,9 +25,9 @@ function CustomScript({ service }: CustomScriptProps) {
   const strategy =
     service.strategy ?? service.async ? 'afterInteractive' : 'beforeInteractive'
 
-  if (service.shouldLoad !== undefined && !service.shouldLoad()) {
-    return null
-  }
+  // if (service.shouldLoad !== undefined && !service.shouldLoad()) {
+  //   return null
+  // }
 
   return (
     <Script
@@ -59,9 +59,13 @@ export default function CustomScripts({
 
   return (
     <>
-      {servicesToInject.map((service) => (
-        <CustomScript service={service} key={service.name} />
-      ))}
+      {servicesToInject
+        // .filter(
+        //   (service) => service.shouldLoad === undefined || service.shouldLoad()
+        // )
+        .map((service) => (
+          <CustomScript service={service} key={service.name} />
+        ))}
     </>
   )
 }


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR fixes the (most recent consent-manager change)[] and filters the `additionalServices` by their optional `shouldLoad` field in the main component rather than the `<CustomScript />` component. This solves an issue where we were still seeing the service in the `<ConsentPreferences />` dialog when `shouldLoad()` was false

See this canary version in use [here](https://github.com/hashicorp/web/pull/280)

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
