### PR TITLE
Consent Manager & Toggle a11y fixes

### DIFF
--- a/.changeset/big-beds-promise.md
+++ b/.changeset/big-beds-promise.md
@@ -1,0 +1,10 @@
+---
+"@hashicorp/react-consent-manager": patch
+"@hashicorp/react-toggle": patch
+---
+
+Fix a variety of accessiblity issuies around the consent manager.
+- Toggles missing accessible names
+- see more/less button missing accessible name
+- allowing ESC to close the dialog
+- removing unneeded headers

--- a/.changeset/big-beds-promise.md
+++ b/.changeset/big-beds-promise.md
@@ -8,3 +8,4 @@ Fix a variety of accessiblity issuies around the consent manager.
 - see more/less button missing accessible name
 - allowing ESC to close the dialog
 - removing unneeded headers
+- trapping focus inside consent manager dialog

--- a/packages/consent-manager/components/dialog.js
+++ b/packages/consent-manager/components/dialog.js
@@ -145,7 +145,9 @@ export default class ConsentPreferences extends Component {
               this.handleFold(name)
             }}
             aria-label={
-              this.state.showCategories[name] ? 'See less' : 'See more'
+              this.state.showCategories[name] ?
+                `See less in ${this.state.showCategories[name]}` :
+                `See more in ${this.state.showCategories[name]}`
             }
           >
             <IconArrowDown24 />

