### PR TITLE
feat(Card): `<NewsroomCard />` updates

### DIFF
--- a/.changeset/hot-students-knock.md
+++ b/.changeset/hot-students-knock.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-card': minor
+---
+
+Updates NewsroomCard with new/updated props, and creates a LogoThumbnail primitive for use within NewsroomCard

--- a/package-lock.json
+++ b/package-lock.json
@@ -40353,7 +40353,7 @@
     },
     "packages/form-fields": {
       "name": "@hashicorp/react-form-fields",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@hashicorp/flight-icons": "^2.5.0",
         "classnames": "^2.3.2",

--- a/packages/card/docs.mdx
+++ b/packages/card/docs.mdx
@@ -340,7 +340,7 @@ A component used to promote and link to marketing pages, always using a descript
   <CustomerStoryCard
     thumbnail={{
       src: 'https://www.datocms-assets.com/2885/1670949945-example-customer-story.png',
-      alt: 'Customer Story'
+      alt: 'Customer Story',
     }}
     link="https://hashicorp.com"
     heading="Display 5 - 4 lines with character limit of 130. Leo mauris fermentum pharetra blandit tellus"
@@ -351,7 +351,7 @@ A component used to promote and link to marketing pages, always using a descript
     appearance="dark"
     thumbnail={{
       src: 'https://www.datocms-assets.com/2885/1670949945-example-customer-story.png',
-      alt: 'Customer Story'
+      alt: 'Customer Story',
     }}
     link="https://hashicorp.com"
     heading="Display 5 - 4 lines with character limit of 130. Leo mauris fermentum pharetra blandit tellus"
@@ -380,6 +380,7 @@ A component used to promote and link to marketing pages, always using a descript
     link="https://hashicorp.com"
     heading="Display 5 - 4 lines with character limit of 130. Leo mauris fermentum pharetra blandit tellus"
     date="August 15, 2022"
+    category="Case study"
   />
   <NewsroomCard
     appearance="dark"
@@ -390,6 +391,15 @@ A component used to promote and link to marketing pages, always using a descript
     link="https://hashicorp.com"
     heading="Display 5 - 4 lines with character limit of 130. Leo mauris fermentum pharetra blandit tellus"
     date="August 15, 2022"
+    category="Case study"
+  />
+  <NewsroomCard
+    appearance="light"
+    link="https://hashicorp.com"
+    heading="Display 5 - 4 lines with character limit of 130. Leo mauris fermentum pharetra blandit tellus"
+    date="August 15, 2022"
+    category="Press release"
+    withArrow
   />
 </div>
 

--- a/packages/card/newsroom-card/index.test.tsx
+++ b/packages/card/newsroom-card/index.test.tsx
@@ -10,6 +10,7 @@ const defaultProps = {
   link: 'https://hashicorp.com',
   heading: 'Example heading',
   date: 'August 15, 2022',
+  category: 'Post type',
   thumbnail: {
     src: 'https://www.datocms-assets.com/19447/1648680074-screenshot-2022-03-31-at-00-40-47.png',
     alt: 'HashiConf Europe 2022 Recap',
@@ -18,7 +19,7 @@ const defaultProps = {
 
 describe('<NewsroomCard />', () => {
   it('should render the provided metadata correctly', () => {
-    const expectedMeta = [defaultProps.date]
+    const expectedMeta = [defaultProps.date, defaultProps.category]
 
     render(<NewsroomCard {...defaultProps} />)
 
@@ -28,6 +29,11 @@ describe('<NewsroomCard />', () => {
       expect(metaElement).toContainElement(screen.getByText(item))
     })
 
-    expect(metaElement).not.toContainElement(screen.queryByText('|'))
+    expect(metaElement).toContainElement(screen.queryByText('|'))
+  })
+
+  it('should not render the logo thumbnail if no thumbnail data provided', () => {
+    render(<NewsroomCard {...defaultProps} thumbnail={undefined} />)
+    expect(screen.queryByTestId('wpl-card-logo-thumbnail')).toBeNull()
   })
 })

--- a/packages/card/newsroom-card/index.tsx
+++ b/packages/card/newsroom-card/index.tsx
@@ -9,28 +9,33 @@ import type { CardProps, ThumbnailProps } from '../types'
 export interface NewsroomCardProps {
   heading: string
   date: string
+  category: string
   link: string
-  thumbnail: ThumbnailProps
+  thumbnail?: ThumbnailProps
   appearance?: CardProps['appearance']
+  withArrow?: boolean
 }
 
 export function NewsroomCard({
   heading,
   date,
+  category,
   link,
   thumbnail,
   appearance,
+  withArrow = false,
 }: NewsroomCardProps): JSX.Element {
+  console.log(withArrow)
   return (
     <CardPrimitives.Card
       heading={heading}
       link={link}
-      withArrow={false}
+      withArrow={withArrow}
       appearance={appearance}
     >
-      <CardPrimitives.LogoThumbnail {...thumbnail} />
+      {thumbnail ? <CardPrimitives.LogoThumbnail {...thumbnail} /> : null}
       <CardPrimitives.Content>
-        <CardPrimitives.Meta items={[date]} />
+        <CardPrimitives.Meta items={[date, category]} />
         <CardPrimitives.Heading>{heading}</CardPrimitives.Heading>
       </CardPrimitives.Content>
     </CardPrimitives.Card>

--- a/packages/card/newsroom-card/index.tsx
+++ b/packages/card/newsroom-card/index.tsx
@@ -25,7 +25,6 @@ export function NewsroomCard({
   appearance,
   withArrow = false,
 }: NewsroomCardProps): JSX.Element {
-  console.log(withArrow)
   return (
     <CardPrimitives.Card
       heading={heading}

--- a/packages/card/newsroom-card/index.tsx
+++ b/packages/card/newsroom-card/index.tsx
@@ -28,7 +28,7 @@ export function NewsroomCard({
       withArrow={false}
       appearance={appearance}
     >
-      <CardPrimitives.Thumbnail {...thumbnail} />
+      <CardPrimitives.LogoThumbnail {...thumbnail} />
       <CardPrimitives.Content>
         <CardPrimitives.Meta items={[date]} />
         <CardPrimitives.Heading>{heading}</CardPrimitives.Heading>

--- a/packages/card/primitives.tsx
+++ b/packages/card/primitives.tsx
@@ -58,6 +58,16 @@ function Thumbnail({ src, alt }: ThumbnailProps) {
   )
 }
 
+function LogoThumbnail({ src, alt }: ThumbnailProps) {
+  return (
+    <div className={s.logoThumbnail} data-testid="wpl-card-logo-thumbnail">
+      <div className={s.image}>
+        <Image src={src} alt={alt} width={800} height={450} />
+      </div>
+    </div>
+  )
+}
+
 function Meta({ items }: MetaProps) {
   return (
     <ul className={s.meta} data-testid="wpl-card-meta">
@@ -121,4 +131,13 @@ function Description({ children }: DescriptionProps) {
 }
 
 Card.displayName = 'Card'
-export { Card, Thumbnail, Meta, Content, Heading, Description, ProductBadges }
+export {
+  Card,
+  Thumbnail,
+  LogoThumbnail,
+  Meta,
+  Content,
+  Heading,
+  Description,
+  ProductBadges,
+}

--- a/packages/card/style.module.css
+++ b/packages/card/style.module.css
@@ -92,6 +92,20 @@
   }
 }
 
+.logoThumbnail {
+  composes: thumbnail;
+  padding: var(--wpl-spacing-05);
+
+  & .image {
+    aspect-ratio: none;
+
+    & img {
+      aspect-ratio: 16 / 9;
+      object-fit: contain;
+    }
+  }
+}
+
 .meta {
   composes: g-type-label from global;
   color: var(--secondary-text-color);


### PR DESCRIPTION
💬 [Slack context](https://hashicorp.slack.com/archives/C031LA4KS4S/p1689102495068719?thread_ts=1689099305.128409&cid=C031LA4KS4S)
🔍 [Preview Link](https://react-components-git-nqcard-update-newsroomcard-hashicorp.vercel.app/components/card)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR updates `<NewsroomCard />` to support:
- logo-oriented thumbnail styles, via a `<LogoThumbnail />` primitive
- Tweaks to props:
  - Category for eyebrow
  - Optional thumbnails

Updates have been approved by design via [the end of this Figma thread](https://www.figma.com/file/CaKUjhzM1Q8y2EOCMIoIl1?node-id=2327:7048&mode=dev#490070226).

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
