### PR TITLE
fix: treat all-whitespace values as invalid

### DIFF
--- a/.changeset/witty-snakes-pull.md
+++ b/.changeset/witty-snakes-pull.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-marketo-form': patch
+---
+
+Treat all-whitespace values as invalid

--- a/package-lock.json
+++ b/package-lock.json
@@ -39642,7 +39642,7 @@
     },
     "packages/consent-manager": {
       "name": "@hashicorp/react-consent-manager",
-      "version": "9.0.2",
+      "version": "9.1.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/flight-icons": "^2.5.0",

--- a/packages/marketo-form/form/index.tsx
+++ b/packages/marketo-form/form/index.tsx
@@ -154,7 +154,9 @@ const Form = ({
             !(field.id in values) ||
             values[field.id] === '' ||
             values[field.id] === false ||
-            values[field.id] === undefined
+            values[field.id] === undefined ||
+            (typeof values[field.id] === 'string' &&
+              (values[field.id] as string).trim() === '')
           ) {
             errors[field.id] = {
               message: field.validationMessage ?? 'This field is required.',


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR updates the validation logic of `marketo-form` to treat all-whitespace values as invalid. This prevents users from submitting forms with `     ` as a valid value (which Marketo will happily accept).

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
