### PR TITLE
feat: add support for compactTertiary variant

### DIFF
--- a/.changeset/rotten-feet-confess.md
+++ b/.changeset/rotten-feet-confess.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-call-to-action': minor
+---
+
+Add support for compactTertiary variant

--- a/package-lock.json
+++ b/package-lock.json
@@ -40258,7 +40258,7 @@
     },
     "packages/marketo-form": {
       "name": "@hashicorp/react-marketo-form",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-analytics": "^0.11.2",

--- a/packages/call-to-action/index.tsx
+++ b/packages/call-to-action/index.tsx
@@ -5,6 +5,7 @@
 
 import type { ReactNode } from 'react'
 import Button from '@hashicorp/react-button'
+import type { ThemeVariant } from '@hashicorp/react-button/types'
 import type { Products } from '@hashicorp/platform-product-meta'
 import classNames from 'classnames'
 import variantCentered from './styles/variant-centered.module.css'
@@ -15,6 +16,7 @@ import variantLinks from './styles/variant-links.module.css'
 const stylesDict = {
   centered: variantCentered,
   compact: variantCompact,
+  compactTertiary: variantCompact,
   compactGrid: variantCompactGrid,
   links: variantLinks,
 }
@@ -27,7 +29,7 @@ interface CallToActionProps {
     text: string
     url: string
   }[]
-  variant?: 'centered' | 'compact' | 'compactGrid' | 'links'
+  variant?: keyof typeof stylesDict
   product?: Products
   theme?: 'light' | 'gray' | 'dark' | 'brand'
   className?: string
@@ -72,12 +74,13 @@ function CallToAction({
           {links && (
             <div className={s.links} data-testid="links">
               {links.map((link, stableIdx) => {
-                const buttonVariant =
-                  variant === 'links'
-                    ? 'tertiary-neutral'
-                    : stableIdx === 0
-                    ? 'primary'
-                    : 'secondary'
+                let buttonVariant: ThemeVariant =
+                  stableIdx === 0 ? 'primary' : 'secondary'
+                if (variant === 'links') {
+                  buttonVariant = 'tertiary-neutral'
+                } else if (variant === 'compactTertiary') {
+                  buttonVariant = 'tertiary'
+                }
                 const linkType =
                   variant === 'links' ? link.type || 'inbound' : link.type
                 return (

--- a/packages/call-to-action/props.js
+++ b/packages/call-to-action/props.js
@@ -8,7 +8,7 @@ module.exports = {
     type: 'string',
     description:
       'Controls the visual appearance of the call to action, defaults to `centered`.',
-    options: ['centered', 'compact', 'compactGrid', 'links'],
+    options: ['centered', 'compact', 'compactGrid', 'compactTertiary', 'links'],
   },
   heading: {
     type: 'string',


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-{branch-slug}-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR adds support for the `compactTertiary` variant for CallToAction, which renders supplied links using the `tertiary` button style.

<img width="622" alt="image" src="https://github.com/hashicorp/react-components/assets/88163/f77bbb9a-0be9-4182-9fee-7d8693084ac5">


### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
