### PR TITLE
bump sha for workflows referenced from web-platform-packages

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   release-canary:
-    uses: hashicorp/web-platform-packages/.github/workflows/canary-release.yml@fc015ac1758893ad184d08b4638a8feeb93d0613
+    uses: hashicorp/web-platform-packages/.github/workflows/canary-release.yml@5eee43c8a4a8f311e08f473132c617f757a8c6b5
     secrets:
       CHANGESETS_PAT: ${{ secrets.CHANGESETS_PAT }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    uses: hashicorp/web-platform-packages/.github/workflows/release.yml@fc015ac1758893ad184d08b4638a8feeb93d0613
+    uses: hashicorp/web-platform-packages/.github/workflows/release.yml@5eee43c8a4a8f311e08f473132c617f757a8c6b5
     secrets:
       CHANGESETS_PAT: ${{ secrets.CHANGESETS_PAT }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
🎟️ [Asana Task][task]

## What

Bumps the SHA in references to `web-platform-packages` workflows in `release.yml` and `canary-release.yml`.

## Why

To clean up some stray `node 16 will be deprecated` warnings, which are happening due to references to older versions of workflows.

[task]: https://app.asana.com/0/799513369421962/1207374598912342/f