### PR TITLE
chore: remove @reach/auto-id dep, opt for react's `useId`

### DIFF
--- a/.changeset/old-days-rescue.md
+++ b/.changeset/old-days-rescue.md
@@ -1,7 +1,7 @@
 ---
-'@hashicorp/react-checkbox-input': patch
-'@hashicorp/react-text-input': patch
-'@hashicorp/react-textarea-input': patch
+'@hashicorp/react-checkbox-input': major
+'@hashicorp/react-text-input': major
+'@hashicorp/react-textarea-input': major
 ---
 
-Remove @reach/auto-id dependency in favor of react's `useId`
+Remove @reach/auto-id dependency in favor of react's `useId` and update peer dependency `react` version to >=18.x

--- a/.changeset/old-days-rescue.md
+++ b/.changeset/old-days-rescue.md
@@ -1,0 +1,7 @@
+---
+'@hashicorp/react-checkbox-input': patch
+'@hashicorp/react-text-input': patch
+'@hashicorp/react-textarea-input': patch
+---
+
+Remove @reach/auto-id dependency in favor of react's `useId`

--- a/package-lock.json
+++ b/package-lock.json
@@ -39694,7 +39694,7 @@
     },
     "packages/card": {
       "name": "@hashicorp/react-card",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/react-expandable-arrow": "^0.1.0",
@@ -39725,63 +39725,12 @@
       "version": "5.0.3",
       "license": "MPL-2.0",
       "dependencies": {
-        "@reach/auto-id": "^0.17.0",
         "classnames": "^2.3.1"
       },
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",
         "react": ">=16.x"
       }
