### PR TITLE
feat(card): Make `date` optional on `<ResourceCard />`

### DIFF
--- a/.changeset/old-comics-argue.md
+++ b/.changeset/old-comics-argue.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/react-card': minor
+---
+
+Makes the `date` prop optional, preventing it and the `|` separator from rendering if not set.

--- a/package-lock.json
+++ b/package-lock.json
@@ -39694,7 +39694,7 @@
     },
     "packages/card": {
       "name": "@hashicorp/react-card",
-      "version": "0.12.0",
+      "version": "0.14.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/react-expandable-arrow": "^0.1.0",
@@ -39722,7 +39722,7 @@
     },
     "packages/checkbox-input": {
       "name": "@hashicorp/react-checkbox-input",
-      "version": "5.0.3",
+      "version": "6.0.0",
       "license": "MPL-2.0",
       "dependencies": {
         "classnames": "^2.3.1"
@@ -39746,7 +39746,7 @@
     },
     "packages/code-block": {
       "name": "@hashicorp/react-code-block",
-      "version": "6.3.0",
+      "version": "6.4.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/react-inline-svg": "^6.0.3",
@@ -40405,7 +40405,7 @@
     },
     "packages/inline-video": {
       "name": "@hashicorp/react-inline-video",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MPL-2.0",
       "dependencies": {
         "classnames": "^2.3.1",
@@ -40859,10 +40859,10 @@
     },
     "packages/related-content": {
       "name": "@hashicorp/react-related-content",
-      "version": "0.3.5",
+      "version": "0.3.7",
       "license": "MPL-2.0",
       "dependencies": {
-        "@hashicorp/react-card": "^0.12.0",
+        "@hashicorp/react-card": "^0.14.0",
         "@hashicorp/react-standalone-link": "^0.4.0",
         "classnames": "^2.3.1"
       },
@@ -41088,7 +41088,7 @@
     },
     "packages/text-input": {
       "name": "@hashicorp/react-text-input",
-      "version": "5.0.2",
+      "version": "6.0.0",
       "license": "MPL-2.0",
       "dependencies": {
         "classnames": "^2.3.1"
@@ -41169,7 +41169,7 @@
     },
     "packages/textarea-input": {
       "name": "@hashicorp/react-textarea-input",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "license": "MPL-2.0",
       "dependencies": {
         "clsx": "^1.1.1"
@@ -41222,11 +41222,11 @@
     },
     "packages/video-feature": {
       "name": "@hashicorp/react-video-feature",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/react-author-byline": "^0.4.0",
-        "@hashicorp/react-inline-video": "^0.4.0",
+        "@hashicorp/react-inline-video": "^0.5.0",
         "classnames": "^2.3.1"
       },
       "peerDependencies": {

--- a/packages/card/docs.mdx
+++ b/packages/card/docs.mdx
@@ -316,7 +316,6 @@ A component used to promote and link to marketing pages, always using a descript
     appearance="dark"
     heading="Display 5 - 4 lines with character limit of 130. Leo mauris fermentum pharetra blandit tellus"
     category="Category"
-    date="August 15, 2022"
     thumbnail={{
       src: 'https://www.datocms-assets.com/19447/1648680074-screenshot-2022-03-31-at-00-40-47.png',
       alt: 'HashiConf Europe 2022 Recap',

--- a/packages/card/resource-card/index.test.tsx
+++ b/packages/card/resource-card/index.test.tsx
@@ -18,7 +18,7 @@ const defaultProps = {
 }
 
 describe('<ResourceCard />', () => {
-  it('should render the provided metadata correctly', () => {
+  it('should render the provided date and category with separator', () => {
     const expectedMeta = [defaultProps.date, defaultProps.category]
 
     render(<ResourceCard {...defaultProps} />)
@@ -30,5 +30,19 @@ describe('<ResourceCard />', () => {
     })
 
     expect(metaElement).toContainElement(screen.getByText('|'))
+  })
+
+  it('should not render the date if no date is provided', () => {
+    defaultProps.date = ''
+
+    render(<ResourceCard {...defaultProps} />)
+
+    const metaElement = screen.getByTestId('wpl-card-meta')
+
+    expect(metaElement).toContainElement(
+      screen.getByText(defaultProps.category)
+    )
+
+    expect(metaElement).not.toContainElement(screen.queryByText('|'))
   })
 })

--- a/packages/card/resource-card/index.test.tsx
+++ b/packages/card/resource-card/index.test.tsx
@@ -33,9 +33,9 @@ describe('<ResourceCard />', () => {
   })
 
   it('should not render the date if no date is provided', () => {
-    defaultProps.date = ''
+    const defaultPropsWithoutDate = { ...defaultProps, date: '' }
 
-    render(<ResourceCard {...defaultProps} />)
+    render(<ResourceCard {...defaultPropsWithoutDate} />)
 
     const metaElement = screen.getByTestId('wpl-card-meta')
 

--- a/packages/card/resource-card/index.tsx
+++ b/packages/card/resource-card/index.tsx
@@ -8,7 +8,7 @@ import type { CardProps, ThumbnailProps } from '../types'
 
 export interface ResourceCardProps {
   heading: string
-  date: string
+  date?: string
   category: string
   link: string
   productBadges?: CardProps['productBadges']
@@ -25,6 +25,12 @@ export function ResourceCard({
   thumbnail,
   appearance,
 }: ResourceCardProps): JSX.Element {
+  const meta: string[] = [category]
+
+  if (date) {
+    meta.unshift(date)
+  }
+
   return (
     <CardPrimitives.Card
       heading={heading}
@@ -34,7 +40,7 @@ export function ResourceCard({
     >
       <CardPrimitives.Thumbnail {...thumbnail} />
       <CardPrimitives.Content>
-        <CardPrimitives.Meta items={[date, category]} />
+        <CardPrimitives.Meta items={meta} />
         <CardPrimitives.Heading>{heading}</CardPrimitives.Heading>
         {productBadges && productBadges?.length > 0 ? (
           <CardPrimitives.ProductBadges

--- a/packages/card/resource-card/index.tsx
+++ b/packages/card/resource-card/index.tsx
@@ -25,11 +25,7 @@ export function ResourceCard({
   thumbnail,
   appearance,
 }: ResourceCardProps): JSX.Element {
-  const meta: string[] = [category]
-
-  if (date) {
-    meta.unshift(date)
-  }
+  const meta: string[] = date ? [date, category] : [category]
 
   return (
     <CardPrimitives.Card


### PR DESCRIPTION
🎟️ [Asana Task for request prompting the change](https://app.asana.com/0/1202791227659279/1205347737637312/f)
🔢 [PR on `www` implementing the canary release](https://github.com/hashicorp/web/pull/781)
🔍 [Preview Link](https://react-components-git-nqcard-make-dates-optiona-b3beed-hashicorp.vercel.app/components/card)
🔍 [Preview Link for example usage on `www` (see each case study library item's card)](https://hashicorp-www-next-git-nqwww-hide-case-study-l-583a57-hashicorp.vercel.app/case-studies)

---

<!-- Reminder: This is an open source project, make sure not to include any sensitive information in the pull request. -->

## Description

This PR updates our `<ResourceCard />` component to make showing the date optional; if no date is passed in, no date (or `|` separator) is shown.

### PR Checklist 🚀

Items in this checklist may not may not apply to your PR, but please consider each item carefully.

- [x] Add Asana and Preview links above.
- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Conduct reasonable cross browser testing for both compatibility and responsive behavior (We have a [Sauce Labs](https://app.saucelabs.com/) account for this, if you don't have access, just ask!).
- [x] Conduct reasonable accessibility review (use the [WAS](https://accessible.org/Web-Accessibility-Standards-WAS-2.pdf) as a guide or an [axe browser plugin](https://www.deque.com/axe/) until we establish more formal checks).
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