--- a/packages/consent-manager/components/dialog.js
+++ b/packages/consent-manager/components/dialog.js
@@ -106,11 +106,14 @@ export default class ConsentPreferences extends Component {
   // Build each individual category and integration row
   buildCategory(items, name) {
     const categoryItems = items.map((item) => {
+      const categoryItemTitleID = `consent-manager-categoryItemTitle-${item.name}`;
+
       return (
         <div className={s.categoryItem} key={item.name}>
           <div className={s.categoryItemHeader}>
-            <h4 className={s.categoryItemTitle}>{item.name}</h4>
+            <h4 id={categoryItemTitleID} className={s.categoryItemTitle}>{item.name}</h4>
             <Toggle
+              ariaLabelledBy={categoryItemTitleID}
               onChange={this.handleToggle.bind(this, item.name, item.origin)}
               enabled={Boolean(
                 this.state.consent.loadAll ||
@@ -125,12 +128,15 @@ export default class ConsentPreferences extends Component {
       )
     })
 
+    const categoryHeaderTitleID = `consent-manager-categoryHeaderTitle-${name}`;
+
     return (
       <div className={s.category} key={name}>
         <div className={s.categoryHeader}>
-          <h3 className={s.categoryHeaderTitle}>{name}</h3>
+          <h3 id={categoryHeaderTitleID} className={s.categoryHeaderTitle}>{name}</h3>
           {!this.state.showCategories[name] && (
             <Toggle
+              ariaLabelledBy={categoryHeaderTitleID}
               onChange={this.handleToggle.bind(this, name, 'categories')}
               enabled={
                 this.state.consent.loadAll || this.getCategoryToggle(name)
@@ -146,8 +152,8 @@ export default class ConsentPreferences extends Component {
             }}
             aria-label={
               this.state.showCategories[name] ?
-                `See less in ${this.state.showCategories[name]}` :
-                `See more in ${this.state.showCategories[name]}`
+                `See less in ${name}` :
+                `See more in ${name}`
             }
           >
             <IconArrowDown24 />

--- a/packages/consent-manager/components/dialog.js
+++ b/packages/consent-manager/components/dialog.js
@@ -8,7 +8,7 @@
   Managing preferences dialog
 */
 
-import { Component } from 'react'
+import { Component, createRef } from 'react'
 import getIntegrations from '../util/integrations'
 import Button from '@hashicorp/react-button'
 import Toggle from '@hashicorp/react-toggle'
@@ -33,6 +33,7 @@ export default class ConsentPreferences extends Component {
 
     this.handleFold = this.handleFold.bind(this)
     this.getCategoryToggle = this.getCategoryToggle.bind(this)
+    this.dialogRef = createRef()
   }
 
   componentDidMount() {
@@ -44,6 +45,12 @@ export default class ConsentPreferences extends Component {
     ).then((groupedIntegrations) => {
       this.setState({ groupedIntegrations })
     })
+
+    this.dialogRef.current?.showModal()
+  }
+
+  componentWillUnmount() {
+    this.dialogRef.current?.close()
   }
 
   // Handler for when user toggles a category or individual integration
@@ -111,7 +118,9 @@ export default class ConsentPreferences extends Component {
       return (
         <div className={s.categoryItem} key={item.name}>
           <div className={s.categoryItemHeader}>
-            <h4 id={categoryItemTitleID} className={s.categoryItemTitle}>{item.name}</h4>
+            <h4 id={categoryItemTitleID} className={s.categoryItemTitle}>
+              {item.name}
+            </h4>
             <Toggle
               ariaLabelledBy={categoryItemTitleID}
               onChange={this.handleToggle.bind(this, item.name, item.origin)}
@@ -133,7 +142,9 @@ export default class ConsentPreferences extends Component {
     return (
       <div className={s.category} key={name}>
         <div className={s.categoryHeader}>
-          <h3 id={categoryHeaderTitleID} className={s.categoryHeaderTitle}>{name}</h3>
+          <h3 id={categoryHeaderTitleID} className={s.categoryHeaderTitle}>
+            {name}
+          </h3>
           {!this.state.showCategories[name] && (
             <Toggle
               ariaLabelledBy={categoryHeaderTitleID}
@@ -151,9 +162,9 @@ export default class ConsentPreferences extends Component {
               this.handleFold(name)
             }}
             aria-label={
-              this.state.showCategories[name] ?
-                `See less in ${name}` :
-                `See more in ${name}`
+              this.state.showCategories[name]
+                ? `See less in ${name}`
+                : `See more in ${name}`
             }
           >
             <IconArrowDown24 />
@@ -181,11 +192,18 @@ export default class ConsentPreferences extends Component {
     })
 
     return (
-      <div className={s.root} data-testid="consent-mgr-dialog">
+      <dialog
+        aria-labelledby="consent-mgr-dialog-title"
+        className={s.root}
+        data-testid="consent-mgr-dialog"
+        ref={this.dialogRef}
+      >
         {/* Manage preferences dialog */}
         <div className={s.visibleDialog}>
           <div className={s.dialogHeader}>
-            <h2 className={s.dialogHeaderTitle}>Manage cookies</h2>
+            <h2 id="consent-mgr-dialog-title" className={s.dialogHeaderTitle}>
+              Manage cookies
+            </h2>
           </div>
           <div className={s.dialogBody}>
             <p className={s.dialogBodyIntro}>
@@ -232,6 +250,7 @@ export default class ConsentPreferences extends Component {
               }}
             />
             <Button
+              autoFocus
               className={s.saveButton}
               title="Accept all"
               onClick={() => {
@@ -240,7 +259,7 @@ export default class ConsentPreferences extends Component {
             />
           </div>
         </div>
-      </div>
+      </dialog>
     )
   }
 }

--- a/packages/consent-manager/components/dialog.js
+++ b/packages/consent-manager/components/dialog.js
@@ -106,7 +106,7 @@ export default class ConsentPreferences extends Component {
   // Build each individual category and integration row
   buildCategory(items, name) {
     const categoryItems = items.map((item) => {
-      const categoryItemTitleID = `consent-manager-categoryItemTitle-${item.name}`;
+      const categoryItemTitleID = `consent-manager-categoryItemTitle-${item.name}`
 
       return (
         <div className={s.categoryItem} key={item.name}>
@@ -128,7 +128,7 @@ export default class ConsentPreferences extends Component {
       )
     })
 
-    const categoryHeaderTitleID = `consent-manager-categoryHeaderTitle-${name}`;
+    const categoryHeaderTitleID = `consent-manager-categoryHeaderTitle-${name}`
 
     return (
       <div className={s.category} key={name}>

--- a/packages/consent-manager/components/dialog.js
+++ b/packages/consent-manager/components/dialog.js
@@ -126,9 +126,9 @@ export default class ConsentPreferences extends Component {
               onChange={this.handleToggle.bind(this, item.name, item.origin)}
               enabled={Boolean(
                 this.state.consent.loadAll ||
-                (this.state.consent &&
-                  this.state.consent[item.origin] &&
-                  this.state.consent[item.origin][item.name])
+                  (this.state.consent &&
+                    this.state.consent[item.origin] &&
+                    this.state.consent[item.origin][item.name])
               )}
             />
           </div>
@@ -138,6 +138,7 @@ export default class ConsentPreferences extends Component {
     })
 
     const categoryHeaderTitleID = `consent-manager-categoryHeaderTitle-${name}`
+    const categoryListID = `consent-manager-categoryHeaderTitle-${name}-list`
 
     return (
       <div className={s.category} key={name}>
@@ -166,12 +167,16 @@ export default class ConsentPreferences extends Component {
                 ? `See less in ${name}`
                 : `See more in ${name}`
             }
+            aria-expanded={this.state.showCategories[name] ? `true` : `false`}
+            aria-controls={
+              this.state.showCategories[name] ? categoryListID : null
+            }
           >
             <IconArrowDown24 />
           </button>
         </div>
         {this.state.showCategories[name] && (
-          <div className={s.categoryFold}>
+          <div className={s.categoryFold} id={categoryListID}>
             <p className={s.categoryFoldDescription}>
               {this.state.categories[name]}
             </p>

--- a/packages/consent-manager/components/dialog.js
+++ b/packages/consent-manager/components/dialog.js
@@ -108,18 +108,18 @@ export default class ConsentPreferences extends Component {
     const categoryItems = items.map((item) => {
       return (
         <div className={s.categoryItem} key={item.name}>
-          <header className={s.categoryItemHeader}>
+          <div className={s.categoryItemHeader}>
             <h4 className={s.categoryItemTitle}>{item.name}</h4>
             <Toggle
               onChange={this.handleToggle.bind(this, item.name, item.origin)}
               enabled={Boolean(
                 this.state.consent.loadAll ||
-                  (this.state.consent &&
-                    this.state.consent[item.origin] &&
-                    this.state.consent[item.origin][item.name])
+                (this.state.consent &&
+                  this.state.consent[item.origin] &&
+                  this.state.consent[item.origin][item.name])
               )}
             />
-          </header>
+          </div>
           <p className={s.categoryItemDescription}>{item.description}</p>
         </div>
       )
@@ -127,7 +127,7 @@ export default class ConsentPreferences extends Component {
 
     return (
       <div className={s.category} key={name}>
-        <header className={s.categoryHeader}>
+        <div className={s.categoryHeader}>
           <h3 className={s.categoryHeaderTitle}>{name}</h3>
           {!this.state.showCategories[name] && (
             <Toggle
@@ -150,7 +150,7 @@ export default class ConsentPreferences extends Component {
           >
             <IconArrowDown24 />
           </button>
-        </header>
+        </div>
         {this.state.showCategories[name] && (
           <div className={s.categoryFold}>
             <p className={s.categoryFoldDescription}>
@@ -176,9 +176,9 @@ export default class ConsentPreferences extends Component {
       <div className={s.root} data-testid="consent-mgr-dialog">
         {/* Manage preferences dialog */}
         <div className={s.visibleDialog}>
-          <header className={s.dialogHeader}>
+          <div className={s.dialogHeader}>
             <h2 className={s.dialogHeaderTitle}>Manage cookies</h2>
-          </header>
+          </div>
           <div className={s.dialogBody}>
             <p className={s.dialogBodyIntro}>
               HashiCorp uses data collected by cookies and JavaScript libraries

--- a/packages/consent-manager/components/dialog.module.css
+++ b/packages/consent-manager/components/dialog.module.css
@@ -13,6 +13,7 @@
   justify-content: center;
   align-items: center;
   z-index: 10;
+  background-color: transparent;
 }
 
 .flexCenteredRow {

--- a/packages/consent-manager/index.test.js
+++ b/packages/consent-manager/index.test.js
@@ -82,6 +82,12 @@ const defaultProps = {
   container: '#consent-manager',
 }
 
+beforeAll(() => {
+  HTMLDialogElement.prototype.show = jest.fn()
+  HTMLDialogElement.prototype.showModal = jest.fn()
+  HTMLDialogElement.prototype.close = jest.fn()
+})
+
 test('shows the banner if the forceShow prop is true', () => {
   const { default: ConsentManager } = require('./')
   render(<ConsentManager {...defaultProps} forceShow={true} />)

--- a/packages/consent-manager/index.tsx
+++ b/packages/consent-manager/index.tsx
@@ -77,7 +77,7 @@ export default function ConsentManager(props: ConsentManagerProps) {
         return
       }
 
-      closeDialog();
+      closeDialog()
     },
     [props.version]
   )
@@ -122,15 +122,15 @@ export default function ConsentManager(props: ConsentManagerProps) {
     if (showDialog && event.key === "Escape") {
 			closeDialog()
     }
-  }, [showDialog]);
+  }, [showDialog])
 
   useEffect(() => {
-    document.addEventListener("keydown", escFunction, false);
+    document.addEventListener("keydown", escFunction, false)
 
     return () => {
-      document.removeEventListener("keydown", escFunction, false);
-    };
-  }, [escFunction]);
+      document.removeEventListener("keydown", escFunction, false)
+    }
+  }, [escFunction])
 
   const filteredAdditionalServices = props.additionalServices?.filter(
     (service) => service.shouldLoad === undefined || service.shouldLoad()

--- a/packages/consent-manager/index.tsx
+++ b/packages/consent-manager/index.tsx
@@ -52,6 +52,13 @@ export default function ConsentManager(props: ConsentManagerProps) {
     if (props.forceShow) return true
   })
 
+	const closeDialog = () => {
+		document.body.classList.remove('g-noscroll')
+		setShowDialog(false)
+		setShowBanner(false)
+		setPreferences(loadPreferences() ?? {})
+	}
+
   const hasEmptyPreferencesOrVersionMismatch =
     Object.keys(preferences).length === 0 ||
     preferences.version !== props.version
@@ -70,11 +77,7 @@ export default function ConsentManager(props: ConsentManagerProps) {
         return
       }
 
-      // Close all dialogs
-      document.body.classList.remove('g-noscroll')
-      setShowDialog(false)
-      setShowBanner(false)
-      setPreferences(loadPreferences() ?? {})
+      closeDialog();
     },
     [props.version]
   )
@@ -114,6 +117,20 @@ export default function ConsentManager(props: ConsentManagerProps) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- We only want to run this check once
   }, [])
+
+  const escFunction = useCallback((event) => {
+    if (showDialog && event.key === "Escape") {
+			closeDialog()
+    }
+  }, [showDialog]);
+
+  useEffect(() => {
+    document.addEventListener("keydown", escFunction, false);
+
+    return () => {
+      document.removeEventListener("keydown", escFunction, false);
+    };
+  }, [escFunction]);
 
   const filteredAdditionalServices = props.additionalServices?.filter(
     (service) => service.shouldLoad === undefined || service.shouldLoad()

--- a/packages/toggle/index.js
+++ b/packages/toggle/index.js
@@ -10,8 +10,9 @@ import s from './style.module.css'
 export default function Toggle({
   appearance = 'light',
   enabled,
-  onChange = () => {},
+  onChange = () => { },
   disabled = false,
+  ariaLabelledBy,
 }) {
   const [enabledState, setEnabledState] = useState(enabled || false)
 
@@ -40,6 +41,7 @@ export default function Toggle({
       )}
     >
       <input
+        aria-labelledby={ariaLabelledBy}
         type="checkbox"
         role="switch"
         checked={enabledState}

--- a/packages/toggle/index.js
+++ b/packages/toggle/index.js
@@ -31,6 +31,13 @@ export default function Toggle({
     onChange(event.currentTarget.checked)
   }
 
+  const handleKey = (event) => {
+    if (event.key === 'Enter') {
+      setEnabledState(!event.currentTarget.checked)
+      onChange(!event.currentTarget.checked)
+    }
+  }
+
   return (
     <label
       className={classNames(
@@ -46,6 +53,7 @@ export default function Toggle({
         role="switch"
         checked={enabledState}
         onChange={handleChange}
+        onKeyDown={handleKey}
         className={s.toggleInput}
         disabled={disabled}
         data-testid="react-toggle"


### PR DESCRIPTION
🎟️ Asana Tasks
- [[TF VPAT A11Y] Cookie manager modal does not respond to the ESC key](https://app.asana.com/0/1205890709355230/1205890709355251/f)
- [[TF VPAT A11Y] Cookie manager modal has multiple banner landmarks](https://app.asana.com/0/1205890709355230/1205890709355253/f)
- [[TF VPAT A11Y] Consent manager - Indistinguishable “see more” buttons](https://app.asana.com/0/1205890709355230/1205890709355259/f)
- [[TF VPAT A11Y] Switch toggles missing accessible name](https://app.asana.com/0/1205890709355230/1205890709355261/f)
- [[TF VPAT A11Y] Switches missing keyboard interactions](https://app.asana.com/0/1205890709355230/1205890709355249/f)

## Description

Fix a variety of accessiblity issuies around the consent manager:
- Toggles missing accessible names
- see more/less button missing accessible name
- allowing ESC to close the dialog
- removing unneeded headers

### Testing 🚀

1. [Load up dev-portal](https://github.com/hashicorp/dev-portal)
2. Update @hashicorp/react-consent-manager to this branch:
```sh
npm install 'https://gitpkg.now.sh/hashicorp/react-components/packages/consent-manager?rn/fix/consent-manager-a11y-fixes'
```
3. Start dev-portal in an incognito window (so you can open the consent manager)
4. Test the following
    1. `esc` closes the modal
    2. `tab` is "focus trapped" in the modal and will not exit it
    3. The more/less and toggle buttons now have accessible names
    4. The toggle button responds to both `space` and `enter`
    5. The modal no longer has any `<header>` tags within it
