### PR TITLE
feat(ConsentManager): Enable `onLoad` functionality for scripts

### DIFF
--- a/.changeset/modern-pianos-draw.md
+++ b/.changeset/modern-pianos-draw.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-consent-manager': minor
+---
+
+Add onload functionality to scripts handled by ConsentManager

--- a/packages/consent-manager/scripts/custom.tsx
+++ b/packages/consent-manager/scripts/custom.tsx
@@ -31,6 +31,7 @@ function CustomScript({ service }: CustomScriptProps) {
       strategy={strategy}
       id={service.name}
       {...dataAttrs}
+      onLoad={service?.onLoad}
     >
       {service.body ? service.body : null}
     </Script>

--- a/packages/consent-manager/types.ts
+++ b/packages/consent-manager/types.ts
@@ -19,6 +19,12 @@ export interface ConsentManagerService {
    * If left undefined, script will load as usual.
    */
   shouldLoad?: () => boolean
+  /**
+   * Optional function that runs when a script has
+   * finished loading.
+   * Docs: https://nextjs.org/docs/pages/api-reference/components/script#onload
+   */
+  onLoad?: () => void
 }
 
 export interface ConsentManagerPreset {


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1202791227659279/1204854420026344/f)
🔍 [Preview Link](https://react-components-git-nels-update-consent-manager-hashicorp.vercel.app/components/consentmanager)

## Description
This change enables `onLoad` functionality for scripts loaded via the `ConsentManager` component. This will allow us to register an event handler to track events for the Qualified chatbot.

## Validation Steps
- [ ] Navigate to [the preview](https://react-components-git-nels-update-consent-manager-hashicorp.vercel.app/components/consentmanager)
- [ ] Validate that there are no errors in the console
- [ ] Navigate to the [preview of the canary release on `www`](https://hashicorp-www-next-git-nels-observabilityadd-t-1713ef-hashicorp.vercel.app/)
- [ ] Validate that the `qualified.js` script loads in the DOM
<img width="451" alt="Screenshot 2023-07-12 at 9 33 53 AM" src="https://github.com/hashicorp/react-components/assets/39201593/19dda5de-c788-41f8-88ce-e3de62b88103">