-    },
-    "packages/checkbox-input/node_modules/@reach/auto-id": {
-      "version": "0.17.0",
-      "license": "MIT",
-      "dependencies": {
-        "@reach/utils": "0.17.0",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "packages/checkbox-input/node_modules/@reach/auto-id/node_modules/@reach/utils": {
-      "version": "0.17.0",
-      "license": "MIT",
-      "dependencies": {
-        "tiny-warning": "^1.0.3",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "packages/checkbox-input/node_modules/react-dom": {
-      "version": "17.0.2",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
-      },
-      "peerDependencies": {
-        "react": "17.0.2"
-      }
-    },
-    "packages/checkbox-input/node_modules/scheduler": {
-      "version": "0.20.2",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "packages/checkbox-input/node_modules/tslib": {
-      "version": "2.4.0",
-      "license": "0BSD"
     },
     "packages/close-button": {
       "name": "@hashicorp/react-close-button",
@@ -39920,7 +39869,7 @@
     },
     "packages/consent-manager": {
       "name": "@hashicorp/react-consent-manager",
-      "version": "9.1.2",
+      "version": "9.2.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/flight-icons": "^2.5.0",
@@ -40910,10 +40859,10 @@
     },
     "packages/related-content": {
       "name": "@hashicorp/react-related-content",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "MPL-2.0",
       "dependencies": {
-        "@hashicorp/react-card": "^0.11.0",
+        "@hashicorp/react-card": "^0.12.0",
         "@hashicorp/react-standalone-link": "^0.4.0",
         "classnames": "^2.3.1"
       },
@@ -41142,63 +41091,12 @@
       "version": "5.0.2",
       "license": "MPL-2.0",
       "dependencies": {
-        "@reach/auto-id": "^0.17.0",
         "classnames": "^2.3.1"
       },
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",
         "react": ">=16.x"
       }
-    },
-    "packages/text-input/node_modules/@reach/auto-id": {
-      "version": "0.17.0",
-      "license": "MIT",
-      "dependencies": {
-        "@reach/utils": "0.17.0",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "packages/text-input/node_modules/@reach/auto-id/node_modules/@reach/utils": {
-      "version": "0.17.0",
-      "license": "MIT",
-      "dependencies": {
-        "tiny-warning": "^1.0.3",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "packages/text-input/node_modules/react-dom": {
-      "version": "17.0.2",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
-      },
-      "peerDependencies": {
-        "react": "17.0.2"
-      }
-    },
-    "packages/text-input/node_modules/scheduler": {
-      "version": "0.20.2",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "packages/text-input/node_modules/tslib": {
-      "version": "2.4.0",
-      "license": "0BSD"
     },
     "packages/text-split": {
       "name": "@hashicorp/react-text-split",
@@ -41274,63 +41172,12 @@
       "version": "1.1.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@reach/auto-id": "^0.17.0",
         "clsx": "^1.1.1"
       },
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",
         "react": ">=16.x"
       }
-    },
-    "packages/textarea-input/node_modules/@reach/auto-id": {
-      "version": "0.17.0",
-      "license": "MIT",
-      "dependencies": {
-        "@reach/utils": "0.17.0",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "packages/textarea-input/node_modules/@reach/auto-id/node_modules/@reach/utils": {
-      "version": "0.17.0",
-      "license": "MIT",
-      "dependencies": {
-        "tiny-warning": "^1.0.3",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "packages/textarea-input/node_modules/react-dom": {
-      "version": "17.0.2",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
-      },
-      "peerDependencies": {
-        "react": "17.0.2"
-      }
-    },
-    "packages/textarea-input/node_modules/scheduler": {
-      "version": "0.20.2",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "packages/textarea-input/node_modules/tslib": {
-      "version": "2.4.0",
-      "license": "0BSD"
     },
     "packages/toggle": {
       "name": "@hashicorp/react-toggle",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39729,7 +39729,7 @@
       },
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",
-        "react": ">=16.x"
+        "react": ">=18.x"
       }
     },
     "packages/close-button": {
@@ -41095,7 +41095,7 @@
       },
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",
-        "react": ">=16.x"
+        "react": ">=18.x"
       }
     },
     "packages/text-split": {
@@ -41176,7 +41176,7 @@
       },
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",
-        "react": ">=16.x"
+        "react": ">=18.x"
       }
     },
     "packages/toggle": {

--- a/packages/checkbox-input/index.js
+++ b/packages/checkbox-input/index.js
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import React from 'react'
-import { useId } from '@reach/auto-id'
+import React, { useId } from 'react'
 import s from './style.module.css'
 import classNames from 'classnames'
 

--- a/packages/checkbox-input/package.json
+++ b/packages/checkbox-input/package.json
@@ -12,7 +12,7 @@
   "license": "MPL-2.0",
   "peerDependencies": {
     "@hashicorp/mktg-global-styles": ">=3.x",
-    "react": ">=16.x"
+    "react": ">=18.x"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/checkbox-input/package.json
+++ b/packages/checkbox-input/package.json
@@ -7,7 +7,6 @@
     "Zach Shilton"
   ],
   "dependencies": {
-    "@reach/auto-id": "^0.17.0",
     "classnames": "^2.3.1"
   },
   "license": "MPL-2.0",

--- a/packages/text-input/index.js
+++ b/packages/text-input/index.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import { useId } from 'react'
 import classNames from 'classnames'
-import { useId } from '@reach/auto-id'
 import s from './style.module.css'
 
 function TextInput({

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -12,7 +12,7 @@
   "license": "MPL-2.0",
   "peerDependencies": {
     "@hashicorp/mktg-global-styles": ">=3.x",
-    "react": ">=16.x"
+    "react": ">=18.x"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -7,7 +7,6 @@
     "Zach Shilton"
   ],
   "dependencies": {
-    "@reach/auto-id": "^0.17.0",
     "classnames": "^2.3.1"
   },
   "license": "MPL-2.0",

--- a/packages/textarea-input/index.tsx
+++ b/packages/textarea-input/index.tsx
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import { useId } from 'react'
 import clsx from 'clsx'
-import { useId } from '@reach/auto-id'
 import type { ChangeEventHandler, FocusEventHandler } from 'react'
 import s from './style.module.css'
 

--- a/packages/textarea-input/package.json
+++ b/packages/textarea-input/package.json
@@ -12,7 +12,7 @@
   "license": "MPL-2.0",
   "peerDependencies": {
     "@hashicorp/mktg-global-styles": ">=3.x",
-    "react": ">=16.x"
+    "react": ">=18.x"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/textarea-input/package.json
+++ b/packages/textarea-input/package.json
@@ -7,7 +7,6 @@
     "Zach Shilton"
   ],
   "dependencies": {
-    "@reach/auto-id": "^0.17.0",
     "clsx": "^1.1.1"
   },
   "license": "MPL-2.0",


### PR DESCRIPTION
🎟️ [Asana Task]()
🔍 [Preview Link](https://react-components-git-ksupdate-use-id-hashicorp.vercel.app)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

`@reach/auto-id` is pinned <= react 17 and this dependency causes conflicts / warnings where react 18 is used. This refactors all uses of `@reach/auto-id` to use the [react version](https://react.dev/reference/react/useId). 

<img width="588" alt="Screenshot 2023-08-01 at 9 04 25 AM" src="https://github.com/hashicorp/react-components/assets/36613477/0e6eef81-ee47-4449-a543-05e5a2a9af67">

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [ ] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [ ] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
